### PR TITLE
Show recording evidence in import review

### DIFF
--- a/frontend/src/features/importReview/ImportReviewPage.tsx
+++ b/frontend/src/features/importReview/ImportReviewPage.tsx
@@ -47,6 +47,7 @@ import type {
   FolderStatsResponse,
   ImportTargetPreviewResponse,
   JobStartResponse,
+  RecordingLocalEvidence,
   ReviewCandidate,
   ReviewCounts,
   ReviewOriginCounts,
@@ -54,6 +55,7 @@ import type {
   ReviewEvidence,
   ReviewItem,
   ReviewItemType,
+  ReviewRecordingCandidate,
 } from '../../api/types';
 
 /** Unified filter for the Review Queue. Type-based (pending_ai, skipped, library_no_mb)
@@ -632,7 +634,351 @@ function musicBrainzReleaseGroupUrl(mbReleaseGroupId?: string): string {
   return mbReleaseGroupId ? `https://musicbrainz.org/release-group/${mbReleaseGroupId}` : '';
 }
 
+function musicBrainzRecordingUrl(mbTrackId?: string): string {
+  return mbTrackId ? `https://musicbrainz.org/recording/${mbTrackId}` : '';
+}
+
+function pathFilename(path?: string): string {
+  return (path || '').split(/[\\/]/).filter(Boolean).pop() || '';
+}
+
+function valueLabel(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '-';
+  return String(value);
+}
+
+function evidenceYear(value: unknown): string {
+  const text = valueLabel(value);
+  const match = text.match(/^((?:19|20)\d{2})/);
+  return match ? match[1] : text === '-' ? '' : text;
+}
+
+function missingIdType(item: ReviewItem): string {
+  if (item.missing_id_type) return item.missing_id_type;
+  if (item.target_kind === 'item') return 'Recording ID';
+  if (!item.mb_releasegroupid) return 'Release Group ID';
+  if (!item.mb_albumid) return 'Release ID';
+  return 'MusicBrainz ID';
+}
+
+function recordingCandidateKey(candidate: ReviewRecordingCandidate, fallback: number): string {
+  return (candidate.mb_trackid || `${candidate.candidate_index ?? fallback}`).trim().toLowerCase();
+}
+
+function asRecordingCandidate(raw: unknown): ReviewRecordingCandidate | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const candidate = raw as ReviewRecordingCandidate;
+  const hasRecordingShape = Boolean(
+    candidate.mb_trackid
+      || candidate.recording_title
+      || candidate.recording_artist
+      || candidate.selected_release
+      || candidate.linked_releases?.length
+      || candidate.decision
+      || candidate.safety_result,
+  );
+  return hasRecordingShape ? candidate : null;
+}
+
+function recordingCandidatesFrom(response?: AiSuggestResponse, item?: ReviewItem): ReviewRecordingCandidate[] {
+  const suggestion = response?.suggestions ?? response?.suggestion;
+  const rawCandidates: unknown[] = [
+    suggestion?.selected_recording_candidate,
+    suggestion?.candidate_evidence,
+    response?.selected_candidate,
+    response?.evidence?.selected_recording_candidate,
+    item?.evidence?.selected_recording_candidate,
+    ...(suggestion?.recording_candidates ?? []),
+    ...(response?.recording_candidates ?? []),
+    ...(response?.evidence?.recording_candidates ?? []),
+    ...(item?.evidence?.recording_candidates ?? []),
+  ];
+  const seen = new Set<string>();
+  const candidates: ReviewRecordingCandidate[] = [];
+  rawCandidates.forEach((raw, index) => {
+    const candidate = asRecordingCandidate(raw);
+    if (!candidate) return;
+    const key = recordingCandidateKey(candidate, index);
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    candidates.push(candidate);
+  });
+  return candidates;
+}
+
+function selectedRecordingCandidate(response: AiSuggestResponse | undefined, item: ReviewItem, mbid: string): ReviewRecordingCandidate | undefined {
+  const candidates = recordingCandidatesFrom(response, item);
+  return candidates.find((candidate) => sameMbid(candidate.mb_trackid, mbid)) || candidates[0];
+}
+
+function localEvidenceForItem(item: ReviewItem, response?: AiSuggestResponse): RecordingLocalEvidence {
+  const suggestion = response?.suggestions ?? response?.suggestion;
+  const evidence = response?.evidence ?? suggestion?.review_evidence ?? item.evidence;
+  const current = evidence?.current ?? {};
+  const sourcePath = current.source_path || item.path || '';
+  return {
+    filename: current.filename || pathFilename(sourcePath),
+    source_path: sourcePath,
+    title: current.title || item.title || '',
+    artist: current.artist || item.artist || '',
+    album: current.album || item.album || '',
+    albumartist: current.albumartist || item.albumartist || '',
+    year: current.year ?? item.year ?? '',
+    track: current.track ?? item.track ?? '',
+    disc: current.disc ?? item.disc ?? '',
+    duration: current.duration || item.duration || '',
+    duration_seconds: current.duration_seconds ?? item.duration_seconds,
+    mb_trackid: current.mb_trackid || item.mb_trackid || '',
+    mb_albumid: current.mb_albumid || item.mb_albumid || '',
+    mb_releasegroupid: current.mb_releasegroupid || item.mb_releasegroupid || '',
+    fingerprint_status: current.fingerprint_status || evidence?.fingerprint?.status || evidence?.fingerprint?.acoustid_status || 'not checked',
+  };
+}
+
+function recordingCandidateScoreText(candidate: ReviewRecordingCandidate): string {
+  const raw = candidate.confidence_score ?? candidate.acoustid_score ?? candidate.match_total ?? candidate.score;
+  const score = typeof raw === 'number' ? raw : Number(raw);
+  if (!Number.isFinite(score)) return valueLabel(candidate.confidence);
+  return score > 1 ? `${Math.round(score)}%` : formatPercent(score);
+}
+
+function recordingCandidateScoreClass(candidate: ReviewRecordingCandidate): string {
+  const raw = candidate.confidence_score ?? candidate.acoustid_score ?? candidate.match_total ?? candidate.score;
+  return scoreClass(raw === null ? undefined : raw);
+}
+
+function DetailRow({
+  label,
+  value,
+  href,
+  mono = false,
+}: {
+  label: string;
+  value?: unknown;
+  href?: string;
+  mono?: boolean;
+}) {
+  const text = valueLabel(value);
+  return (
+    <div className="min-w-0">
+      <div className="text-[0.68rem] font-semibold uppercase tracking-wide text-zinc-500">{label}</div>
+      {href && text !== '-' ? (
+        <a className={`${mono ? 'font-mono' : ''} break-all text-xs text-sky-700 underline decoration-sky-300`} href={href} target="_blank" rel="noreferrer">
+          {text}
+        </a>
+      ) : (
+        <div className={`${mono ? 'font-mono' : ''} break-words text-xs text-zinc-800`}>{text}</div>
+      )}
+    </div>
+  );
+}
+
+function MatchSummaryRow({ label, field }: { label: string; field?: { status?: string; score?: number; local?: string; suggested?: string; delta_seconds?: number | null } }) {
+  if (!field) return null;
+  const status = field.status || 'unknown';
+  const score = typeof field.score === 'number' ? ` ${formatPercent(field.score)}` : '';
+  const delta = typeof field.delta_seconds === 'number' ? ` (${field.delta_seconds}s delta)` : '';
+  const detail = field.local || field.suggested
+    ? `${valueLabel(field.local)} vs ${valueLabel(field.suggested)}`
+    : delta;
+  const tone = status === 'yes'
+    ? 'text-emerald-700'
+    : status === 'conflict' || status === 'no'
+      ? 'text-rose-700'
+      : status === 'fuzzy' || status === 'tolerance'
+        ? 'text-amber-700'
+        : 'text-zinc-500';
+  return (
+    <div className="flex items-start justify-between gap-3 border-b border-graphite-100 py-1.5 last:border-b-0">
+      <div className="min-w-0">
+        <div className="text-xs font-medium text-zinc-700">{label}</div>
+        {detail ? <div className="truncate text-[0.72rem] text-zinc-500">{detail}</div> : null}
+      </div>
+      <div className={`shrink-0 text-xs font-semibold ${tone}`}>{status}{score}</div>
+    </div>
+  );
+}
+
+function RecordingCandidateRow({
+  candidate,
+  index,
+  selected,
+  onUseCandidate,
+}: {
+  candidate: ReviewRecordingCandidate;
+  index: number;
+  selected: boolean;
+  onUseCandidate: (mbid: string) => void;
+}) {
+  const recordingUrl = candidate.musicbrainz_url || candidate.mb_url || musicBrainzRecordingUrl(candidate.mb_trackid);
+  const releaseUrl = musicBrainzUrl(candidate.mb_albumid || candidate.selected_release?.mb_albumid);
+  const rgUrl = candidate.mb_releasegroupurl || musicBrainzReleaseGroupUrl(candidate.mb_releasegroupid || candidate.selected_release?.mb_releasegroupid);
+  const releaseLabel = [
+    candidate.release_title || candidate.album || candidate.selected_release?.album,
+    candidate.release_year || candidate.year || candidate.selected_release?.year,
+    candidate.country || candidate.selected_release?.country,
+    candidate.medium_format || candidate.media_format || candidate.selected_release?.medium_format || candidate.selected_release?.media_format,
+  ].filter(Boolean).join(' / ');
+  return (
+    <div className={`rounded border px-2 py-2 text-xs ${selected ? 'border-sky-300 bg-sky-50' : 'border-graphite-200 bg-white'}`}>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-semibold text-zinc-900">{index === 0 ? 'Backend selected candidate' : 'Backend alternate candidate'}</span>
+        {selected ? <Chip size="small" color="info" label="Selected" /> : null}
+        <span className={recordingCandidateScoreClass(candidate)}>{recordingCandidateScoreText(candidate)}</span>
+        {candidate.match_method || candidate.source ? <span className="text-zinc-500">{candidate.match_method || candidate.source}</span> : null}
+        {candidate.safety_result ? <span className="font-medium text-zinc-700">{candidate.safety_result}</span> : null}
+      </div>
+      <div className="mt-1 min-w-0 font-medium text-zinc-800">
+        {candidate.recording_artist || candidate.artist || '(unknown artist)'} - {candidate.recording_title || candidate.title || '(unknown title)'}
+      </div>
+      <div className="mt-0.5 min-w-0 text-zinc-600">{releaseLabel || 'No linked release context'}</div>
+      {candidate.reason ? <div className="mt-1 text-zinc-600">{candidate.reason}</div> : null}
+      {candidate.conflicts?.length ? <div className="mt-1 font-medium text-amber-800">Conflicts: {candidate.conflicts.join(', ')}</div> : null}
+      <div className="mt-2 flex flex-wrap gap-2">
+        <Button size="small" variant={selected ? 'contained' : 'outlined'} onClick={() => onUseCandidate(candidate.mb_trackid || '')} disabled={!candidate.mb_trackid}>
+          Use Recording ID
+        </Button>
+        {recordingUrl ? <Button size="small" variant="text" href={recordingUrl} target="_blank" rel="noreferrer">Recording</Button> : null}
+        {releaseUrl ? <Button size="small" variant="text" href={releaseUrl} target="_blank" rel="noreferrer">Release</Button> : null}
+        {rgUrl ? <Button size="small" variant="text" href={rgUrl} target="_blank" rel="noreferrer">Release Group</Button> : null}
+      </div>
+    </div>
+  );
+}
+
+function RecordingIdEvidencePanel({
+  item,
+  response,
+  mbid,
+  onUseCandidate,
+}: {
+  item: ReviewItem;
+  response?: AiSuggestResponse;
+  mbid: string;
+  onUseCandidate: (mbid: string) => void;
+}) {
+  const local = localEvidenceForItem(item, response);
+  const candidates = recordingCandidatesFrom(response, item);
+  const selectedCandidate = selectedRecordingCandidate(response, item, mbid);
+  const candidate = selectedCandidate || candidates[0];
+  const decision = candidate?.decision;
+  const localYear = evidenceYear(local.year);
+  const suggestedYear = evidenceYear(candidate?.release_year ?? candidate?.year ?? candidate?.selected_release?.year ?? candidate?.release_date);
+  const linkedReleases = candidate?.linked_releases ?? [];
+  const recordingUrl = candidate?.musicbrainz_url || candidate?.mb_url || musicBrainzRecordingUrl(candidate?.mb_trackid || mbid);
+  const releaseUrl = musicBrainzUrl(candidate?.mb_albumid || candidate?.selected_release?.mb_albumid);
+  const rgUrl = candidate?.mb_releasegroupurl || musicBrainzReleaseGroupUrl(candidate?.mb_releasegroupid || candidate?.selected_release?.mb_releasegroupid);
+
+  return (
+    <div className="mt-3 rounded border border-cyan-200 bg-cyan-50 p-3 text-xs text-zinc-700">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-semibold text-zinc-900">Recording ID review</span>
+        <Chip size="small" color="info" label={`Missing ID type: ${missingIdType(item)}`} />
+        {candidate?.safety_result ? <Chip size="small" variant="outlined" label={candidate.safety_result} /> : null}
+        {candidate?.recommended_action ? <Chip size="small" variant="outlined" label={candidate.recommended_action} /> : null}
+      </div>
+
+      <div className="mt-3 grid gap-3 lg:grid-cols-2">
+        <div className="rounded border border-white/70 bg-white/80 p-3">
+          <div className="font-semibold text-zinc-900">Local file evidence</div>
+          <div className="mt-2 grid grid-cols-2 gap-2">
+            <DetailRow label="Filename" value={local.filename} />
+            <DetailRow label="Fingerprint status" value={local.fingerprint_status} />
+            <DetailRow label="Current title tag" value={local.title} />
+            <DetailRow label="Current artist tag" value={local.artist} />
+            <DetailRow label="Current album tag" value={local.album} />
+            <DetailRow label="Current album artist tag" value={local.albumartist} />
+            <DetailRow label="Current year/date tag" value={local.year} />
+            <DetailRow label="Current track number" value={local.track} />
+            <DetailRow label="Disc" value={local.disc} />
+            <DetailRow label="Duration" value={local.duration || local.duration_seconds} />
+          </div>
+        </div>
+
+        <div className="rounded border border-white/70 bg-white/80 p-3">
+          <div className="font-semibold text-zinc-900">Suggested MusicBrainz / AcoustID match</div>
+          {candidate ? (
+            <div className="mt-2 grid grid-cols-2 gap-2">
+              <DetailRow label="Suggested Recording ID" value={candidate.mb_trackid} href={recordingUrl} mono />
+              <DetailRow label="AcoustID score/confidence" value={recordingCandidateScoreText(candidate)} />
+              <DetailRow label="Recording title" value={candidate.recording_title || candidate.title} />
+              <DetailRow label="Recording artist credit" value={candidate.recording_artist || candidate.artist} />
+              <DetailRow label="Release ID" value={candidate.mb_albumid || candidate.selected_release?.mb_albumid} href={releaseUrl} mono />
+              <DetailRow label="Release Group ID" value={candidate.mb_releasegroupid || candidate.selected_release?.mb_releasegroupid} href={rgUrl} mono />
+              <DetailRow label="Release title" value={candidate.release_title || candidate.album || candidate.selected_release?.album} />
+              <DetailRow label="Release year/date" value={candidate.release_year || candidate.year || candidate.release_date || candidate.selected_release?.year || candidate.selected_release?.date} />
+              <DetailRow label="Backend status" value={candidate.safety_result || candidate.safety_key} />
+              <DetailRow label="Recommended action" value={candidate.recommended_action} />
+            </div>
+          ) : (
+            <div className="mt-2 text-zinc-500">Run AI Suggest to load backend recording candidates.</div>
+          )}
+          {candidate?.reason ? <div className="mt-2 text-zinc-700">{candidate.reason}</div> : null}
+          {candidate?.conflicts?.length ? <div className="mt-2 font-medium text-amber-800">Backend conflicts: {candidate.conflicts.join(', ')}</div> : null}
+          {decision?.year_match?.status === 'conflict' ? (
+            <div className="mt-2 rounded border border-amber-200 bg-amber-50 px-2 py-1.5 text-amber-900">
+              <div className="font-semibold">Year conflict</div>
+              <div>Local {localYear || 'unknown'} vs Suggested {suggestedYear || 'unknown'}</div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {decision ? (
+        <div className="mt-3 rounded border border-white/70 bg-white/80 p-3">
+          <div className="font-semibold text-zinc-900">Backend match evidence</div>
+          <div className="mt-1 divide-y divide-graphite-100">
+            <MatchSummaryRow label="Title" field={decision.title_match} />
+            <MatchSummaryRow label="Artist" field={decision.artist_match} />
+            <MatchSummaryRow label="Album" field={decision.album_match} />
+            <MatchSummaryRow label="Year" field={decision.year_match} />
+            <MatchSummaryRow label="Duration" field={decision.duration_match} />
+            <MatchSummaryRow label="Release group" field={decision.release_group_match} />
+          </div>
+        </div>
+      ) : null}
+
+      {linkedReleases.length > 1 ? (
+        <div className="mt-3 rounded border border-white/70 bg-white/80 p-3">
+          <div className="font-semibold text-zinc-900">Same recording appears on {linkedReleases.length} releases</div>
+          <div className="mt-1 text-zinc-600">
+            {candidate?.matching_local_release_found ? 'Backend marked a local album/year release context.' : 'No backend local album/year preference was reported.'}
+          </div>
+          <div className="mt-2 grid gap-2 md:grid-cols-2">
+            {linkedReleases.slice(0, 4).map((release, index) => {
+              const releaseHref = musicBrainzUrl(release.mb_albumid);
+              return (
+                <div key={`${release.mb_albumid || index}`} className="rounded border border-graphite-200 bg-white px-2 py-1.5">
+                  <div className="truncate font-medium text-zinc-800">{release.album || '(unknown release)'}</div>
+                  <div className="truncate text-zinc-500">{[release.artist, release.year || release.date, release.country, release.medium_format || release.media_format].filter(Boolean).join(' / ')}</div>
+                  {releaseHref ? <a className="font-mono text-[0.7rem] text-sky-700 underline" href={releaseHref} target="_blank" rel="noreferrer">{release.mb_albumid}</a> : null}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+
+      {candidates.length ? (
+        <div id={`recording-candidates-${item.id}`} className="mt-3 space-y-2">
+          <div className="font-semibold text-zinc-900">Backend recording candidates</div>
+          {candidates.map((candidateRow, index) => (
+            <RecordingCandidateRow
+              key={recordingCandidateKey(candidateRow, index)}
+              candidate={candidateRow}
+              index={index}
+              selected={sameMbid(candidateRow.mb_trackid, mbid)}
+              onUseCandidate={onUseCandidate}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function initialMbid(item: ReviewItem): string {
+  if (item.target_kind === 'item') return item.mb_trackid || '';
   return item.mb_releasegroupid || item.mb_albumid || '';
 }
 
@@ -2117,7 +2463,10 @@ function ReviewCard({
     item.tracks ? `${item.tracks} track${item.tracks === 1 ? '' : 's'}` : '',
     selectedConfidenceText || (item.confidence ? `${item.confidence} confidence` : ''),
   ].filter(Boolean);
-  const mbUrl = item.mb_url || musicBrainzUrl(item.mb_albumid);
+  const isRecordingReview = item.type === 'library_no_mb' && item.target_kind === 'item';
+  const mbUrl = isRecordingReview
+    ? item.mb_url || musicBrainzRecordingUrl(mbid || item.mb_trackid)
+    : item.mb_url || musicBrainzUrl(item.mb_albumid);
   const itemReleaseGroupId = item.mb_releasegroupid || item.evidence?.preflight?.release_group || '';
   const itemReleaseGroupUrl = item.mb_releasegroupurl || musicBrainzReleaseGroupUrl(itemReleaseGroupId);
   const busy = actionState?.status === 'running';
@@ -2252,7 +2601,14 @@ function ReviewCard({
             ) : null}
 
             {/* Once a visible candidate is selected, show that candidate's state instead of stale stored evidence. */}
