### PR TITLE
fix: show AI batch startup recovery message

### DIFF
--- a/app.py
+++ b/app.py
@@ -23819,13 +23819,18 @@ def _ai_batch_reconnect_response(batch_job_id: str):
             "reconnected": True,
         })
     if startup_disappeared:
+        startup_message = (
+            "The startup reservation ended before an active worker could be confirmed. "
+            "Refresh batch status and retry if needed."
+        )
         return jsonify({
             "ok": False,
             "reconnected": False,
             "retryable": True,
             "startup_unconfirmed": True,
             "batch_job_id": batch_job_id,
-            "message": "The startup reservation ended before an active worker could be confirmed. Refresh batch status and retry if needed.",
+            "message": startup_message,
+            "error": startup_message,
         }), 409
     return jsonify({
         "ok": False,

--- a/tests/test_ai_batch_retry_race.py
+++ b/tests/test_ai_batch_retry_race.py
@@ -1522,6 +1522,30 @@ class WrongBatchSuccessfulJobNotAcceptedTests(BehavioralTestCase):
         self.assertNotEqual(payload.get("job_id"), other_job.job_id)
 
 
+class StartupUnconfirmedResponseContractTests(BehavioralTestCase):
+    def test_startup_unconfirmed_response_has_operator_error_message_and_no_worker(self):
+        folders = {"f1": _make_folder(self.batch_job_id, "f1", status="failed")}
+        _write_batch_state(self.batch_job_id, folders)
+
+        self.assertTrue(APP._ai_batch_reserve_worker(self.batch_job_id))
+        APP._ai_batch_release_worker(self.batch_job_id, expected=None)
+
+        with mock.patch.object(APP.jobs, "start_python", wraps=APP.jobs.start_python) as start_python:
+            with APP.app.test_request_context():
+                resp, status_code = APP._ai_batch_reconnect_response(self.batch_job_id)
+        payload = json.loads(resp.get_data(as_text=True))
+
+        self.assertEqual(status_code, 409)
+        self.assertTrue(payload.get("startup_unconfirmed"))
+        self.assertTrue(payload.get("retryable"))
+        self.assertFalse(payload.get("reconnected"))
+        self.assertEqual(payload.get("error"), payload.get("message"))
+        self.assertIn("Refresh batch status", payload.get("error", ""))
+        self.assertIn("retry if needed", payload.get("error", ""))
+        self.assertNotIn("job_id", payload)
+        start_python.assert_not_called()
+
+
 class HistoricalSuccessfulJobWithNoReservationTests(BehavioralTestCase):
     """Required test 3: no active registry entry at all, only a persisted
     old successful job -- must not return successful reconnection."""


### PR DESCRIPTION
## Summary
- Adds an `error` field matching the existing `startup_unconfirmed` message so the frontend API client shows the useful operator message instead of `HTTP 409`.
- Adds a focused response-contract test for the `startup_unconfirmed` 409 shape.

## Scope
- Backend response only; no frontend API client change.
- No worker ownership, registry, handoff, retry, JobStore, or matching behavior changes.

## Validation
- `python -m unittest tests.test_ai_batch_retry_race`
- `python -m unittest discover -s tests -p "test_*.py"`
- `python -m py_compile app.py`
- `python scripts/security_secret_scan.py`
- `git diff --check origin/main...HEAD`
- `cd frontend; npm.cmd ci`
- `cd frontend; npm.cmd run typecheck`
- `cd frontend; npm.cmd run lint`
- `cd frontend; npm.cmd run build`
- `cd frontend; npm.cmd audit --audit-level=high`

Note: `npm audit --audit-level=high` exits successfully and reports 2 moderate vulnerabilities.