-            {selectedMatch && selectedMatch.source !== 'manual' ? (
+            {isRecordingReview ? (
+              <RecordingIdEvidencePanel
+                item={item}
+                response={suggestion}
+                mbid={mbid}
+                onUseCandidate={onUseCandidate}
+              />
+            ) : selectedMatch && selectedMatch.source !== 'manual' ? (
               <div className="mt-3 space-y-2 text-xs text-zinc-600">
                 <div>
                   <span>Selected candidate: </span>
@@ -2298,7 +2654,7 @@ function ReviewCard({
             ) : (
               <EvidenceSummary item={item} />
             )}
-            {!suggestion && (item.evidence?.top_candidates ?? []).length > 0 ? (
+            {!isRecordingReview && !suggestion && (item.evidence?.top_candidates ?? []).length > 0 ? (
               <CandidateCarousel
                 candidates={item.evidence?.top_candidates ?? []}
                 folder={item.path}
@@ -2307,12 +2663,14 @@ function ReviewCard({
                 onSelectMatch={onSelectMatch}
               />
             ) : null}
-            <AiSuggestionPanel
-              response={suggestion}
-              folder={item.path}
-              onUseCandidate={onUseCandidate}
-              onSelectMatch={onSelectMatch}
-            />
+            {!isRecordingReview ? (
+              <AiSuggestionPanel
+                response={suggestion}
+                folder={item.path}
+                onUseCandidate={onUseCandidate}
+                onSelectMatch={onSelectMatch}
+              />
+            ) : null}
             <TargetPathPreviewPanel state={targetPreviewState} />
 
             {actionState?.message ? (
@@ -2350,7 +2708,7 @@ function ReviewCard({
 
             {blockedActive && visibleBlockReason ? (
               <div className="rounded border border-amber-300 bg-amber-50 px-2 py-1.5 text-xs text-amber-950">
-                <div className="font-semibold">Import blocked</div>
+                <div className="font-semibold">{isRecordingReview ? 'Attach blocked' : 'Import blocked'}</div>
                 <div className="mt-0.5">{visibleBlockReason}</div>
                 {visibleBlockHint ? <div className="mt-1 font-medium">Next: {visibleBlockHint}</div> : null}
                 {cleanupReady ? (
@@ -3395,13 +3753,16 @@ export function ImportReviewPage({
       // shared album-shaped path below.
       try {
         const response = await suggestItem(item.item_id);
-        const s = response.suggestions;
-        if (s?.mb_valid && s.mb_trackid) {
-          setMbids((current) => ({ ...current, [item.id]: s.mb_trackid || '' }));
+        const s = response.suggestions ?? response.suggestion;
+        const candidate = selectedRecordingCandidate(response, item, s?.mb_trackid || '');
+        const mbTrackId = s?.mb_trackid || candidate?.mb_trackid || '';
+        setSuggestions((current) => ({ ...current, [item.id]: response }));
+        if (mbTrackId) {
+          setMbids((current) => ({ ...current, [item.id]: mbTrackId }));
         }
         setAction(item.id, {
           status: 'success',
-          message: s?.reason || (s?.mb_valid ? 'AI suggestion ready. Verify the recording ID before attaching.' : 'No confident recording match found.'),
+          message: s?.reason || candidate?.reason || (mbTrackId ? 'AI suggestion ready. Review the backend recording evidence before attaching.' : 'No confident recording match found.'),
         });
       } catch (err) {
         setAction(item.id, { status: 'error', message: err instanceof Error ? err.message : String(err) });
@@ -3715,6 +4076,16 @@ export function ImportReviewPage({
     if (!activeItem) return;
     const item = activeItem;
     setMbids((c) => ({ ...c, [item.id]: value }));
+    if (item.target_kind === 'item') {
+      setSelectedMatches((current) => {
+        if (!current[item.id]) return current;
+        const next = { ...current };
+        delete next[item.id];
+        return next;
+      });
+      delete targetPreviewKeysRef.current[item.id];
+      return;
+    }
     setSelectedMatches((current) => {
       const prev = current[item.id];
       return {
@@ -3746,7 +4117,17 @@ export function ImportReviewPage({
   }, [activeItem]);
 
   const handleUseCandidate = useCallback((value: string) => {
-    if (activeItem) setMbids((c) => ({ ...c, [activeItem.id]: value }));
+    if (!activeItem) return;
+    setMbids((c) => ({ ...c, [activeItem.id]: value }));
+    if (activeItem.target_kind === 'item') {
+      setSelectedMatches((current) => {
+        if (!current[activeItem.id]) return current;
+        const next = { ...current };
+        delete next[activeItem.id];
+        return next;
+      });
+      delete targetPreviewKeysRef.current[activeItem.id];
+    }
   }, [activeItem]);
 
   const handleSelectMatch = useCallback((match: SelectedMatch) => {

--- a/frontend/src/features/importReview/ImportReviewPage.tsx
+++ b/frontend/src/features/importReview/ImportReviewPage.tsx
@@ -662,7 +662,14 @@ function missingIdType(item: ReviewItem): string {
 }
 
 function recordingCandidateKey(candidate: ReviewRecordingCandidate, fallback: number): string {
-  return (candidate.mb_trackid || `${candidate.candidate_index ?? fallback}`).trim().toLowerCase();
+  const mbTrackId = candidate.mb_trackid?.trim().toLowerCase();
+  if (mbTrackId) return `recording:${mbTrackId}`;
+  return [
+    'evidence',
+    String(candidate.candidate_index ?? fallback),
+    candidate.recording_title || candidate.title || '',
+    candidate.recording_artist || candidate.artist || '',
+  ].join(':').toLowerCase();
 }
 
 function asRecordingCandidate(raw: unknown): ReviewRecordingCandidate | null {
@@ -680,19 +687,7 @@ function asRecordingCandidate(raw: unknown): ReviewRecordingCandidate | null {
   return hasRecordingShape ? candidate : null;
 }
 
-function recordingCandidatesFrom(response?: AiSuggestResponse, item?: ReviewItem): ReviewRecordingCandidate[] {
-  const suggestion = response?.suggestions ?? response?.suggestion;
-  const rawCandidates: unknown[] = [
-    suggestion?.selected_recording_candidate,
-    suggestion?.candidate_evidence,
-    response?.selected_candidate,
-    response?.evidence?.selected_recording_candidate,
-    item?.evidence?.selected_recording_candidate,
-    ...(suggestion?.recording_candidates ?? []),
-    ...(response?.recording_candidates ?? []),
-    ...(response?.evidence?.recording_candidates ?? []),
-    ...(item?.evidence?.recording_candidates ?? []),
-  ];
+function compactRecordingCandidates(rawCandidates: unknown[]): ReviewRecordingCandidate[] {
   const seen = new Set<string>();
   const candidates: ReviewRecordingCandidate[] = [];
   rawCandidates.forEach((raw, index) => {
@@ -706,9 +701,82 @@ function recordingCandidatesFrom(response?: AiSuggestResponse, item?: ReviewItem
   return candidates;
 }
 
-function selectedRecordingCandidate(response: AiSuggestResponse | undefined, item: ReviewItem, mbid: string): ReviewRecordingCandidate | undefined {
-  const candidates = recordingCandidatesFrom(response, item);
-  return candidates.find((candidate) => sameMbid(candidate.mb_trackid, mbid)) || candidates[0];
+function firstUsableRecordingCandidateList(...sources: Array<unknown[] | undefined>): unknown[] {
+  for (const source of sources) {
+    if (source && compactRecordingCandidates(source).length > 0) return source;
+  }
+  return [];
+}
+
+function confirmedCandidateEvidence(
+  suggestion: AiSuggestion | undefined,
+  explicitCandidates: ReviewRecordingCandidate[],
+): ReviewRecordingCandidate | null {
+  const candidate = asRecordingCandidate(suggestion?.candidate_evidence);
+  if (!candidate || !isMusicBrainzUuid(candidate.mb_trackid)) return null;
+  if (suggestion?.mb_trackid && sameMbid(candidate.mb_trackid, suggestion.mb_trackid)) return candidate;
+  if (explicitCandidates.some((explicit) => sameMbid(explicit.mb_trackid, candidate.mb_trackid))) return candidate;
+  return null;
+}
+
+function responseRecordingCandidateInputs(response?: AiSuggestResponse): unknown[] {
+  if (!response) return [];
+  const suggestion = response.suggestions ?? response.suggestion;
+  const candidateList = firstUsableRecordingCandidateList(
+    suggestion?.recording_candidates,
+    response.recording_candidates,
+    response.evidence?.recording_candidates,
+    suggestion?.review_evidence?.recording_candidates,
+  );
+  if (candidateList.length) return candidateList;
+
+  const explicitRaw: unknown[] = [
+    suggestion?.selected_recording_candidate,
+    response.evidence?.selected_recording_candidate,
+    response.selected_candidate,
+  ];
+  const explicitCandidates = compactRecordingCandidates(explicitRaw);
+  const candidateEvidence = confirmedCandidateEvidence(suggestion, explicitCandidates);
+  return candidateEvidence ? [...explicitRaw, candidateEvidence] : explicitRaw;
+}
+
+function itemEvidenceRecordingCandidateInputs(item?: ReviewItem): unknown[] {
+  const evidence = item?.evidence;
+  if (!evidence) return [];
+  const candidateList = firstUsableRecordingCandidateList(evidence.recording_candidates);
+  return candidateList.length ? candidateList : [evidence.selected_recording_candidate];
+}
+
+// Temporary compatibility adapter: prefer the newest AI-suggest response and
+// fall back to persisted item evidence only until the shared matching-result
+// contract gives the frontend one canonical recording-candidate shape.
+function recordingCandidatesFrom(response?: AiSuggestResponse, item?: ReviewItem): ReviewRecordingCandidate[] {
+  const responseCandidates = compactRecordingCandidates(responseRecordingCandidateInputs(response));
+  if (responseCandidates.length) return responseCandidates;
+  return compactRecordingCandidates(itemEvidenceRecordingCandidateInputs(item));
+}
+
+function backendSelectedRecordingCandidate(response: AiSuggestResponse | undefined, item: ReviewItem): ReviewRecordingCandidate | undefined {
+  const responseCandidates = compactRecordingCandidates(responseRecordingCandidateInputs(response));
+  const useCurrentResponse = responseCandidates.length > 0;
+  const suggestion = useCurrentResponse ? response?.suggestions ?? response?.suggestion : undefined;
+  const explicitRaw: unknown[] = useCurrentResponse
+    ? [suggestion?.selected_recording_candidate, response?.evidence?.selected_recording_candidate, response?.selected_candidate]
+    : [item.evidence?.selected_recording_candidate];
+  const explicitCandidates = compactRecordingCandidates(explicitRaw);
+  const candidateEvidence = useCurrentResponse ? confirmedCandidateEvidence(suggestion, explicitCandidates) : null;
+  const selectedByExplicitField = [...explicitCandidates, ...(candidateEvidence ? [candidateEvidence] : [])]
+    .find((candidate) => isMusicBrainzUuid(candidate.mb_trackid));
+  if (selectedByExplicitField) return selectedByExplicitField;
+  if (useCurrentResponse && isMusicBrainzUuid(suggestion?.mb_trackid)) {
+    return responseCandidates.find((candidate) => sameMbid(candidate.mb_trackid, suggestion?.mb_trackid));
+  }
+  return undefined;
+}
+
+function recordingCandidateMatchingEnteredId(candidates: ReviewRecordingCandidate[], mbid: string): ReviewRecordingCandidate | undefined {
+  if (!isMusicBrainzUuid(mbid)) return undefined;
+  return candidates.find((candidate) => sameMbid(candidate.mb_trackid, mbid));
 }
 
 function localEvidenceForItem(item: ReviewItem, response?: AiSuggestResponse): RecordingLocalEvidence {
@@ -735,18 +803,63 @@ function localEvidenceForItem(item: ReviewItem, response?: AiSuggestResponse): R
   };
 }
 
-function recordingCandidateScoreText(candidate: ReviewRecordingCandidate): string {
-  const raw = candidate.confidence_score ?? candidate.acoustid_score ?? candidate.match_total ?? candidate.score;
-  const score = typeof raw === 'number' ? raw : Number(raw);
-  if (!Number.isFinite(score)) return valueLabel(candidate.confidence);
-  return score > 1 ? `${Math.round(score)}%` : formatPercent(score);
+type RecordingCandidateMetric = {
+  label: string;
+  value: string;
+  toneClass: string;
+};
+
+function numericMetricValue(value: unknown): number | null {
+  const score = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(score) ? score : null;
 }
 
-function recordingCandidateScoreClass(candidate: ReviewRecordingCandidate): string {
-  const raw = candidate.confidence_score ?? candidate.acoustid_score ?? candidate.match_total ?? candidate.score;
-  return scoreClass(raw === null ? undefined : raw);
+function normalizedMetricValue(value: unknown): { value: string; toneClass: string } {
+  const score = numericMetricValue(value);
+  if (score !== null && score >= 0 && score <= 1) {
+    return { value: formatPercent(score), toneClass: scoreClass(score) };
+  }
+  return { value: valueLabel(value), toneClass: 'text-zinc-500' };
 }
 
+function rawMetricValue(value: unknown): { value: string; toneClass: string } {
+  return { value: valueLabel(value), toneClass: 'text-zinc-500' };
+}
+
+function recordingCandidateMetric(candidate: ReviewRecordingCandidate): RecordingCandidateMetric {
+  if (candidate.confidence_score !== null && candidate.confidence_score !== undefined) {
+    return { label: 'Match confidence', ...normalizedMetricValue(candidate.confidence_score) };
+  }
+  if (candidate.match_total !== null && candidate.match_total !== undefined) {
+    const score = numericMetricValue(candidate.match_total);
+    if (score !== null && score >= 0 && score <= 1) {
+      return { label: 'Match confidence', ...normalizedMetricValue(candidate.match_total) };
+    }
+    return { label: 'Candidate score', ...rawMetricValue(candidate.match_total) };
+  }
+  if (candidate.acoustid_score !== null && candidate.acoustid_score !== undefined) {
+    return { label: 'AcoustID score', ...normalizedMetricValue(candidate.acoustid_score) };
+  }
+  if (candidate.score !== null && candidate.score !== undefined) {
+    return { label: 'Candidate score', ...rawMetricValue(candidate.score) };
+  }
+  return { label: 'Confidence', ...rawMetricValue(candidate.confidence) };
+}
+
+function recordingCandidateRowLabel({
+  isBackendSelected,
+  matchesEnteredId,
+  isFirstBackendCandidate,
+}: {
+  isBackendSelected: boolean;
+  matchesEnteredId: boolean;
+  isFirstBackendCandidate: boolean;
+}): string {
+  if (isBackendSelected) return 'Backend selected candidate';
+  if (matchesEnteredId) return 'Candidate matching entered ID';
+  if (isFirstBackendCandidate) return 'First backend candidate';
+  return 'Backend alternate candidate';
+}
 function DetailRow({
   label,
   value,
@@ -801,15 +914,18 @@ function MatchSummaryRow({ label, field }: { label: string; field?: { status?: s
 
 function RecordingCandidateRow({
   candidate,
-  index,
-  selected,
+  isBackendSelected,
+  matchesEnteredId,
+  isFirstBackendCandidate,
   onUseCandidate,
 }: {
   candidate: ReviewRecordingCandidate;
-  index: number;
-  selected: boolean;
+  isBackendSelected: boolean;
+  matchesEnteredId: boolean;
+  isFirstBackendCandidate: boolean;
   onUseCandidate: (mbid: string) => void;
 }) {
+  const metric = recordingCandidateMetric(candidate);
   const recordingUrl = candidate.musicbrainz_url || candidate.mb_url || musicBrainzRecordingUrl(candidate.mb_trackid);
   const releaseUrl = musicBrainzUrl(candidate.mb_albumid || candidate.selected_release?.mb_albumid);
   const rgUrl = candidate.mb_releasegroupurl || musicBrainzReleaseGroupUrl(candidate.mb_releasegroupid || candidate.selected_release?.mb_releasegroupid);
@@ -819,12 +935,14 @@ function RecordingCandidateRow({
     candidate.country || candidate.selected_release?.country,
     candidate.medium_format || candidate.media_format || candidate.selected_release?.medium_format || candidate.selected_release?.media_format,
   ].filter(Boolean).join(' / ');
+  const label = recordingCandidateRowLabel({ isBackendSelected, matchesEnteredId, isFirstBackendCandidate });
+  const canUseRecordingId = isMusicBrainzUuid(candidate.mb_trackid);
   return (
-    <div className={`rounded border px-2 py-2 text-xs ${selected ? 'border-sky-300 bg-sky-50' : 'border-graphite-200 bg-white'}`}>
+    <div className={`rounded border px-2 py-2 text-xs ${matchesEnteredId ? 'border-sky-300 bg-sky-50' : 'border-graphite-200 bg-white'}`}>
       <div className="flex flex-wrap items-center gap-2">
-        <span className="font-semibold text-zinc-900">{index === 0 ? 'Backend selected candidate' : 'Backend alternate candidate'}</span>
-        {selected ? <Chip size="small" color="info" label="Selected" /> : null}
-        <span className={recordingCandidateScoreClass(candidate)}>{recordingCandidateScoreText(candidate)}</span>
+        <span className="font-semibold text-zinc-900">{label}</span>
+        {matchesEnteredId ? <Chip size="small" color="info" label="Entered ID" /> : null}
+        <span className={metric.toneClass}>{metric.label}: {metric.value}</span>
         {candidate.match_method || candidate.source ? <span className="text-zinc-500">{candidate.match_method || candidate.source}</span> : null}
         {candidate.safety_result ? <span className="font-medium text-zinc-700">{candidate.safety_result}</span> : null}
       </div>
@@ -835,7 +953,7 @@ function RecordingCandidateRow({
       {candidate.reason ? <div className="mt-1 text-zinc-600">{candidate.reason}</div> : null}
       {candidate.conflicts?.length ? <div className="mt-1 font-medium text-amber-800">Conflicts: {candidate.conflicts.join(', ')}</div> : null}
       <div className="mt-2 flex flex-wrap gap-2">
-        <Button size="small" variant={selected ? 'contained' : 'outlined'} onClick={() => onUseCandidate(candidate.mb_trackid || '')} disabled={!candidate.mb_trackid}>
+        <Button size="small" variant={matchesEnteredId ? 'contained' : 'outlined'} onClick={() => onUseCandidate(candidate.mb_trackid || '')} disabled={!canUseRecordingId}>
           Use Recording ID
         </Button>
         {recordingUrl ? <Button size="small" variant="text" href={recordingUrl} target="_blank" rel="noreferrer">Recording</Button> : null}
@@ -859,23 +977,33 @@ function RecordingIdEvidencePanel({
 }) {
   const local = localEvidenceForItem(item, response);
   const candidates = recordingCandidatesFrom(response, item);
-  const selectedCandidate = selectedRecordingCandidate(response, item, mbid);
-  const candidate = selectedCandidate || candidates[0];
-  const decision = candidate?.decision;
+  const backendSelectedCandidate = backendSelectedRecordingCandidate(response, item);
+  const candidateMatchingEnteredId = recordingCandidateMatchingEnteredId(candidates, mbid);
+  const displayCandidate = backendSelectedCandidate || candidateMatchingEnteredId || candidates[0];
+  const displayMetric = displayCandidate ? recordingCandidateMetric(displayCandidate) : null;
+  const displayReason = displayCandidate && backendSelectedCandidate && sameMbid(displayCandidate.mb_trackid, backendSelectedCandidate.mb_trackid)
+    ? 'Backend selected candidate'
+    : displayCandidate && candidateMatchingEnteredId && sameMbid(displayCandidate.mb_trackid, candidateMatchingEnteredId.mb_trackid)
+      ? 'Candidate matching entered ID'
+      : displayCandidate
+        ? 'First backend candidate'
+        : '';
+  const decision = displayCandidate?.decision;
   const localYear = evidenceYear(local.year);
-  const suggestedYear = evidenceYear(candidate?.release_year ?? candidate?.year ?? candidate?.selected_release?.year ?? candidate?.release_date);
-  const linkedReleases = candidate?.linked_releases ?? [];
-  const recordingUrl = candidate?.musicbrainz_url || candidate?.mb_url || musicBrainzRecordingUrl(candidate?.mb_trackid || mbid);
-  const releaseUrl = musicBrainzUrl(candidate?.mb_albumid || candidate?.selected_release?.mb_albumid);
-  const rgUrl = candidate?.mb_releasegroupurl || musicBrainzReleaseGroupUrl(candidate?.mb_releasegroupid || candidate?.selected_release?.mb_releasegroupid);
+  const suggestedYear = evidenceYear(displayCandidate?.release_year ?? displayCandidate?.year ?? displayCandidate?.selected_release?.year ?? displayCandidate?.release_date);
+  const linkedReleases = displayCandidate?.linked_releases ?? [];
+  const recordingUrl = displayCandidate?.musicbrainz_url || displayCandidate?.mb_url || musicBrainzRecordingUrl(displayCandidate?.mb_trackid || mbid);
+  const releaseUrl = musicBrainzUrl(displayCandidate?.mb_albumid || displayCandidate?.selected_release?.mb_albumid);
+  const rgUrl = displayCandidate?.mb_releasegroupurl || musicBrainzReleaseGroupUrl(displayCandidate?.mb_releasegroupid || displayCandidate?.selected_release?.mb_releasegroupid);
 
   return (
     <div className="mt-3 rounded border border-cyan-200 bg-cyan-50 p-3 text-xs text-zinc-700">
       <div className="flex flex-wrap items-center gap-2">
         <span className="font-semibold text-zinc-900">Recording ID review</span>
         <Chip size="small" color="info" label={`Missing ID type: ${missingIdType(item)}`} />
-        {candidate?.safety_result ? <Chip size="small" variant="outlined" label={candidate.safety_result} /> : null}
-        {candidate?.recommended_action ? <Chip size="small" variant="outlined" label={candidate.recommended_action} /> : null}
+        {displayReason ? <Chip size="small" variant="outlined" label={displayReason} /> : null}
+        {displayCandidate?.safety_result ? <Chip size="small" variant="outlined" label={displayCandidate.safety_result} /> : null}
+        {displayCandidate?.recommended_action ? <Chip size="small" variant="outlined" label={displayCandidate.recommended_action} /> : null}
       </div>
 
       <div className="mt-3 grid gap-3 lg:grid-cols-2">
@@ -897,24 +1025,25 @@ function RecordingIdEvidencePanel({
 
         <div className="rounded border border-white/70 bg-white/80 p-3">
           <div className="font-semibold text-zinc-900">Suggested MusicBrainz / AcoustID match</div>
-          {candidate ? (
+          {displayCandidate ? (
             <div className="mt-2 grid grid-cols-2 gap-2">
-              <DetailRow label="Suggested Recording ID" value={candidate.mb_trackid} href={recordingUrl} mono />
-              <DetailRow label="AcoustID score/confidence" value={recordingCandidateScoreText(candidate)} />
-              <DetailRow label="Recording title" value={candidate.recording_title || candidate.title} />
-              <DetailRow label="Recording artist credit" value={candidate.recording_artist || candidate.artist} />
-              <DetailRow label="Release ID" value={candidate.mb_albumid || candidate.selected_release?.mb_albumid} href={releaseUrl} mono />
-              <DetailRow label="Release Group ID" value={candidate.mb_releasegroupid || candidate.selected_release?.mb_releasegroupid} href={rgUrl} mono />
-              <DetailRow label="Release title" value={candidate.release_title || candidate.album || candidate.selected_release?.album} />
-              <DetailRow label="Release year/date" value={candidate.release_year || candidate.year || candidate.release_date || candidate.selected_release?.year || candidate.selected_release?.date} />
-              <DetailRow label="Backend status" value={candidate.safety_result || candidate.safety_key} />
-              <DetailRow label="Recommended action" value={candidate.recommended_action} />
+              <DetailRow label="Displayed candidate" value={displayReason} />
+              {displayMetric ? <DetailRow label={displayMetric.label} value={displayMetric.value} /> : null}
+              <DetailRow label="Suggested Recording ID" value={displayCandidate.mb_trackid} href={recordingUrl} mono />
+              <DetailRow label="Recording title" value={displayCandidate.recording_title || displayCandidate.title} />
+              <DetailRow label="Recording artist credit" value={displayCandidate.recording_artist || displayCandidate.artist} />
+              <DetailRow label="Release ID" value={displayCandidate.mb_albumid || displayCandidate.selected_release?.mb_albumid} href={releaseUrl} mono />
+              <DetailRow label="Release Group ID" value={displayCandidate.mb_releasegroupid || displayCandidate.selected_release?.mb_releasegroupid} href={rgUrl} mono />
+              <DetailRow label="Release title" value={displayCandidate.release_title || displayCandidate.album || displayCandidate.selected_release?.album} />
+              <DetailRow label="Release year/date" value={displayCandidate.release_year || displayCandidate.year || displayCandidate.release_date || displayCandidate.selected_release?.year || displayCandidate.selected_release?.date} />
+              <DetailRow label="Backend status" value={displayCandidate.safety_result || displayCandidate.safety_key} />
+              <DetailRow label="Recommended action" value={displayCandidate.recommended_action} />
             </div>
           ) : (
             <div className="mt-2 text-zinc-500">Run AI Suggest to load backend recording candidates.</div>
           )}
-          {candidate?.reason ? <div className="mt-2 text-zinc-700">{candidate.reason}</div> : null}
-          {candidate?.conflicts?.length ? <div className="mt-2 font-medium text-amber-800">Backend conflicts: {candidate.conflicts.join(', ')}</div> : null}
+          {displayCandidate?.reason ? <div className="mt-2 text-zinc-700">{displayCandidate.reason}</div> : null}
+          {displayCandidate?.conflicts?.length ? <div className="mt-2 font-medium text-amber-800">Backend conflicts: {displayCandidate.conflicts.join(', ')}</div> : null}
           {decision?.year_match?.status === 'conflict' ? (
             <div className="mt-2 rounded border border-amber-200 bg-amber-50 px-2 py-1.5 text-amber-900">
               <div className="font-semibold">Year conflict</div>
@@ -942,7 +1071,7 @@ function RecordingIdEvidencePanel({
         <div className="mt-3 rounded border border-white/70 bg-white/80 p-3">
           <div className="font-semibold text-zinc-900">Same recording appears on {linkedReleases.length} releases</div>
           <div className="mt-1 text-zinc-600">
-            {candidate?.matching_local_release_found ? 'Backend marked a local album/year release context.' : 'No backend local album/year preference was reported.'}
+            {displayCandidate?.matching_local_release_found ? 'Backend marked a local album/year release context.' : 'No backend local album/year preference was reported.'}
           </div>
           <div className="mt-2 grid gap-2 md:grid-cols-2">
             {linkedReleases.slice(0, 4).map((release, index) => {
@@ -962,21 +1091,25 @@ function RecordingIdEvidencePanel({
       {candidates.length ? (
         <div id={`recording-candidates-${item.id}`} className="mt-3 space-y-2">
           <div className="font-semibold text-zinc-900">Backend recording candidates</div>
-          {candidates.map((candidateRow, index) => (
-            <RecordingCandidateRow
-              key={recordingCandidateKey(candidateRow, index)}
-              candidate={candidateRow}
-              index={index}
-              selected={sameMbid(candidateRow.mb_trackid, mbid)}
-              onUseCandidate={onUseCandidate}
-            />
-          ))}
+          {candidates.map((candidateRow, index) => {
+            const isBackendSelected = Boolean(backendSelectedCandidate && sameMbid(candidateRow.mb_trackid, backendSelectedCandidate.mb_trackid));
+            const matchesEnteredId = Boolean(candidateMatchingEnteredId && sameMbid(candidateRow.mb_trackid, candidateMatchingEnteredId.mb_trackid));
+            return (
+              <RecordingCandidateRow
+                key={recordingCandidateKey(candidateRow, index)}
+                candidate={candidateRow}
+                isBackendSelected={isBackendSelected}
+                matchesEnteredId={matchesEnteredId}
+                isFirstBackendCandidate={index === 0}
+                onUseCandidate={onUseCandidate}
+              />
+            );
+          })}
         </div>
       ) : null}
     </div>
   );
 }
-
 function initialMbid(item: ReviewItem): string {
   if (item.target_kind === 'item') return item.mb_trackid || '';
   return item.mb_releasegroupid || item.mb_albumid || '';
@@ -3754,15 +3887,15 @@ export function ImportReviewPage({
       try {
         const response = await suggestItem(item.item_id);
         const s = response.suggestions ?? response.suggestion;
-        const candidate = selectedRecordingCandidate(response, item, s?.mb_trackid || '');
-        const mbTrackId = s?.mb_trackid || candidate?.mb_trackid || '';
+        const backendCandidate = backendSelectedRecordingCandidate(response, item);
+        const mbTrackId = s?.mb_trackid || backendCandidate?.mb_trackid || '';
         setSuggestions((current) => ({ ...current, [item.id]: response }));
         if (mbTrackId) {
           setMbids((current) => ({ ...current, [item.id]: mbTrackId }));
         }
         setAction(item.id, {
           status: 'success',
-          message: s?.reason || candidate?.reason || (mbTrackId ? 'AI suggestion ready. Review the backend recording evidence before attaching.' : 'No confident recording match found.'),
+          message: s?.reason || backendCandidate?.reason || (mbTrackId ? 'AI suggestion ready. Review the backend recording evidence before attaching.' : 'No confident recording match found.'),
         });
       } catch (err) {
         setAction(item.id, { status: 'error', message: err instanceof Error ? err.message : String(err) });

--- a/tests/test_import_review_recording_id_frontend.py
+++ b/tests/test_import_review_recording_id_frontend.py
@@ -1,0 +1,76 @@
+"""Static coverage for display-only Import Review recording-ID evidence."""
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORT_REVIEW_SOURCE = (ROOT / "frontend" / "src" / "features" / "importReview" / "ImportReviewPage.tsx").read_text(encoding="utf-8")
+
+
+def _source_between(src: str, start_marker: str, end_marker: str) -> str:
+    start = src.index(start_marker)
+    end = src.index(end_marker, start)
+    return src[start:end]
+
+
+class ImportReviewRecordingIdFrontendTests(unittest.TestCase):
+    def test_recording_id_panel_renders_backend_evidence(self):
+        panel = _source_between(IMPORT_REVIEW_SOURCE, "function RecordingIdEvidencePanel", "function initialMbid")
+        self.assertIn("Local file evidence", panel)
+        self.assertIn("Current title tag", panel)
+        self.assertIn("Current artist tag", panel)
+        self.assertIn("Current album tag", panel)
+        self.assertIn("Current album artist tag", panel)
+        self.assertIn("Current year/date tag", panel)
+        self.assertIn("Current track number", panel)
+        self.assertIn("Fingerprint status", panel)
+        self.assertIn("Suggested MusicBrainz / AcoustID match", panel)
+        self.assertIn("Backend match evidence", panel)
+        self.assertIn("Backend recording candidates", panel)
+
+    def test_recording_candidates_display_ids_confidence_and_release_context(self):
+        panel = _source_between(IMPORT_REVIEW_SOURCE, "function RecordingIdEvidencePanel", "function initialMbid")
+        self.assertIn("Suggested Recording ID", panel)
+        self.assertIn("Recording title", panel)
+        self.assertIn("Recording artist credit", panel)
+        self.assertIn("Release ID", panel)
+        self.assertIn("Release Group ID", panel)
+        self.assertIn("AcoustID score/confidence", panel)
+        self.assertIn("Same recording appears on", panel)
+        self.assertIn("matching_local_release_found", panel)
+        self.assertIn("musicBrainzRecordingUrl", IMPORT_REVIEW_SOURCE)
+        self.assertIn("https://musicbrainz.org/recording/", IMPORT_REVIEW_SOURCE)
+
+    def test_item_ai_suggest_response_is_kept_for_display(self):
+        fn = _source_between(IMPORT_REVIEW_SOURCE, "const handleSuggest = useCallback(", "const startApply = useCallback(")
+        self.assertIn("await suggestItem(item.item_id)", fn)
+        self.assertIn("setSuggestions((current) => ({ ...current, [item.id]: response }));", fn)
+        self.assertIn("selectedRecordingCandidate(response, item", fn)
+        self.assertIn("Review the backend recording evidence before attaching", fn)
+
+    def test_candidate_selection_only_copies_visible_recording_id(self):
+        row = _source_between(IMPORT_REVIEW_SOURCE, "function RecordingCandidateRow", "function RecordingIdEvidencePanel")
+        self.assertIn("Use Recording ID", row)
+        self.assertIn("onUseCandidate(candidate.mb_trackid || '')", row)
+        self.assertNotIn("attachRecording", row)
+        self.assertNotIn("confirmed_conflicts", row)
+
+    def test_reduced_work_does_not_make_frontend_authoritative(self):
+        self.assertNotIn("RECORDING_REJECTS_STORAGE_KEY", IMPORT_REVIEW_SOURCE)
+        self.assertNotIn("recordingAttachBlockReason", IMPORT_REVIEW_SOURCE)
+        self.assertNotIn("confirmedRecordingConflicts", IMPORT_REVIEW_SOURCE)
+        self.assertNotIn("recordingCandidateHasHardConflict", IMPORT_REVIEW_SOURCE)
+        self.assertNotIn("candidate: selectedRecordingCandidate", IMPORT_REVIEW_SOURCE)
+        run_apply = _source_between(IMPORT_REVIEW_SOURCE, "const runApply = useCallback(", "const requestDismiss = useCallback(")
+        self.assertIn("started = await attachRecording(item.item_id, representativeId);", run_apply)
+
+    def test_recording_rows_stay_out_of_album_match_state(self):
+        self.assertIn("if (item.target_kind === 'item') return item.mb_trackid || '';", IMPORT_REVIEW_SOURCE)
+        handler = _source_between(IMPORT_REVIEW_SOURCE, "const handleMbidChange = useCallback(", "const handleUseCandidate = useCallback(")
+        self.assertIn("if (item.target_kind === 'item')", handler)
+        self.assertIn("delete next[item.id];", handler)
+        self.assertIn("delete targetPreviewKeysRef.current[item.id];", handler)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_import_review_recording_id_frontend.py
+++ b/tests/test_import_review_recording_id_frontend.py
@@ -1,4 +1,8 @@
-"""Static coverage for display-only Import Review recording-ID evidence."""
+"""Static structural checks for display-only Import Review recording-ID evidence.
+
+These checks protect source-level invariants only. They are not executable React
+component interaction tests.
+"""
 import unittest
 from pathlib import Path
 
@@ -28,30 +32,80 @@ class ImportReviewRecordingIdFrontendTests(unittest.TestCase):
         self.assertIn("Backend match evidence", panel)
         self.assertIn("Backend recording candidates", panel)
 
-    def test_recording_candidates_display_ids_confidence_and_release_context(self):
+    def test_candidate_labels_separate_backend_form_and_fallback_states(self):
+        self.assertNotIn("index === 0 ? 'Backend selected candidate'", IMPORT_REVIEW_SOURCE)
+        label_fn = _source_between(IMPORT_REVIEW_SOURCE, "function recordingCandidateRowLabel", "function RecordingCandidateRow")
+        self.assertIn("if (isBackendSelected) return 'Backend selected candidate';", label_fn)
+        self.assertIn("if (matchesEnteredId) return 'Candidate matching entered ID';", label_fn)
+        self.assertIn("if (isFirstBackendCandidate) return 'First backend candidate';", label_fn)
+        self.assertIn("return 'Backend alternate candidate';", label_fn)
+        self.assertNotIn("index", label_fn)
+        panel = _source_between(IMPORT_REVIEW_SOURCE, "function RecordingIdEvidencePanel", "function initialMbid")
+        self.assertIn("const backendSelectedCandidate = backendSelectedRecordingCandidate(response, item);", panel)
+        self.assertIn("const candidateMatchingEnteredId = recordingCandidateMatchingEnteredId(candidates, mbid);", panel)
+        self.assertIn("const displayCandidate = backendSelectedCandidate || candidateMatchingEnteredId || candidates[0];", panel)
+        self.assertIn("isBackendSelected={isBackendSelected}", panel)
+        self.assertIn("matchesEnteredId={matchesEnteredId}", panel)
+        self.assertIn("isFirstBackendCandidate={index === 0}", panel)
+
+    def test_backend_selection_is_explicit_not_array_order(self):
+        helper = _source_between(IMPORT_REVIEW_SOURCE, "function backendSelectedRecordingCandidate", "function recordingCandidateMatchingEnteredId")
+        self.assertIn("suggestion?.selected_recording_candidate", helper)
+        self.assertIn("response?.evidence?.selected_recording_candidate", helper)
+        self.assertIn("response?.selected_candidate", helper)
+        self.assertIn("confirmedCandidateEvidence(suggestion, explicitCandidates)", helper)
+        self.assertIn("isMusicBrainzUuid(suggestion?.mb_trackid)", helper)
+        self.assertNotIn("candidates[0]", helper)
+        self.assertNotIn("index", helper)
+
+    def test_candidate_source_precedence_does_not_mix_stale_item_evidence(self):
+        adapter = _source_between(IMPORT_REVIEW_SOURCE, "// Temporary compatibility adapter", "function backendSelectedRecordingCandidate")
+        self.assertIn("prefer the newest AI-suggest response", adapter)
+        self.assertIn("fall back to persisted item evidence only", adapter)
+        self.assertIn("const responseCandidates = compactRecordingCandidates(responseRecordingCandidateInputs(response));", adapter)
+        self.assertIn("if (responseCandidates.length) return responseCandidates;", adapter)
+        self.assertIn("return compactRecordingCandidates(itemEvidenceRecordingCandidateInputs(item));", adapter)
+
+    def test_recording_candidates_display_ids_metric_and_release_context(self):
         panel = _source_between(IMPORT_REVIEW_SOURCE, "function RecordingIdEvidencePanel", "function initialMbid")
         self.assertIn("Suggested Recording ID", panel)
         self.assertIn("Recording title", panel)
         self.assertIn("Recording artist credit", panel)
         self.assertIn("Release ID", panel)
         self.assertIn("Release Group ID", panel)
-        self.assertIn("AcoustID score/confidence", panel)
         self.assertIn("Same recording appears on", panel)
         self.assertIn("matching_local_release_found", panel)
         self.assertIn("musicBrainzRecordingUrl", IMPORT_REVIEW_SOURCE)
         self.assertIn("https://musicbrainz.org/recording/", IMPORT_REVIEW_SOURCE)
 
+    def test_metric_labels_are_honest_about_score_sources(self):
+        metric = _source_between(IMPORT_REVIEW_SOURCE, "function recordingCandidateMetric", "function recordingCandidateRowLabel")
+        self.assertNotIn("AcoustID score/confidence", IMPORT_REVIEW_SOURCE)
+        self.assertIn("candidate.confidence_score", metric)
+        self.assertIn("return { label: 'Match confidence', ...normalizedMetricValue(candidate.confidence_score) };", metric)
+        self.assertIn("candidate.match_total", metric)
+        self.assertIn("return { label: 'Match confidence', ...normalizedMetricValue(candidate.match_total) };", metric)
+        self.assertIn("candidate.acoustid_score", metric)
+        self.assertIn("return { label: 'AcoustID score', ...normalizedMetricValue(candidate.acoustid_score) };", metric)
+        self.assertIn("candidate.score", metric)
+        self.assertIn("return { label: 'Candidate score', ...rawMetricValue(candidate.score) };", metric)
+        self.assertIn("return { label: 'Confidence', ...rawMetricValue(candidate.confidence) };", metric)
+        self.assertIn("score >= 0 && score <= 1", metric)
+        self.assertNotIn("Math.round(score)}%", metric)
+
     def test_item_ai_suggest_response_is_kept_for_display(self):
         fn = _source_between(IMPORT_REVIEW_SOURCE, "const handleSuggest = useCallback(", "const startApply = useCallback(")
         self.assertIn("await suggestItem(item.item_id)", fn)
         self.assertIn("setSuggestions((current) => ({ ...current, [item.id]: response }));", fn)
-        self.assertIn("selectedRecordingCandidate(response, item", fn)
+        self.assertIn("backendSelectedRecordingCandidate(response, item)", fn)
+        self.assertNotIn("candidates[0]", fn)
         self.assertIn("Review the backend recording evidence before attaching", fn)
 
     def test_candidate_selection_only_copies_visible_recording_id(self):
         row = _source_between(IMPORT_REVIEW_SOURCE, "function RecordingCandidateRow", "function RecordingIdEvidencePanel")
         self.assertIn("Use Recording ID", row)
         self.assertIn("onUseCandidate(candidate.mb_trackid || '')", row)
+        self.assertIn("disabled={!canUseRecordingId}", row)
         self.assertNotIn("attachRecording", row)
         self.assertNotIn("confirmed_conflicts", row)
 
@@ -61,8 +115,11 @@ class ImportReviewRecordingIdFrontendTests(unittest.TestCase):
         self.assertNotIn("confirmedRecordingConflicts", IMPORT_REVIEW_SOURCE)
         self.assertNotIn("recordingCandidateHasHardConflict", IMPORT_REVIEW_SOURCE)
         self.assertNotIn("candidate: selectedRecordingCandidate", IMPORT_REVIEW_SOURCE)
+        self.assertNotIn("candidate: backendSelectedCandidate", IMPORT_REVIEW_SOURCE)
+        self.assertNotIn("confirmed_conflicts", IMPORT_REVIEW_SOURCE)
         run_apply = _source_between(IMPORT_REVIEW_SOURCE, "const runApply = useCallback(", "const requestDismiss = useCallback(")
         self.assertIn("started = await attachRecording(item.item_id, representativeId);", run_apply)
+        self.assertNotIn("started = await attachRecording(item.item_id, representativeId, {", run_apply)
 
     def test_recording_rows_stay_out_of_album_match_state(self):
         self.assertIn("if (item.target_kind === 'item') return item.mb_trackid || '';", IMPORT_REVIEW_SOURCE)


### PR DESCRIPTION
## Summary

This PR keeps the isolated Import Review frontend WIP reduced to a display-only recording-ID review fix.

- Adds a dedicated recording-ID evidence panel for singleton `library_no_mb` item rows.
- Shows backend-provided local file evidence, MusicBrainz/AcoustID recording candidates, backend match evidence, conflicts, recommendations, safety labels, and linked release context.
- Lets the user copy a visible backend-provided recording ID into the existing field.
- Keeps final attach validation and eligibility with the backend.

## Review correction

The original PR had a blocking candidate-label defect: the first row in the collected candidate list was labeled `Backend selected candidate` based on array position. That was misleading when the frontend was only falling back to the first backend-ranked candidate.

This update separates the states explicitly:

- `Backend selected candidate`: only when a candidate matches an explicit backend selection field.
- `Candidate matching entered ID`: when a visible candidate matches the current form value.
- `First backend candidate`: first candidate in the backend-provided list when there is no explicit backend selection.
- `Backend alternate candidate`: all other candidates.

## Score labels

The previous `AcoustID score/confidence` label combined unlike metrics. This update uses one shared display helper:

- `Match confidence` for `confidence_score`.
- `Match confidence` for normalized `match_total` values.
- `AcoustID score` only for `acoustid_score`.
- `Candidate score` for generic raw `score` or non-normalized `match_total`.
- `Confidence` for textual confidence.

Known 0-1 confidence values are formatted as percentages. Raw generic scores are displayed as raw values instead of being guessed into percentages.

## Candidate source precedence

The temporary compatibility adapter now prefers candidates from the newest AI-suggest response. It falls back to persisted `item.evidence` only when the current response has no usable recording-candidate evidence, preserving backend ordering within the chosen source and deduplicating by recording ID for display only. This adapter should collapse after the shared backend matching-result contract exists.

## Backend authority

This remains display-only. The frontend still does not rank candidates, calculate confidence, accept conflicts, approve safety, determine attach eligibility, persist rejected candidates, submit candidate payloads, or auto-attach after choosing a candidate.

Clicking `Use Recording ID` only copies the visible backend-provided recording ID into the existing field. Final apply still calls:

```tsx
attachRecording(item.item_id, representativeId)
```

No backend API, backend matching behavior, or shared matching-result contract work is included.

## Validation

- `python -m unittest tests.test_review_queue_singleton_items`: passed, 17 tests in 0.002s.
- `python -m unittest tests.test_import_review_recording_id_frontend`: passed, 10 tests in 0.001s.
- `python -m unittest discover -s tests -p "test_*.py"`: passed, 880 tests in 224.366s.
- `python scripts/security_secret_scan.py`: passed, `secret scan passed`.
- `git diff --check origin/main...HEAD`: passed with no output.
- `cd frontend; npm.cmd ci`: passed, added 252 packages and audited 253 packages in 30s; reported 2 moderate vulnerabilities.
- `cd frontend; npm.cmd run typecheck`: passed.
- `cd frontend; npm.cmd run lint`: passed.
- `cd frontend; npm.cmd run build`: passed; Next.js 16.2.10 compiled successfully and generated 13 static routes.
- `cd frontend; npm.cmd audit --audit-level=high`: passed with exit 0; reports 2 moderate `postcss` advisories below the requested high gate.

## Test limitation

The focused tests are static structural checks. Typecheck, lint, and build provide compile-level validation. The repository currently lacks executable React component tests, so real browser/component interaction coverage remains future technical debt.