### PR TITLE
fix: enforce matching decisions for import review attachment

### DIFF
--- a/app.py
+++ b/app.py
@@ -293,7 +293,7 @@ from backend.beets_config import (
     filter_job_plugins as _filter_job_plugins,
 )
 from backend.mb_alignment import summarize_mb_track_alignment
-from backend.matching_contract import AiState, build_recording_matching_decision
+from backend.matching_contract import AiState, build_recording_matching_decision, compute_decision_version
 from backend.import_guard import (
     existing_track_can_block_downloaded_replacement as _guard_existing_track_can_block_downloaded_replacement,
     filter_wanted_tracks_against_missing as _guard_filter_wanted_tracks_against_missing,
@@ -2841,6 +2841,38 @@ def _run_item_metadata_restore(item_id: int, fields: Dict[str, Any], log: List[s
     log.append(f"  [rollback] Restored metadata for item {item_id}.")
     return True
 
+
+def _run_item_recording_id_restore(item_id: int, fields: Dict[str, Any], log: List[str], cancel_event=None) -> bool:
+    """Undo executor for attach-recording: restores the previous
+    Recording/Release/Release-Group IDs and re-runs the same
+    modify+mbsync+write+move sequence attach-recording used, so the file's
+    on-disk tags and library path go back in sync with the pre-attach IDs
+    (not just the beets database row)."""
+    mb_trackid = _s((fields or {}).get("mb_trackid", "")).strip().lower()
+    mb_albumid = _s((fields or {}).get("mb_albumid", "")).strip().lower()
+    mb_releasegroupid = _s((fields or {}).get("mb_releasegroupid", "")).strip().lower()
+    cfg = _write_fast_item_modify_config(f"/tmp/beets_rollback_recording_{item_id}_{uuid.uuid4().hex}.yaml")
+    base = [BEET_BIN, "-c", cfg]
+    query = f"id:{item_id}"
+    parts = [f"mb_trackid={mb_trackid}", f"mb_albumid={mb_albumid}", f"mb_releasegroupid={mb_releasegroupid}"]
+    r = _beet_run(base + ["modify", "--yes", "--nowrite", query] + parts, log, timeout=60, env=_beet_env(), cancel=cancel_event)
+    if r.returncode not in (0, -9, 124):
+        log.append(f"  [rollback] Recording ID restore failed for item {item_id} (rc={r.returncode}).")
+        return False
+    if mb_trackid:
+        r = _beet_run(base + ["mbsync", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
+        if r.returncode not in (0, -9, 124):
+            log.append(f"  [rollback] WARN mbsync rc={r.returncode} while restoring item {item_id}.")
+    r = _beet_run(base + ["write", "--yes", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
+    if r.returncode not in (0, -9, 124):
+        log.append(f"  [rollback] WARN write rc={r.returncode} while restoring item {item_id}.")
+    r = _beet_run(base + ["move", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
+    if r.returncode not in (0, -9, 124):
+        log.append(f"  [rollback] WARN move rc={r.returncode} while restoring item {item_id}.")
+    _invalidate_lib_cache()
+    log.append(f"  [rollback] Restored recording identity for item {item_id}.")
+    return True
+
 # ── Items / Albums ────────────────────────────────────────────────────────────
 
 @app.get("/api/items")
@@ -3148,12 +3180,99 @@ def album_add_mbids(aid: int):
     return jsonify({"ok": True, "job_id": job.job_id})
 
 
+def _reconstruct_track_recording_candidates(item, iid: int):
+    """Rebuild the current-tag snapshot and enriched MB/AcoustID recording
+    candidates for a singleton item -- the same trusted candidate-generation
+    pipeline /api/items/<iid>/ai-suggest uses (AcoustID lookup + MusicBrainz
+    text search + matching-contract enrichment). attach-recording calls this
+    fresh at request time instead of trusting anything the browser sends, so
+    the set of Recording IDs it will accept always reflects current backend
+    evidence, not a snapshot the client could have held onto or edited."""
+    item_path = _item_ai_abs_path(item)
+    filename = Path(item_path or _s(item.path)).name
+    raw_year = str(item.year or "")
+    clean_year = re.match(r'^((?:19|20)\d{2})', raw_year)
+    clean_year = clean_year.group(1) if clean_year else raw_year
+
+    current = {
+        "title":       item.title       or "",
+        "artist":      item.artist      or "",
+        "album":       item.album       or "",
+        "albumartist": item.albumartist or "",
+        "year":        clean_year,
+        "genre":       _s(getattr(item, "genre", "")) or "",
+        "track":       item.track       or "",
+        "label":       _s(getattr(item, "label", "")) or "",
+        "mb_trackid":  _s(getattr(item, "mb_trackid", "")) or "",
+        "mb_albumid":  _s(getattr(item, "mb_albumid", "")) or "",
+        "mb_releasegroupid": _s(getattr(item, "mb_releasegroupid", "")) or "",
+        "filename": filename,
+        "source_path": item_path,
+        "duration_seconds": float(getattr(item, "length", 0) or 0),
+        "duration": _format_duration(float(getattr(item, "length", 0) or 0)),
+    }
+
+    stem = Path(filename).stem
+    stem_clean = re.sub(r'^\d+\s*[-_.]\s*', '', stem).strip()
+    search_title  = current["title"] or stem_clean
+    search_artist = current["artist"] or current["albumartist"] or ""
+    if " - " in search_title:
+        parts = search_title.split(" - ", 1)
+        candidate_artist, candidate_title = parts[0].strip(), parts[1].strip()
+        _junk_patterns = re.compile(
+            r'radio|station|channel|network|records|music|media|official|vevo|'
+            r'entertainment|group|label|^various',
+            re.I)
+        if (not search_artist or _junk_patterns.search(search_artist)
+                or len(search_artist) > 30):
+            search_title  = candidate_title
+            search_artist = candidate_artist
+
+    _mb_t, _mb_a = _clean_for_mb(search_title, search_artist)
+
+    acoustid_cands = _acoustid_lookup_cached(item_path) if item_path else []
+    mb_text_cands = _mb_recording_search(_mb_t, _mb_a, limit=6)
+    if not mb_text_cands and _mb_a:
+        mb_text_cands = _mb_recording_search(_mb_t, "", limit=6)
+
+    seen_ids: set = set()
+    mb_candidates: List[Dict[str, Any]] = []
+    for c in acoustid_cands + mb_text_cands:
+        mid = c.get("mb_trackid", "")
+        if mid and mid not in seen_ids:
+            seen_ids.add(mid)
+            is_acoustid = c in acoustid_cands
+            c["source"] = c.get("source") or ("acoustid" if is_acoustid else "mb")
+            c["fingerprint_attempted"] = bool(item_path)
+            c["fingerprint_matched"] = bool(is_acoustid)
+            c["fingerprint_status"] = c.get("fingerprint_status") or (
+                "matched" if is_acoustid else ("no_result" if item_path else "not_attempted")
+            )
+            c["mapped_recording_id"] = mid if is_acoustid else ""
+            c["_match_score"] = _score_track_ai_candidate(current, _mb_t, _mb_a, filename, c)
+            mb_candidates.append(c)
+    mb_candidates.sort(key=lambda c: c.get("_match_score", {}).get("total", 0), reverse=True)
+    mb_candidates = mb_candidates[:8]
+    for c in mb_candidates:
+        _enrich_track_ai_candidate(current, c, item_id=iid)
+    mb_candidates.sort(key=lambda c: c.get("_match_score", {}).get("total", 0), reverse=True)
+    for idx, c in enumerate(mb_candidates):
+        c["candidate_index"] = idx
+    return current, mb_candidates, item_path, filename
+
+
 @app.post("/api/items/<int:iid>/attach-recording")
 def item_attach_recording(iid: int):
     """Attach a MusicBrainz recording ID to a singleton item (no album_id)
     and sync/move it, mirroring album_add_mbids's direct modify+write+move
-    pattern at item level. Meant for recording IDs a user picked from
-    /api/items/<iid>/ai-suggest candidates."""
+    pattern at item level.
+
+    The backend -- never the browser -- decides whether the requested
+    Recording ID is safe to attach without review, requires explicit
+    confirmed review, or must be rejected outright: every client-supplied
+    safety/confidence/eligibility field is ignored, and the matching
+    decision is rebuilt from the current trusted MusicBrainz/AcoustID
+    candidate set for this item at request time."""
     item = lib.get_item(iid)
     if not item:
         return jsonify({"ok": False, "error": "Item not found"}), 404
@@ -3163,48 +3282,230 @@ def item_attach_recording(iid: int):
         return jsonify({"ok": False, "error": "mb_trackid is required"}), 400
     if not _MB_UUID_RE.match(mb_trackid):
         return jsonify({"ok": False, "error": "Invalid MusicBrainz UUID format"}), 400
-    confirmed_conflicts = bool(payload.get("confirmed_conflicts"))
-    candidate_context = payload.get("candidate") if isinstance(payload.get("candidate"), dict) else {}
+
+    mode = _s(payload.get("mode") or "safe").strip().lower()
+    if mode not in ("safe", "confirmed_review"):
+        return jsonify({"ok": False, "error": "Unknown attachment mode.", "code": "invalid_mode"}), 400
+
+    try:
+        current, candidates, item_path, filename = _reconstruct_track_recording_candidates(item, iid)
+    except Exception as exc:
+        return jsonify({
+            "ok": False,
+            "error": "Unable to rebuild trusted MusicBrainz/AcoustID evidence for this item.",
+            "detail": _s(exc),
+            "code": "matching_evidence_unavailable",
+        }), 503
+
+    candidate = next(
+        (c for c in candidates if _s(c.get("mb_trackid", "")).strip().lower() == mb_trackid),
+        None,
+    )
+    if candidate is None:
+        return jsonify({
+            "ok": False,
+            "error": "This Recording ID is not part of the current trusted candidate set for this item.",
+            "code": "candidate_not_in_trusted_set",
+        }), 400
+
+    decision = candidate.get("decision") or {}
+    action_eligibility = decision.get("action_eligibility") or {}
+    review_required = bool(decision.get("review_required"))
+    requires_confirmation = bool(decision.get("requires_confirmation"))
+    conflicts = list(decision.get("conflicts") or [])
+    warnings = list(decision.get("warnings") or [])
+    identity = (candidate.get("matching_contract") or {}).get("identity") or {}
+    resolved_recording_id = _s(identity.get("resolved_recording_id"))
+    computed_version = _s(candidate.get("decision_version") or "")
+    submitted_version = _s(payload.get("decision_version") or "").strip()
+    sanitized_candidate = _compact_track_ai_candidate(candidate)
+
+    def _stale_response():
+        return jsonify({
+            "ok": False,
+            "error": "The matching decision has changed since it was displayed; refresh the review item.",
+            "code": "matching_decision_stale",
+            "candidate": sanitized_candidate,
+        }), 409
+
+    confirmation_reason = ""
+    if mode == "safe":
+        if submitted_version and submitted_version != computed_version:
+            return _stale_response()
+        if not resolved_recording_id or resolved_recording_id != mb_trackid:
+            return jsonify({
+                "ok": False,
+                "error": "Requested Recording ID does not match the backend-resolved Recording ID.",
+                "code": "recording_id_mismatch",
+                "candidate": sanitized_candidate,
+            }), 409
+        if (not action_eligibility.get("attach_without_review") or review_required
+                or requires_confirmation or conflicts):
+            return jsonify({
+                "ok": False,
+                "error": "This candidate requires explicit confirmed review before it can be attached.",
+                "code": "review_confirmation_required",
+                "candidate": sanitized_candidate,
+            }), 409
+    else:
+        if payload.get("confirm") is not True:
+            return jsonify({
+                "ok": False,
+                "error": "Explicit confirmation is required for confirmed-review attachment.",
+                "code": "review_confirmation_required",
+            }), 400
+        confirmation_reason = _s(payload.get("confirmation_reason") or "").strip()
+        if not confirmation_reason:
+            return jsonify({
+                "ok": False,
+                "error": "A confirmation reason is required for confirmed-review attachment.",
+                "code": "confirmation_reason_required",
+            }), 400
+        if not submitted_version:
+            return jsonify({
+                "ok": False,
+                "error": "decision_version is required for confirmed-review attachment.",
+                "code": "matching_decision_stale",
+            }), 400
+        if submitted_version != computed_version:
+            return _stale_response()
+        # Confirmation only ever authorizes attaching this Recording ID --
+        # it never elevates the candidate's own safety/eligibility fields,
+        # and never authorizes any destructive follow-on action.
+
+    existing_mb_trackid = _s(getattr(item, "mb_trackid", "")).strip().lower()
+    existing_mb_albumid = _s(getattr(item, "mb_albumid", "")).strip().lower()
+    existing_rgid = _s(getattr(item, "mb_releasegroupid", "")).strip().lower()
+    release_id = _s(candidate.get("release_id") or candidate.get("mb_albumid") or "").strip().lower()
+    release_group_id = _s(candidate.get("release_group_id") or candidate.get("mb_releasegroupid") or "").strip().lower()
+
+    if (existing_mb_trackid == mb_trackid
+            and (not release_id or existing_mb_albumid == release_id)
+            and (not release_group_id or existing_rgid == release_group_id)):
+        return jsonify({
+            "ok": True,
+            "changed": False,
+            "reason": "already_attached",
+            "recording_id": mb_trackid,
+        })
+
+    before_snapshot = {
+        "mb_trackid": existing_mb_trackid,
+        "mb_albumid": existing_mb_albumid,
+        "mb_releasegroupid": existing_rgid,
+    }
+    after_snapshot = {
+        "mb_trackid": mb_trackid,
+        "mb_albumid": release_id,
+        "mb_releasegroupid": release_group_id,
+    }
+    tx = transactions.create(
+        operation_type="MusicBrainz Match",
+        initiating_user=_transaction_user_label(),
+        status="Running",
+        dry_run=False,
+        summary=f"Attach recording ID for item {iid} ({'confirmed review' if mode == 'confirmed_review' else 'safe attach'})",
+        reason=confirmation_reason or _s(decision.get("eligibility_reason") or ""),
+        source="Import Review attach-recording",
+        confidence={"overall": decision.get("confidence_score")},
+        changes=[{
+            "id": f"item:{iid}",
+            "operation": "MusicBrainz Match",
+            "track": current.get("title") or filename,
+            "artist": current.get("artist") or "",
+            "album": current.get("album") or "",
+            "current_metadata": before_snapshot,
+            "new_metadata": after_snapshot,
+            "metadata_diff": metadata_diff(before_snapshot, after_snapshot),
+            "confidence": {"overall": decision.get("confidence_score")},
+            "reason": confirmation_reason or _s(decision.get("eligibility_reason") or ""),
+            "source": "Import Review attach-recording",
+        }],
+        rollback_available=True,
+        rollback_reason="Restores the previous Recording/Release/Release-Group IDs and resyncs tags from MusicBrainz.",
+        metadata={
+            "item_id": iid,
+            "mode": mode,
+            "decision_version": computed_version,
+            "resolved_recording_id": resolved_recording_id,
+            "conflicts": conflicts,
+            "warnings": warnings,
+            "review_required": review_required,
+            "requires_confirmation": requires_confirmation,
+            "confirmation_reason": confirmation_reason,
+        },
+    )
+    transactions.update(tx["id"], rollback={
+        "available": True,
+        "reason": "Restores the previous Recording/Release/Release-Group IDs and resyncs tags from MusicBrainz.",
+        "operations": [{
+            "type": "recording_id_restore",
+            "item_id": iid,
+            "fields": before_snapshot,
+            "reason": "Restore recording identity captured before attach-recording.",
+        }],
+    }, counts={"items": 1, "changes": 1})
+    audit_id = tx["id"]
+
     def _do(log, cancel_event=None):
-        cfg = _write_job_beets_config(f"/tmp/beets_attach_recording_{iid}.yaml")
-        base = [BEET_BIN, "-c", cfg]
-        query = f"id:{iid}"
-        r = _beet_run(base + ["modify", "--yes", "--nowrite", f"mb_trackid={mb_trackid}", query],
-                      log, timeout=120, env=_beet_env(), cancel=cancel_event)
-        if r.returncode not in (0, -9, 124):
-            raise RuntimeError(f"beet modify failed rc={r.returncode}")
-        r = _beet_run(base + ["mbsync", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
-        if r.returncode not in (0, -9, 124):
-            log.append(f"  WARN beet mbsync rc={r.returncode}")
-        r = _beet_run(base + ["write", "--yes", query], log, timeout=120, env=_beet_env(), cancel=cancel_event)
-        if r.returncode not in (0, -9, 124):
-            log.append(f"  WARN beet write rc={r.returncode}")
-        r = _beet_run(base + ["move", query], log, timeout=120, env=_beet_env(), cancel=cancel_event)
-        if r.returncode not in (0, -9, 124):
-            log.append(f"  WARN beet move rc={r.returncode}")
-        log.append("Revalidating MusicBrainz recording details after attach.")
-        details = _fetch_mb_recording_details(mb_trackid)
-        linked_count = len(details.get("linked_releases") or []) if isinstance(details, dict) else 0
-        selected_release = (details.get("selected_release") or {}) if isinstance(details, dict) else {}
-        if confirmed_conflicts:
-            log.append("User confirmed visible candidate conflicts before attaching the Recording ID.")
-        if candidate_context:
-            log.append(f"Attached candidate safety result: {_s(candidate_context.get('safety_result') or 'unknown')}.")
-        if linked_count:
-            rel_title = _s(selected_release.get("album") or details.get("album") or "")
-            rel_year = _s(selected_release.get("year") or details.get("year") or "")
-            rgid = _s(selected_release.get("mb_releasegroupid") or details.get("mb_releasegroupid") or "")
-            log.append(f"MusicBrainz recording lookup returned {linked_count} linked release(s); selected release context: {rel_title or '(unknown release)'} {rel_year or ''} {rgid or ''}".strip())
-            if not rgid:
-                log.append("Album/release identity remains under review; no Release Group ID was attached from the recording candidate.")
-        else:
-            log.append("MusicBrainz recording lookup returned no linked releases; album identity remains under review.")
-        _invalidate_lib_cache()
-        log.append("Review eligibility will be recalculated from the refreshed library state.")
-        _trigger_plex_refresh(log)
-        log.append("Recording ID attached and item synced/moved.")
+        transactions.update(audit_id, status="Running")
+        try:
+            cfg = _write_job_beets_config(f"/tmp/beets_attach_recording_{iid}.yaml")
+            base = [BEET_BIN, "-c", cfg]
+            query = f"id:{iid}"
+            r = _beet_run(base + ["modify", "--yes", "--nowrite", f"mb_trackid={mb_trackid}", query],
+                          log, timeout=120, env=_beet_env(), cancel=cancel_event)
+            if r.returncode not in (0, -9, 124):
+                raise RuntimeError(f"beet modify failed rc={r.returncode}")
+            r = _beet_run(base + ["mbsync", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
+            if r.returncode not in (0, -9, 124):
+                log.append(f"  WARN beet mbsync rc={r.returncode}")
+            r = _beet_run(base + ["write", "--yes", query], log, timeout=120, env=_beet_env(), cancel=cancel_event)
+            if r.returncode not in (0, -9, 124):
+                log.append(f"  WARN beet write rc={r.returncode}")
+            r = _beet_run(base + ["move", query], log, timeout=120, env=_beet_env(), cancel=cancel_event)
+            if r.returncode not in (0, -9, 124):
+                log.append(f"  WARN beet move rc={r.returncode}")
+            log.append("Revalidating MusicBrainz recording details after attach.")
+            details = _fetch_mb_recording_details(mb_trackid)
+            linked_count = len(details.get("linked_releases") or []) if isinstance(details, dict) else 0
+            selected_release = (details.get("selected_release") or {}) if isinstance(details, dict) else {}
+            if mode == "confirmed_review":
+                log.append(f"User confirmed this candidate before attaching the Recording ID: {confirmation_reason}")
+            if linked_count:
+                rel_title = _s(selected_release.get("album") or details.get("album") or "")
+                rel_year = _s(selected_release.get("year") or details.get("year") or "")
+                rgid = _s(selected_release.get("mb_releasegroupid") or details.get("mb_releasegroupid") or "")
+                log.append(f"MusicBrainz recording lookup returned {linked_count} linked release(s); selected release context: {rel_title or '(unknown release)'} {rel_year or ''} {rgid or ''}".strip())
+                if not rgid:
+                    log.append("Album/release identity remains under review; no Release Group ID was attached from the recording candidate.")
+            else:
+                log.append("MusicBrainz recording lookup returned no linked releases; album identity remains under review.")
+            _invalidate_lib_cache()
+            log.append("Review eligibility will be recalculated from the refreshed library state.")
+            _trigger_plex_refresh(log)
+            log.append("Recording ID attached and item synced/moved.")
+            transactions.update(audit_id, status="Completed", logs=list(log)[-500:])
+            return {
+                "ok": True, "changed": True, "mode": mode, "recording_id": mb_trackid,
+                "decision_version": computed_version, "audit_id": audit_id,
+            }
+        except Exception as ex:
+            transactions.update(audit_id, status="Failed", logs=list(log)[-500:])
+            transactions.append_log(audit_id, f"ERROR: {ex}")
+            raise
+
     job = jobs.start_python(_do, label=f"Attach recording ID: item {iid}")
-    return jsonify({"ok": True, "job_id": job.job_id})
+    transactions.attach_job(audit_id, job.job_id)
+    return jsonify({
+        "ok": True,
+        "changed": True,
+        "mode": mode,
+        "recording_id": mb_trackid,
+        "decision_version": computed_version,
+        "audit_id": audit_id,
+        "job_id": job.job_id,
+    })
 
 
 def _format_duration(seconds: Any) -> str:
@@ -3410,7 +3711,7 @@ def _track_ai_match_status(score: float, strong: float = 0.82, fuzzy: float = 0.
 
 
 def _enrich_track_ai_candidate(current: Dict[str, Any], candidate: Dict[str, Any], details: Optional[Dict[str, Any]] = None,
-                               *, ai_state: Optional[AiState] = None) -> Dict[str, Any]:
+                               *, ai_state: Optional[AiState] = None, item_id: Optional[int] = None) -> Dict[str, Any]:
     details = details or {}
     mb_trackid = _s(candidate.get("mb_trackid") or details.get("recording_id") or "").strip().lower()
     if mb_trackid and not details:
@@ -3429,6 +3730,10 @@ def _enrich_track_ai_candidate(current: Dict[str, Any], candidate: Dict[str, Any
         similarity_fn=_track_ai_similarity,
     )
     candidate.update(matching_result.to_review_recording_candidate())
+    if item_id is not None:
+        # decision_version proves later that a submitted attach request saw
+        # this exact decision -- it never grants authority by itself.
+        candidate["decision_version"] = compute_decision_version(item_id, matching_result)
     return candidate
 
 
@@ -3495,6 +3800,7 @@ def _compact_track_ai_candidate(candidate: Optional[Dict[str, Any]]) -> Dict[str
         "same_recording_release_count": c.get("same_recording_release_count") or len(c.get("linked_releases") or []),
         "matching_local_release_found": bool(c.get("matching_local_release_found")),
         "matching_contract": c.get("matching_contract") or {},
+        "decision_version": _s(c.get("decision_version") or ""),
     }
 
 
@@ -3666,7 +3972,7 @@ def ai_suggest(iid):
     mb_candidates = mb_candidates[:8]
     for c in mb_candidates:
         try:
-            _enrich_track_ai_candidate(current, c)
+            _enrich_track_ai_candidate(current, c, item_id=iid)
         except Exception as exc:
             c["enrichment_error"] = _s(exc)
     mb_candidates.sort(key=lambda c: c.get("_match_score", {}).get("total", 0), reverse=True)
@@ -48523,7 +48829,10 @@ def api_transaction_rollback(transaction_id):
             "rollback_available": False,
         }), 409
 
-    unsupported = [op for op in operations if op.get("type") != "metadata_restore"]
+    unsupported = [
+        op for op in operations
+        if op.get("type") != "metadata_restore" and op.get("type") != "recording_id_restore"
+    ]
     if unsupported:
         return jsonify({
             "ok": False,
@@ -48546,7 +48855,11 @@ def api_transaction_rollback(transaction_id):
                     failed_count += 1
                     log.append("  [rollback] Missing item id; skipped operation.")
                     continue
-                if _run_item_metadata_restore(item_id, fields, log, cancel_event=cancel_event):
+                if op.get("type") == "recording_id_restore":
+                    restored = _run_item_recording_id_restore(item_id, fields, log, cancel_event=cancel_event)
+                else:
+                    restored = _run_item_metadata_restore(item_id, fields, log, cancel_event=cancel_event)
+                if restored:
                     ok_count += 1
                 else:
                     failed_count += 1

--- a/app.py
+++ b/app.py
@@ -2306,10 +2306,41 @@ def _redact_secret_assignment_match(match: "re.Match[str]") -> str:
     return f"{match.group(1)}{match.group(2)}{_REDACTED_SECRET}"
 
 
+# Matches userinfo credentials embedded directly in a URL, e.g.
+# "https://user:password@example.test/" -- these don't have a
+# "keyword: value" shape so _SECRET_ASSIGNMENT_RE never sees them.
+_URL_CREDENTIALS_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^\s/@]+:[^\s/@]+@")
+
+
 def _redact_security_text(value: Any) -> str:
     text = _s(value)
     text = _CONTROL_CHAR_RE.sub("?", text)
+    text = _URL_CREDENTIALS_RE.sub(lambda m: f"{m.group(1)}{_REDACTED_SECRET}@", text)
     return _SECRET_ASSIGNMENT_RE.sub(_redact_secret_assignment_match, text)
+
+
+_CONFIRMATION_REASON_MAX_LEN = 500
+
+
+def _sanitize_confirmation_reason(value: Any) -> str:
+    """Safe, bounded, single-line projection of a user-supplied
+    confirmed-review confirmation reason. This is untrusted free text that
+    flows into the transaction reason/metadata, the per-change reason, and
+    job logs -- normalize newlines/tabs to spaces, redact anything that
+    looks like a secret (Authorization/Cookie/api_key/password/URL
+    credentials), collapse whitespace, and bound the length. Callers must
+    use only this sanitized value everywhere and never store or log the
+    raw one."""
+    text = _s(value)
+    if not text:
+        return ""
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = text.replace("\n", " ").replace("\t", " ")
+    text = _redact_security_text(text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > _CONFIRMATION_REASON_MAX_LEN:
+        text = text[:_CONFIRMATION_REASON_MAX_LEN].rstrip()
+    return text
 
 
 def _is_public_endpoint() -> bool:
@@ -2842,12 +2873,61 @@ def _run_item_metadata_restore(item_id: int, fields: Dict[str, Any], log: List[s
     return True
 
 
+# ── attach-recording: per-item reservation + strict subprocess outcomes ───────
+#
+# Concurrency: keyed by Beets item id, process-local, and deliberately
+# narrow to this one feature -- two concurrent attach-recording requests for
+# the SAME item can never race each other into conflicting mutations, while
+# unrelated items proceed fully in parallel. Do NOT reuse _IMPORT_JOB_LOCK
+# (global/cross-feature) or add any global attachment lock.
+_ATTACH_RECORDING_RESERVATIONS_LOCK = threading.Lock()
+_ATTACH_RECORDING_RESERVED_ITEMS: set = set()
+
+
+def _reserve_attach_recording_item(item_id: int) -> bool:
+    with _ATTACH_RECORDING_RESERVATIONS_LOCK:
+        if item_id in _ATTACH_RECORDING_RESERVED_ITEMS:
+            return False
+        _ATTACH_RECORDING_RESERVED_ITEMS.add(item_id)
+        return True
+
+
+def _release_attach_recording_item(item_id: int) -> None:
+    with _ATTACH_RECORDING_RESERVATIONS_LOCK:
+        _ATTACH_RECORDING_RESERVED_ITEMS.discard(item_id)
+
+
+class AttachRecordingCancelled(RuntimeError):
+    """Raised when a beet subprocess stage of the attach-recording /
+    recording-ID-rollback workflow was cancelled (rc=-9), so callers can
+    tell an intentional cancellation apart from an ordinary failure."""
+
+
+def _require_attach_stage_success(result, stage: str) -> None:
+    """Strict outcome gate for one beet subprocess stage of the
+    attach-recording / recording-ID-rollback workflows. Only rc=0 counts as
+    success for this identity mutation -- a cancelled (-9) or timed-out
+    (124) stage must never be treated as success, and the caller must not
+    run any later stage after this raises."""
+    if result.returncode == 0:
+        return
+    if result.returncode == -9:
+        raise AttachRecordingCancelled(f"{stage} cancelled")
+    if result.returncode == 124:
+        raise RuntimeError(f"{stage} timed out")
+    raise RuntimeError(f"{stage} failed")
+
+
 def _run_item_recording_id_restore(item_id: int, fields: Dict[str, Any], log: List[str], cancel_event=None) -> bool:
     """Undo executor for attach-recording: restores the previous
     Recording/Release/Release-Group IDs and re-runs the same
     modify+mbsync+write+move sequence attach-recording used, so the file's
     on-disk tags and library path go back in sync with the pre-attach IDs
-    (not just the beets database row)."""
+    (not just the beets database row). Returns True only when every
+    required stage actually succeeded (rc=0) -- a cancelled, timed-out, or
+    failed stage must never be reported as a successful restore, and the
+    caller must not mark the source transaction "Rolled Back" for a False
+    return."""
     mb_trackid = _s((fields or {}).get("mb_trackid", "")).strip().lower()
     mb_albumid = _s((fields or {}).get("mb_albumid", "")).strip().lower()
     mb_releasegroupid = _s((fields or {}).get("mb_releasegroupid", "")).strip().lower()
@@ -2855,20 +2935,22 @@ def _run_item_recording_id_restore(item_id: int, fields: Dict[str, Any], log: Li
     base = [BEET_BIN, "-c", cfg]
     query = f"id:{item_id}"
     parts = [f"mb_trackid={mb_trackid}", f"mb_albumid={mb_albumid}", f"mb_releasegroupid={mb_releasegroupid}"]
-    r = _beet_run(base + ["modify", "--yes", "--nowrite", query] + parts, log, timeout=60, env=_beet_env(), cancel=cancel_event)
-    if r.returncode not in (0, -9, 124):
-        log.append(f"  [rollback] Recording ID restore failed for item {item_id} (rc={r.returncode}).")
+    try:
+        r = _beet_run(base + ["modify", "--yes", "--nowrite", query] + parts, log, timeout=60, env=_beet_env(), cancel=cancel_event)
+        _require_attach_stage_success(r, "rollback modify")
+        if mb_trackid:
+            r = _beet_run(base + ["mbsync", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
+            _require_attach_stage_success(r, "rollback mbsync")
+        r = _beet_run(base + ["write", "--yes", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
+        _require_attach_stage_success(r, "rollback write")
+        r = _beet_run(base + ["move", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
+        _require_attach_stage_success(r, "rollback move")
+    except AttachRecordingCancelled:
+        log.append(f"  [rollback] Recording ID restore cancelled for item {item_id}.")
         return False
-    if mb_trackid:
-        r = _beet_run(base + ["mbsync", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
-        if r.returncode not in (0, -9, 124):
-            log.append(f"  [rollback] WARN mbsync rc={r.returncode} while restoring item {item_id}.")
-    r = _beet_run(base + ["write", "--yes", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
-    if r.returncode not in (0, -9, 124):
-        log.append(f"  [rollback] WARN write rc={r.returncode} while restoring item {item_id}.")
-    r = _beet_run(base + ["move", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
-    if r.returncode not in (0, -9, 124):
-        log.append(f"  [rollback] WARN move rc={r.returncode} while restoring item {item_id}.")
+    except Exception as ex:
+        log.append(f"  [rollback] Recording ID restore failed for item {item_id}: {_redact_security_text(str(ex))[:200]}")
+        return False
     _invalidate_lib_cache()
     log.append(f"  [rollback] Restored recording identity for item {item_id}.")
     return True
@@ -3272,240 +3354,348 @@ def item_attach_recording(iid: int):
     confirmed review, or must be rejected outright: every client-supplied
     safety/confidence/eligibility field is ignored, and the matching
     decision is rebuilt from the current trusted MusicBrainz/AcoustID
-    candidate set for this item at request time."""
-    item = lib.get_item(iid)
-    if not item:
-        return jsonify({"ok": False, "error": "Item not found"}), 404
+    candidate set for this item at request time.
+
+    Concurrency: a per-item reservation (_reserve_attach_recording_item) is
+    held from just before the final idempotency check through the async
+    mutation job, so two concurrent requests for the SAME item can never
+    race -- the second gets 409 attachment_in_progress immediately. The
+    item is re-read after the reservation is acquired and every check below
+    (candidates, decision, existing identity) runs against that fresh read,
+    never a snapshot taken before the reservation. After the beet stages
+    all report success, the item is re-read again and the actual persisted
+    mb_trackid/mb_albumid/mb_releasegroupid are what get audited as
+    "Completed" -- never the pre-mutation candidate-expected identity."""
     payload = request.get_json(silent=True) or {}
     mb_trackid = _s(payload.get("mb_trackid") or "").strip().lower()
     if not mb_trackid:
-        return jsonify({"ok": False, "error": "mb_trackid is required"}), 400
+        return jsonify({"ok": False, "error": "mb_trackid is required.", "code": "recording_id_required"}), 400
     if not _MB_UUID_RE.match(mb_trackid):
-        return jsonify({"ok": False, "error": "Invalid MusicBrainz UUID format"}), 400
+        return jsonify({"ok": False, "error": "Invalid MusicBrainz Recording ID format.", "code": "invalid_recording_id"}), 400
 
     mode = _s(payload.get("mode") or "safe").strip().lower()
     if mode not in ("safe", "confirmed_review"):
         return jsonify({"ok": False, "error": "Unknown attachment mode.", "code": "invalid_mode"}), 400
 
-    try:
-        current, candidates, item_path, filename = _reconstruct_track_recording_candidates(item, iid)
-    except Exception as exc:
+    if lib.get_item(iid) is None:
+        return jsonify({"ok": False, "error": "Item not found.", "code": "review_item_not_found"}), 404
+
+    if not _reserve_attach_recording_item(iid):
         return jsonify({
             "ok": False,
-            "error": "Unable to rebuild trusted MusicBrainz/AcoustID evidence for this item.",
-            "detail": _s(exc),
-            "code": "matching_evidence_unavailable",
-        }), 503
-
-    candidate = next(
-        (c for c in candidates if _s(c.get("mb_trackid", "")).strip().lower() == mb_trackid),
-        None,
-    )
-    if candidate is None:
-        return jsonify({
-            "ok": False,
-            "error": "This Recording ID is not part of the current trusted candidate set for this item.",
-            "code": "candidate_not_in_trusted_set",
-        }), 400
-
-    decision = candidate.get("decision") or {}
-    action_eligibility = decision.get("action_eligibility") or {}
-    review_required = bool(decision.get("review_required"))
-    requires_confirmation = bool(decision.get("requires_confirmation"))
-    conflicts = list(decision.get("conflicts") or [])
-    warnings = list(decision.get("warnings") or [])
-    identity = (candidate.get("matching_contract") or {}).get("identity") or {}
-    resolved_recording_id = _s(identity.get("resolved_recording_id"))
-    computed_version = _s(candidate.get("decision_version") or "")
-    submitted_version = _s(payload.get("decision_version") or "").strip()
-    sanitized_candidate = _compact_track_ai_candidate(candidate)
-
-    def _stale_response():
-        return jsonify({
-            "ok": False,
-            "error": "The matching decision has changed since it was displayed; refresh the review item.",
-            "code": "matching_decision_stale",
-            "candidate": sanitized_candidate,
+            "error": "A Recording ID attachment is already running for this item.",
+            "code": "attachment_in_progress",
         }), 409
 
-    confirmation_reason = ""
-    if mode == "safe":
-        if submitted_version and submitted_version != computed_version:
-            return _stale_response()
-        if not resolved_recording_id or resolved_recording_id != mb_trackid:
+    job_started = False
+    try:
+        # Re-read after acquiring the reservation -- every check from here
+        # on runs against this fresh item, not the pre-reservation snapshot,
+        # so a concurrent mutation between the two reads can't be missed.
+        item = lib.get_item(iid)
+        if item is None:
+            return jsonify({"ok": False, "error": "Item not found.", "code": "review_item_not_found"}), 404
+
+        try:
+            current, candidates, item_path, filename = _reconstruct_track_recording_candidates(item, iid)
+        except Exception as exc:
+            app.logger.error(
+                "attach-recording candidate reconstruction failed for item %s: %s: %s",
+                iid, type(exc).__name__, _redact_security_text(str(exc))[:300],
+            )
             return jsonify({
                 "ok": False,
-                "error": "Requested Recording ID does not match the backend-resolved Recording ID.",
-                "code": "recording_id_mismatch",
-                "candidate": sanitized_candidate,
-            }), 409
-        if (not action_eligibility.get("attach_without_review") or review_required
-                or requires_confirmation or conflicts):
+                "error": "Unable to rebuild trusted MusicBrainz/AcoustID evidence for this item.",
+                "code": "matching_evidence_unavailable",
+            }), 503
+
+        candidate = next(
+            (c for c in candidates if _s(c.get("mb_trackid", "")).strip().lower() == mb_trackid),
+            None,
+        )
+        if candidate is None:
             return jsonify({
                 "ok": False,
-                "error": "This candidate requires explicit confirmed review before it can be attached.",
-                "code": "review_confirmation_required",
-                "candidate": sanitized_candidate,
-            }), 409
-    else:
-        if payload.get("confirm") is not True:
-            return jsonify({
-                "ok": False,
-                "error": "Explicit confirmation is required for confirmed-review attachment.",
-                "code": "review_confirmation_required",
+                "error": "This Recording ID is not part of the current trusted candidate set for this item.",
+                "code": "candidate_not_in_trusted_set",
             }), 400
-        confirmation_reason = _s(payload.get("confirmation_reason") or "").strip()
-        if not confirmation_reason:
+
+        decision = candidate.get("decision") or {}
+        action_eligibility = decision.get("action_eligibility") or {}
+        review_required = bool(decision.get("review_required"))
+        requires_confirmation = bool(decision.get("requires_confirmation"))
+        conflicts = list(decision.get("conflicts") or [])
+        warnings = list(decision.get("warnings") or [])
+        identity = (candidate.get("matching_contract") or {}).get("identity") or {}
+        resolved_recording_id = _s(identity.get("resolved_recording_id"))
+        computed_version = _s(candidate.get("decision_version") or "")
+        submitted_version = _s(payload.get("decision_version") or "").strip()
+        sanitized_candidate = _compact_track_ai_candidate(candidate)
+
+        def _stale_response():
             return jsonify({
                 "ok": False,
-                "error": "A confirmation reason is required for confirmed-review attachment.",
-                "code": "confirmation_reason_required",
-            }), 400
-        if not submitted_version:
-            return jsonify({
-                "ok": False,
-                "error": "decision_version is required for confirmed-review attachment.",
+                "error": "The matching decision has changed since it was displayed; refresh the review item.",
                 "code": "matching_decision_stale",
-            }), 400
-        if submitted_version != computed_version:
-            return _stale_response()
-        # Confirmation only ever authorizes attaching this Recording ID --
-        # it never elevates the candidate's own safety/eligibility fields,
-        # and never authorizes any destructive follow-on action.
+                "candidate": sanitized_candidate,
+            }), 409
 
-    existing_mb_trackid = _s(getattr(item, "mb_trackid", "")).strip().lower()
-    existing_mb_albumid = _s(getattr(item, "mb_albumid", "")).strip().lower()
-    existing_rgid = _s(getattr(item, "mb_releasegroupid", "")).strip().lower()
-    release_id = _s(candidate.get("release_id") or candidate.get("mb_albumid") or "").strip().lower()
-    release_group_id = _s(candidate.get("release_group_id") or candidate.get("mb_releasegroupid") or "").strip().lower()
+        confirmation_reason = ""
+        if mode == "safe":
+            if submitted_version and submitted_version != computed_version:
+                return _stale_response()
+            if not resolved_recording_id or resolved_recording_id != mb_trackid:
+                return jsonify({
+                    "ok": False,
+                    "error": "Requested Recording ID does not match the backend-resolved Recording ID.",
+                    "code": "recording_id_mismatch",
+                    "candidate": sanitized_candidate,
+                }), 409
+            if (not action_eligibility.get("attach_without_review") or review_required
+                    or requires_confirmation or conflicts):
+                return jsonify({
+                    "ok": False,
+                    "error": "This candidate requires explicit confirmed review before it can be attached.",
+                    "code": "review_confirmation_required",
+                    "candidate": sanitized_candidate,
+                }), 409
+        else:
+            if payload.get("confirm") is not True:
+                return jsonify({
+                    "ok": False,
+                    "error": "Explicit confirmation is required for confirmed-review attachment.",
+                    "code": "review_confirmation_required",
+                }), 400
+            confirmation_reason = _sanitize_confirmation_reason(payload.get("confirmation_reason"))
+            if not confirmation_reason:
+                return jsonify({
+                    "ok": False,
+                    "error": "A confirmation reason is required for confirmed-review attachment.",
+                    "code": "confirmation_reason_required",
+                }), 400
+            if not submitted_version:
+                return jsonify({
+                    "ok": False,
+                    "error": "decision_version is required for confirmed-review attachment.",
+                    "code": "matching_decision_stale",
+                }), 400
+            if submitted_version != computed_version:
+                return _stale_response()
+            # Confirmation only ever authorizes attaching this Recording ID --
+            # it never elevates the candidate's own safety/eligibility fields,
+            # and never authorizes any destructive follow-on action.
 
-    if (existing_mb_trackid == mb_trackid
-            and (not release_id or existing_mb_albumid == release_id)
-            and (not release_group_id or existing_rgid == release_group_id)):
-        return jsonify({
-            "ok": True,
-            "changed": False,
-            "reason": "already_attached",
-            "recording_id": mb_trackid,
-        })
+        existing_mb_trackid = _s(getattr(item, "mb_trackid", "")).strip().lower()
+        existing_mb_albumid = _s(getattr(item, "mb_albumid", "")).strip().lower()
+        existing_rgid = _s(getattr(item, "mb_releasegroupid", "")).strip().lower()
+        release_id = _s(candidate.get("release_id") or candidate.get("mb_albumid") or "").strip().lower()
+        release_group_id = _s(candidate.get("release_group_id") or candidate.get("mb_releasegroupid") or "").strip().lower()
 
-    before_snapshot = {
-        "mb_trackid": existing_mb_trackid,
-        "mb_albumid": existing_mb_albumid,
-        "mb_releasegroupid": existing_rgid,
-    }
-    after_snapshot = {
-        "mb_trackid": mb_trackid,
-        "mb_albumid": release_id,
-        "mb_releasegroupid": release_group_id,
-    }
-    tx = transactions.create(
-        operation_type="MusicBrainz Match",
-        initiating_user=_transaction_user_label(),
-        status="Running",
-        dry_run=False,
-        summary=f"Attach recording ID for item {iid} ({'confirmed review' if mode == 'confirmed_review' else 'safe attach'})",
-        reason=confirmation_reason or _s(decision.get("eligibility_reason") or ""),
-        source="Import Review attach-recording",
-        confidence={"overall": decision.get("confidence_score")},
-        changes=[{
+        if (existing_mb_trackid == mb_trackid
+                and (not release_id or existing_mb_albumid == release_id)
+                and (not release_group_id or existing_rgid == release_group_id)):
+            return jsonify({
+                "ok": True,
+                "changed": False,
+                "reason": "already_attached",
+                "recording_id": mb_trackid,
+            })
+
+        before_snapshot = {
+            "mb_trackid": existing_mb_trackid,
+            "mb_albumid": existing_mb_albumid,
+            "mb_releasegroupid": existing_rgid,
+        }
+        # Candidate-expected identity -- what we intend to persist. Kept
+        # distinct from the actually-persisted identity verified after the
+        # mutation (see _do below); never presented as persisted state
+        # until that verification succeeds.
+        candidate_identity = {
+            "mb_trackid": mb_trackid,
+            "mb_albumid": release_id,
+            "mb_releasegroupid": release_group_id,
+        }
+        change_entry = {
             "id": f"item:{iid}",
             "operation": "MusicBrainz Match",
             "track": current.get("title") or filename,
             "artist": current.get("artist") or "",
             "album": current.get("album") or "",
             "current_metadata": before_snapshot,
-            "new_metadata": after_snapshot,
-            "metadata_diff": metadata_diff(before_snapshot, after_snapshot),
+            "new_metadata": candidate_identity,
+            "metadata_diff": metadata_diff(before_snapshot, candidate_identity),
             "confidence": {"overall": decision.get("confidence_score")},
             "reason": confirmation_reason or _s(decision.get("eligibility_reason") or ""),
             "source": "Import Review attach-recording",
-        }],
-        rollback_available=True,
-        rollback_reason="Restores the previous Recording/Release/Release-Group IDs and resyncs tags from MusicBrainz.",
-        metadata={
-            "item_id": iid,
-            "mode": mode,
-            "decision_version": computed_version,
-            "resolved_recording_id": resolved_recording_id,
-            "conflicts": conflicts,
-            "warnings": warnings,
-            "review_required": review_required,
-            "requires_confirmation": requires_confirmation,
-            "confirmation_reason": confirmation_reason,
-        },
-    )
-    transactions.update(tx["id"], rollback={
-        "available": True,
-        "reason": "Restores the previous Recording/Release/Release-Group IDs and resyncs tags from MusicBrainz.",
-        "operations": [{
-            "type": "recording_id_restore",
-            "item_id": iid,
-            "fields": before_snapshot,
-            "reason": "Restore recording identity captured before attach-recording.",
-        }],
-    }, counts={"items": 1, "changes": 1})
-    audit_id = tx["id"]
+            "metadata": {"candidate_identity": dict(candidate_identity)},
+        }
+        tx = transactions.create(
+            operation_type="MusicBrainz Match",
+            initiating_user=_transaction_user_label(),
+            status="Running",
+            dry_run=False,
+            summary=f"Attach recording ID for item {iid} ({'confirmed review' if mode == 'confirmed_review' else 'safe attach'})",
+            reason=confirmation_reason or _s(decision.get("eligibility_reason") or ""),
+            source="Import Review attach-recording",
+            confidence={"overall": decision.get("confidence_score")},
+            changes=[change_entry],
+            rollback_available=True,
+            rollback_reason="Restores the previous Recording/Release/Release-Group IDs and resyncs tags from MusicBrainz.",
+            metadata={
+                "item_id": iid,
+                "mode": mode,
+                "decision_version": computed_version,
+                "resolved_recording_id": resolved_recording_id,
+                "conflicts": conflicts,
+                "warnings": warnings,
+                "review_required": review_required,
+                "requires_confirmation": requires_confirmation,
+                "confirmation_reason": confirmation_reason,
+                "candidate_identity": dict(candidate_identity),
+            },
+        )
+        transactions.update(tx["id"], rollback={
+            "available": True,
+            "reason": "Restores the previous Recording/Release/Release-Group IDs and resyncs tags from MusicBrainz.",
+            "operations": [{
+                "type": "recording_id_restore",
+                "item_id": iid,
+                "fields": before_snapshot,
+                "reason": "Restore recording identity captured before attach-recording.",
+            }],
+        }, counts={"items": 1, "changes": 1})
+        audit_id = tx["id"]
 
-    def _do(log, cancel_event=None):
-        transactions.update(audit_id, status="Running")
+        def _do(log, cancel_event=None):
+            transactions.update(audit_id, status="Running")
+            try:
+                cfg = _write_job_beets_config(f"/tmp/beets_attach_recording_{iid}.yaml")
+                base = [BEET_BIN, "-c", cfg]
+                query = f"id:{iid}"
+                r = _beet_run(base + ["modify", "--yes", "--nowrite", f"mb_trackid={mb_trackid}", query],
+                              log, timeout=120, env=_beet_env(), cancel=cancel_event)
+                _require_attach_stage_success(r, "modify")
+                r = _beet_run(base + ["mbsync", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
+                _require_attach_stage_success(r, "mbsync")
+                r = _beet_run(base + ["write", "--yes", query], log, timeout=120, env=_beet_env(), cancel=cancel_event)
+                _require_attach_stage_success(r, "write")
+                r = _beet_run(base + ["move", query], log, timeout=120, env=_beet_env(), cancel=cancel_event)
+                _require_attach_stage_success(r, "move")
+
+                # Truthfulness: never claim the candidate-expected identity
+                # was persisted without checking. Invalidate the cache and
+                # re-read the item so the audit reflects reality.
+                _invalidate_lib_cache()
+                persisted_item = lib.get_item(iid)
+                actual_mb_trackid = _s(getattr(persisted_item, "mb_trackid", "")).strip().lower() if persisted_item else ""
+                actual_mb_albumid = _s(getattr(persisted_item, "mb_albumid", "")).strip().lower() if persisted_item else ""
+                actual_rgid = _s(getattr(persisted_item, "mb_releasegroupid", "")).strip().lower() if persisted_item else ""
+
+                if actual_mb_trackid != mb_trackid:
+                    transactions.update(audit_id, status="Failed", logs=list(log)[-500:])
+                    transactions.append_log(
+                        audit_id,
+                        "ERROR: Requested Recording ID was not verified on the re-read item after mutation.",
+                    )
+                    raise RuntimeError("Recording ID did not verify after mutation")
+
+                persisted_identity = {
+                    "mb_trackid": actual_mb_trackid,
+                    "mb_albumid": actual_mb_albumid,
+                    "mb_releasegroupid": actual_rgid,
+                }
+                # Recording ID matched; a differing but legitimate release
+                # context is allowed -- record it truthfully rather than
+                # silently claiming the candidate's release context landed.
+                release_mismatch = bool(release_id) and actual_mb_albumid != release_id
+                rgid_mismatch = bool(release_group_id) and actual_rgid != release_group_id
+                if release_mismatch or rgid_mismatch:
+                    log.append(
+                        "Persisted release/release-group identity differs from the evaluated "
+                        "candidate; actual values recorded for audit, candidate expectation kept "
+                        "separate. Review recommended."
+                    )
+
+                log.append("Revalidating MusicBrainz recording details after attach.")
+                details = _fetch_mb_recording_details(mb_trackid)
+                linked_count = len(details.get("linked_releases") or []) if isinstance(details, dict) else 0
+                selected_release = (details.get("selected_release") or {}) if isinstance(details, dict) else {}
+                if mode == "confirmed_review":
+                    log.append(f"User confirmed this candidate before attaching the Recording ID: {confirmation_reason}")
+                if linked_count:
+                    rel_title = _s(selected_release.get("album") or details.get("album") or "")
+                    rel_year = _s(selected_release.get("year") or details.get("year") or "")
+                    rgid = _s(selected_release.get("mb_releasegroupid") or details.get("mb_releasegroupid") or "")
+                    log.append(f"MusicBrainz recording lookup returned {linked_count} linked release(s); selected release context: {rel_title or '(unknown release)'} {rel_year or ''} {rgid or ''}".strip())
+                    if not rgid:
+                        log.append("Album/release identity remains under review; no Release Group ID was attached from the recording candidate.")
+                else:
+                    log.append("MusicBrainz recording lookup returned no linked releases; album identity remains under review.")
+                log.append("Review eligibility will be recalculated from the refreshed library state.")
+                _trigger_plex_refresh(log)
+                log.append("Recording ID attached and item synced/moved.")
+
+                updated_change = dict(change_entry)
+                updated_change["current_metadata"] = before_snapshot
+                updated_change["new_metadata"] = persisted_identity
+                updated_change["metadata_diff"] = metadata_diff(before_snapshot, persisted_identity)
+                updated_change["metadata"] = {
+                    "candidate_identity": dict(candidate_identity),
+                    "persisted_identity": persisted_identity,
+                }
+                transactions.update(
+                    audit_id,
+                    status="Completed",
+                    logs=list(log)[-500:],
+                    changes=[updated_change],
+                    metadata={
+                        "candidate_identity": dict(candidate_identity),
+                        "persisted_identity": persisted_identity,
+                        "release_identity_mismatch": release_mismatch,
+                        "release_group_identity_mismatch": rgid_mismatch,
+                    },
+                )
+                return {
+                    "ok": True, "changed": True, "mode": mode, "recording_id": mb_trackid,
+                    "decision_version": computed_version, "audit_id": audit_id,
+                    "persisted_identity": persisted_identity,
+                }
+            except AttachRecordingCancelled as ex:
+                transactions.update(audit_id, status="Cancelled", logs=list(log)[-500:])
+                transactions.append_log(audit_id, f"Cancelled: {_redact_security_text(str(ex))[:200]}")
+                raise
+            except Exception as ex:
+                transactions.update(audit_id, status="Failed", logs=list(log)[-500:])
+                transactions.append_log(audit_id, f"ERROR: {_redact_security_text(str(ex))[:300]}")
+                raise
+            finally:
+                _release_attach_recording_item(iid)
+
         try:
-            cfg = _write_job_beets_config(f"/tmp/beets_attach_recording_{iid}.yaml")
-            base = [BEET_BIN, "-c", cfg]
-            query = f"id:{iid}"
-            r = _beet_run(base + ["modify", "--yes", "--nowrite", f"mb_trackid={mb_trackid}", query],
-                          log, timeout=120, env=_beet_env(), cancel=cancel_event)
-            if r.returncode not in (0, -9, 124):
-                raise RuntimeError(f"beet modify failed rc={r.returncode}")
-            r = _beet_run(base + ["mbsync", query], log, timeout=60, env=_beet_env(), cancel=cancel_event)
-            if r.returncode not in (0, -9, 124):
-                log.append(f"  WARN beet mbsync rc={r.returncode}")
-            r = _beet_run(base + ["write", "--yes", query], log, timeout=120, env=_beet_env(), cancel=cancel_event)
-            if r.returncode not in (0, -9, 124):
-                log.append(f"  WARN beet write rc={r.returncode}")
-            r = _beet_run(base + ["move", query], log, timeout=120, env=_beet_env(), cancel=cancel_event)
-            if r.returncode not in (0, -9, 124):
-                log.append(f"  WARN beet move rc={r.returncode}")
-            log.append("Revalidating MusicBrainz recording details after attach.")
-            details = _fetch_mb_recording_details(mb_trackid)
-            linked_count = len(details.get("linked_releases") or []) if isinstance(details, dict) else 0
-            selected_release = (details.get("selected_release") or {}) if isinstance(details, dict) else {}
-            if mode == "confirmed_review":
-                log.append(f"User confirmed this candidate before attaching the Recording ID: {confirmation_reason}")
-            if linked_count:
-                rel_title = _s(selected_release.get("album") or details.get("album") or "")
-                rel_year = _s(selected_release.get("year") or details.get("year") or "")
-                rgid = _s(selected_release.get("mb_releasegroupid") or details.get("mb_releasegroupid") or "")
-                log.append(f"MusicBrainz recording lookup returned {linked_count} linked release(s); selected release context: {rel_title or '(unknown release)'} {rel_year or ''} {rgid or ''}".strip())
-                if not rgid:
-                    log.append("Album/release identity remains under review; no Release Group ID was attached from the recording candidate.")
-            else:
-                log.append("MusicBrainz recording lookup returned no linked releases; album identity remains under review.")
-            _invalidate_lib_cache()
-            log.append("Review eligibility will be recalculated from the refreshed library state.")
-            _trigger_plex_refresh(log)
-            log.append("Recording ID attached and item synced/moved.")
-            transactions.update(audit_id, status="Completed", logs=list(log)[-500:])
-            return {
-                "ok": True, "changed": True, "mode": mode, "recording_id": mb_trackid,
-                "decision_version": computed_version, "audit_id": audit_id,
-            }
-        except Exception as ex:
-            transactions.update(audit_id, status="Failed", logs=list(log)[-500:])
-            transactions.append_log(audit_id, f"ERROR: {ex}")
-            raise
-
-    job = jobs.start_python(_do, label=f"Attach recording ID: item {iid}")
-    transactions.attach_job(audit_id, job.job_id)
-    return jsonify({
-        "ok": True,
-        "changed": True,
-        "mode": mode,
-        "recording_id": mb_trackid,
-        "decision_version": computed_version,
-        "audit_id": audit_id,
-        "job_id": job.job_id,
-    })
+            job = jobs.start_python(_do, label=f"Attach recording ID: item {iid}")
+        except Exception:
+            transactions.update(audit_id, status="Failed", logs=["ERROR: failed to start attachment job"])
+            return jsonify({
+                "ok": False,
+                "error": "Unable to start the attachment job.",
+                "code": "attachment_job_start_failed",
+            }), 500
+        # Ownership of the reservation transfers to the job from this point
+        # on (released in its own finally above) -- do not release here.
+        job_started = True
+        transactions.attach_job(audit_id, job.job_id)
+        return jsonify({
+            "ok": True,
+            "changed": True,
+            "mode": mode,
+            "recording_id": mb_trackid,
+            "decision_version": computed_version,
+            "audit_id": audit_id,
+            "job_id": job.job_id,
+        })
+    finally:
+        if not job_started:
+            _release_attach_recording_item(iid)
 
 
 def _format_duration(seconds: Any) -> str:

--- a/app.py
+++ b/app.py
@@ -2309,7 +2309,13 @@ def _redact_secret_assignment_match(match: "re.Match[str]") -> str:
 # Matches userinfo credentials embedded directly in a URL, e.g.
 # "https://user:password@example.test/" -- these don't have a
 # "keyword: value" shape so _SECRET_ASSIGNMENT_RE never sees them.
-_URL_CREDENTIALS_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^\s/@]+:[^\s/@]+@")
+#
+# The username segment excludes ":" (unlike the password segment) so the
+# two adjacent unbounded runs can never both stretch across the same ":" --
+# without that, CodeQL correctly flags this as a polynomial-time regex on
+# attacker-controlled input (confirmation_reason flows straight into this).
+# Both segments are also length-capped as defense in depth.
+_URL_CREDENTIALS_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^\s/@:]{1,256}:[^\s/@]{1,256}@")
 
 
 def _redact_security_text(value: Any) -> str:

--- a/app.py
+++ b/app.py
@@ -2311,11 +2311,13 @@ def _redact_secret_assignment_match(match: "re.Match[str]") -> str:
 # "keyword: value" shape so _SECRET_ASSIGNMENT_RE never sees them.
 #
 # The username segment excludes ":" (unlike the password segment) so the
-# two adjacent unbounded runs can never both stretch across the same ":" --
-# without that, CodeQL correctly flags this as a polynomial-time regex on
-# attacker-controlled input (confirmation_reason flows straight into this).
-# Both segments are also length-capped as defense in depth.
-_URL_CREDENTIALS_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^\s/@:]{1,256}:[^\s/@]{1,256}@")
+# two adjacent runs can never both stretch across the same ":" -- that
+# exclusion, not a length cap, is what makes the ":" delimiter unambiguous
+# and rules out the polynomial-time backtracking CodeQL flagged originally.
+# A length cap on top of that would only make matching fail (and therefore
+# fail to redact) for any credential longer than the cap, so neither
+# segment is length-limited here.
+_URL_CREDENTIALS_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^\s/@:]+:[^\s/@]+@")
 
 
 def _redact_security_text(value: Any) -> str:

--- a/backend/matching_contract.py
+++ b/backend/matching_contract.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+import hashlib
+import json
 import math
 import re
 import unicodedata
@@ -1038,3 +1040,33 @@ def build_recording_matching_decision(
             "mb_albumids": list(candidate.get("mb_albumids") or ([] if not release_id else [release_id])),
         },
     )
+
+
+def compute_decision_version(item_id: Any, decision: "MatchingDecision") -> str:
+    """Server-generated fingerprint of one candidate's matching decision.
+
+    Derived only from stable, already-sanitized decision fields (never
+    secrets or raw provider payloads) so a caller can detect that the
+    displayed decision is stale by the time an attach request arrives --
+    it proves the decision hasn't changed, it never grants authority on
+    its own.
+    """
+    identity = decision.identity
+    d = decision.decision
+    payload = {
+        "schema": 1,
+        "contract_version": 2,
+        "item_id": _s(item_id),
+        "resolved_recording_id": _s(identity.get("resolved_recording_id")),
+        "evaluated_candidate_recording_id": _s(identity.get("evaluated_candidate_recording_id")),
+        "release_id": _s(identity.get("release_id")),
+        "release_group_id": _s(identity.get("release_group_id")),
+        "conflicts": sorted(d.get("conflicts") or []),
+        "warnings": sorted(d.get("warnings") or []),
+        "review_required": bool(d.get("review_required")),
+        "requires_confirmation": bool(d.get("requires_confirmation")),
+        "safety_key": _s(d.get("safety_key")),
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()[:24]
+    return f"drv1:{digest}"

--- a/backend/matching_contract.py
+++ b/backend/matching_contract.py
@@ -1046,15 +1046,32 @@ def compute_decision_version(item_id: Any, decision: "MatchingDecision") -> str:
     """Server-generated fingerprint of one candidate's matching decision.
 
     Derived only from stable, already-sanitized decision fields (never
-    secrets or raw provider payloads) so a caller can detect that the
+    secrets, raw provider payloads, unstable timestamps, candidate display
+    order, or transient UI-only state) so a caller can detect that the
     displayed decision is stale by the time an attach request arrives --
     it proves the decision hasn't changed, it never grants authority on
     its own.
+
+    Schema 2 (`drv2:`) widens the fingerprinted surface to (at least) the
+    full set of trusted evidence actually shown to the user and relied on
+    by the confirmed-review attach path: identity fields, conflicts/
+    warnings, review/confirmation flags, safety key, confidence score,
+    action eligibility, eligibility reason, candidate source, and
+    deterministic AcoustID fingerprint provenance. Schema 1 (`drv1:`)
+    omitted enough of that evidence that a stale decision could still pass
+    the version check. A `drv1:` value submitted against this schema will
+    simply never equal a freshly computed `drv2:` value, so it is
+    correctly rejected as stale by the caller's own version comparison --
+    no separate schema-detection code is required.
     """
     identity = decision.identity
     d = decision.decision
+    evidence = decision.evidence if isinstance(decision.evidence, dict) else {}
+    acoustid = evidence.get("acoustid") or {}
+    candidate = decision.candidate if isinstance(decision.candidate, dict) else {}
+    action_eligibility = d.get("action_eligibility") or {}
     payload = {
-        "schema": 1,
+        "schema": 2,
         "contract_version": 2,
         "item_id": _s(item_id),
         "resolved_recording_id": _s(identity.get("resolved_recording_id")),
@@ -1066,7 +1083,16 @@ def compute_decision_version(item_id: Any, decision: "MatchingDecision") -> str:
         "review_required": bool(d.get("review_required")),
         "requires_confirmation": bool(d.get("requires_confirmation")),
         "safety_key": _s(d.get("safety_key")),
+        "confidence_score": _finite_number(d.get("confidence_score")),
+        "attach_without_review": bool(action_eligibility.get("attach_without_review")),
+        "destructive_use": bool(action_eligibility.get("destructive_use")),
+        "eligibility_reason": _s(d.get("eligibility_reason")),
+        "candidate_source": _s(candidate.get("source")),
+        "fingerprint_attempted": bool(acoustid.get("fingerprint_attempted")),
+        "fingerprint_matched": bool(acoustid.get("fingerprint_matched")),
+        "fingerprint_status": _s(acoustid.get("status")),
+        "mapped_recording_id": _s(acoustid.get("mapped_recording_id")),
     }
     blob = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     digest = hashlib.sha256(blob.encode("utf-8")).hexdigest()[:24]
-    return f"drv1:{digest}"
+    return f"drv2:{digest}"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -35,6 +35,7 @@ import type {
   ImportWithIdPayload,
   JobResponse,
   JobStartResponse,
+  AttachRecordingResponse,
   LibraryImportAllLastResponse,
   DownloadAlbumPayload,
   LidarrArtistAlbumsResponse,
@@ -74,7 +75,6 @@ import type {
   ReimportDiskPayload,
   ReviewQueueParams,
   ReviewQueueResponse,
-  ReviewRecordingCandidate,
   RgidGroupDetailResponse,
   FolderPlaceholderReview,
   FolderPlaceholderMergePreview,
@@ -105,9 +105,20 @@ import type { LibraryTrack } from '../types/api';
 type ApiErrorBody = {
   ok?: boolean;
   error?: string;
+  code?: string;
+  candidate?: unknown;
 };
 
 const _CSRF_EXEMPT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+/** Reads the structured error body (code, sanitized candidate, ...) a
+ * backend rejection attached to its thrown Error -- e.g. distinguishing
+ * `review_confirmation_required` from other failures without parsing
+ * `err.message` text. Returns undefined for non-API errors or plain
+ * network failures. */
+export function apiErrorBody(err: unknown): ApiErrorBody | undefined {
+  return (err as { body?: ApiErrorBody } | null | undefined)?.body;
+}
 
 export async function apiJson<T>(path: string, init?: RequestInit): Promise<T> {
   const method = (init?.method ?? 'GET').toUpperCase();
@@ -124,11 +135,15 @@ export async function apiJson<T>(path: string, init?: RequestInit): Promise<T> {
   const body = (await response.json().catch(() => null)) as ApiErrorBody | null;
 
   if (!response.ok) {
-    throw new Error(body?.error || `HTTP ${response.status}`);
+    const err = new Error(body?.error || `HTTP ${response.status}`) as Error & { body?: ApiErrorBody };
+    err.body = body ?? undefined;
+    throw err;
   }
 
   if (body && body.ok === false) {
-    throw new Error(body.error || 'Request failed');
+    const err = new Error(body.error || 'Request failed') as Error & { body?: ApiErrorBody };
+    err.body = body;
+    throw err;
   }
 
   return body as T;
@@ -1152,14 +1167,31 @@ export function validateManualMusicBrainzId(payload: ImportReviewManualIdPayload
 export function attachRecording(
   itemId: number,
   mbTrackId: string,
-  options: { confirmed_conflicts?: boolean; candidate?: ReviewRecordingCandidate } = {},
-): Promise<JobStartResponse> {
-  return apiJson<JobStartResponse>(
+): Promise<AttachRecordingResponse> {
+  // Always "safe" mode: the backend independently re-derives eligibility
+  // from its own trusted candidate set and rejects anything that actually
+  // needs review (see confirmAttachRecording) -- this call never asserts
+  // safety/confidence/conflicts itself.
+  return apiJson<AttachRecordingResponse>(
+    `/api/items/${itemId}/attach-recording`,
+    jsonRequest('POST', { mb_trackid: mbTrackId, mode: 'safe' }),
+  );
+}
+
+export function confirmAttachRecording(
+  itemId: number,
+  mbTrackId: string,
+  decisionVersion: string,
+  confirmationReason: string,
+): Promise<AttachRecordingResponse> {
+  return apiJson<AttachRecordingResponse>(
     `/api/items/${itemId}/attach-recording`,
     jsonRequest('POST', {
       mb_trackid: mbTrackId,
-      confirmed_conflicts: Boolean(options.confirmed_conflicts),
-      candidate: options.candidate,
+      mode: 'confirmed_review',
+      confirm: true,
+      confirmation_reason: confirmationReason,
+      decision_version: decisionVersion,
     }),
   );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -168,6 +168,10 @@ export interface ReviewRecordingCandidate {
   matching_local_release_found?: boolean;
   decision?: RecordingMatchDecision;
   conflicts?: string[];
+  warnings?: string[];
+  review_required?: boolean;
+  action_eligibility?: { attach_without_review?: boolean; destructive_use?: boolean };
+  decision_version?: string;
   recommended_action?: string;
   requires_confirmation?: boolean;
   safety_result?: string;
@@ -749,6 +753,16 @@ export interface JobStartResponse extends ApiOkResponse {
   batch_job_id?: string;
   state?: AiBatchState;
   reconnected?: boolean;
+}
+
+export interface AttachRecordingResponse extends ApiOkResponse {
+  job_id?: string;
+  changed?: boolean;
+  reason?: string;
+  mode?: 'safe' | 'confirmed_review';
+  recording_id?: string;
+  decision_version?: string;
+  audit_id?: string;
 }
 
 

--- a/frontend/src/features/importReview/ImportReviewPage.tsx
+++ b/frontend/src/features/importReview/ImportReviewPage.tsx
@@ -4358,6 +4358,27 @@ export function ImportReviewPage({
           setAction(item.id, { status: 'idle', message: '' });
           return;
         }
+        // A per-item attachment is already running on the backend -- never
+        // a confirmation dialog for this one, just a concise warning; the
+        // in-flight attachment owns this item until it finishes.
+        if (body?.code === 'attachment_in_progress') {
+          setAction(item.id, {
+            status: 'warning',
+            message: body.error || 'A Recording ID attachment is already running for this item.',
+          });
+          return;
+        }
+        // The backend-computed matching decision moved on since it was
+        // displayed (drv2 schema mismatch or the candidate itself changed) --
+        // safety/eligibility are never recalculated client-side, so surface
+        // a clear refresh prompt rather than retrying blind.
+        if (body?.code === 'matching_decision_stale') {
+          setAction(item.id, {
+            status: 'warning',
+            message: body.error || 'The matching decision has changed since it was displayed; refresh the review item.',
+          });
+          return;
+        }
       }
       const message = err instanceof Error ? err.message : String(err);
       const aiWarning = optionalAiWarning(message);
@@ -4393,6 +4414,21 @@ export function ImportReviewPage({
       removeLocalItem(item);
       void pollJobBackground(started.job_id, item, label, false);
     } catch (err) {
+      const body = apiErrorBody(err);
+      if (body?.code === 'attachment_in_progress') {
+        setAction(item.id, {
+          status: 'warning',
+          message: body.error || 'A Recording ID attachment is already running for this item.',
+        });
+        return;
+      }
+      if (body?.code === 'matching_decision_stale') {
+        setAction(item.id, {
+          status: 'warning',
+          message: body.error || 'The matching decision has changed since it was displayed; refresh the review item.',
+        });
+        return;
+      }
       setAction(item.id, { status: 'error', message: err instanceof Error ? err.message : String(err) });
     }
   }, [pollJobBackground, removeLocalItem, setAction]);

--- a/frontend/src/features/importReview/ImportReviewPage.tsx
+++ b/frontend/src/features/importReview/ImportReviewPage.tsx
@@ -21,10 +21,12 @@ import { apiGet } from '../../lib/api';
 import {
   albumAddMbids,
   albumMbsubmit,
+  apiErrorBody,
   attachRecording,
   autoEnqueueImport,
   cleanupReviewFiles,
   cleanupStaleReview,
+  confirmAttachRecording,
   deleteReviewFolder,
   deletePendingReview,
   getFolderStats,
@@ -45,6 +47,7 @@ import {
 import type {
   AiSuggestResponse,
   AiSuggestion,
+  AttachRecordingResponse,
   FolderStatsResponse,
   ImportReviewManualIdResponse,
   ImportTargetPreviewResponse,
@@ -148,7 +151,8 @@ type SelectedMatch = {
 type ConfirmIntent =
   | { kind: 'apply'; item: ReviewItem; mbid: string }
   | { kind: 'dismiss'; item: ReviewItem }
-  | { kind: 'delete_folder'; item: ReviewItem; folderStats?: FolderStatsResponse };
+  | { kind: 'delete_folder'; item: ReviewItem; folderStats?: FolderStatsResponse }
+  | { kind: 'attach_recording_confirm'; item: ReviewItem; mbid: string; candidate: ReviewRecordingCandidate };
 
 type BgJobStatus =
   | 'running'
@@ -3208,23 +3212,32 @@ function ConfirmDialog({
 }: {
   intent: ConfirmIntent | null;
   onClose: () => void;
-  onConfirm: () => void;
+  onConfirm: (reason?: string) => void;
 }) {
   const item = intent?.item;
   const deletingLibraryFolder = intent?.kind === 'delete_folder' && isMusicLibraryPath(item?.path);
   const wrongSourceNote = intent?.kind === 'delete_folder' ? wrongSourceEvidenceNote(item) : '';
+  const isAttachConfirm = intent?.kind === 'attach_recording_confirm';
+  const [reason, setReason] = useState('');
+  useEffect(() => { setReason(''); }, [intent]);
+  const reasonTrimmed = reason.trim();
+
   const title = intent?.kind === 'dismiss'
     ? 'Remove Review Item'
     : intent?.kind === 'delete_folder'
       ? deletingLibraryFolder ? 'Delete Library Folder' : 'Delete Source Folder'
-      : 'Start Tagging Job';
+      : isAttachConfirm
+        ? 'Confirm Recording ID (Review Required)'
+        : 'Start Tagging Job';
   const detail = intent?.kind === 'dismiss'
     ? 'This removes the folder from Pending Review only. Audio files are not deleted.'
     : intent?.kind === 'delete_folder'
       ? deletingLibraryFolder
         ? 'This permanently deletes this folder from the music library, removes matching Beets DB rows, and removes it from Pending Review. Use this only when the tracks are confirmed wrong.'
         : 'This permanently deletes the source folder from disk and removes it from Pending Review. Use this only when the tracks are confirmed wrong.'
-      : 'This starts a backend Beets job that can write tags and move files according to the configured path template.';
+      : isAttachConfirm
+        ? 'The backend flagged this candidate as needing human review before it can be attached. Confirming only attaches this Recording ID -- it does not authorize any other action.'
+        : 'This starts a backend Beets job that can write tags and move files according to the configured path template.';
 
   return (
     <Dialog open={Boolean(intent)} onClose={onClose} className="relative z-50">
@@ -3261,11 +3274,43 @@ function ConfirmDialog({
                   ) : null}
                 </div>
               ) : null}
+              {intent?.kind === 'attach_recording_confirm' ? (
+                <div className="mt-2 space-y-2 text-xs text-zinc-600">
+                  <div className="truncate font-mono">{intent.candidate.mb_trackid}</div>
+                  {(intent.candidate.conflicts || []).length ? (
+                    <div className="rounded border border-rose-200 bg-rose-50 px-2 py-1 text-rose-800">
+                      <div className="font-semibold">Conflicts</div>
+                      <div>{(intent.candidate.conflicts || []).join(', ')}</div>
+                    </div>
+                  ) : null}
+                  {(intent.candidate.warnings || []).length ? (
+                    <div className="rounded border border-amber-200 bg-amber-50 px-2 py-1 text-amber-800">
+                      <div className="font-semibold">Warnings</div>
+                      <div>{(intent.candidate.warnings || []).join(', ')}</div>
+                    </div>
+                  ) : null}
+                  <TextField
+                    fullWidth
+                    multiline
+                    minRows={2}
+                    size="small"
+                    label="Confirmation reason (required)"
+                    placeholder="Why is this the correct Recording ID despite the conflicts/warnings above?"
+                    value={reason}
+                    onChange={(e) => setReason(e.target.value)}
+                  />
+                </div>
+              ) : null}
             </div>
           ) : null}
           <div className="mt-5 flex justify-end gap-2">
             <Button variant="text" onClick={onClose}>Cancel</Button>
-            <Button color={intent?.kind === 'delete_folder' ? 'error' : 'primary'} variant="contained" onClick={onConfirm}>
+            <Button
+              color={intent?.kind === 'delete_folder' ? 'error' : 'primary'}
+              variant="contained"
+              disabled={isAttachConfirm && !reasonTrimmed}
+              onClick={() => onConfirm(reasonTrimmed)}
+            >
               {intent?.kind === 'delete_folder' ? deleteFolderActionLabel(item) : 'Confirm'}
             </Button>
           </div>
@@ -4248,14 +4293,14 @@ export function ImportReviewPage({
   const runApply = useCallback(async (item: ReviewItem, mbid: string) => {
     if (runningJobItemIdsRef.current.has(item.id)) return;
     setAction(item.id, { status: 'running', message: 'Starting backend job...' });
+    const sm = selectedMatches[item.id];
+    const representativeId = sm?.representative_release_id && sm.representative_release_id !== sm.release_group_id
+      ? sm.representative_release_id
+      : mbid;
     try {
-      let started: JobStartResponse;
+      let started: JobStartResponse | AttachRecordingResponse;
       const existingId = existingAlbumId(item);
-      const sm = selectedMatches[item.id];
       const releaseGroupId = sm?.release_group_id || selectedReleaseGroupId(item, mbid, suggestions[item.id]);
-      const representativeId = sm?.representative_release_id && sm.representative_release_id !== sm.release_group_id
-        ? sm.representative_release_id
-        : mbid;
       const preview = currentTargetPreviewState(item, sm, targetPreviews)?.preview;
       const unfilteredSelectedFiles = selectedImportSourceFiles(sm);
       const selectedSourceFiles = selectedImportSourceFiles(sm, preview);
@@ -4266,6 +4311,11 @@ export function ImportReviewPage({
 
       if (item.type === 'library_no_mb' && item.target_kind === 'item' && item.item_id) {
         started = await attachRecording(item.item_id, representativeId);
+        if (started.changed === false) {
+          setAction(item.id, { status: 'success', message: 'Recording ID already attached; no change needed.' });
+          removeLocalItem(item);
+          return;
+        }
       } else if (item.type === 'library_no_mb' && item.album_id) {
         started = await matchAlbum(item.album_id, representativeId);
       } else if (existingId) {
@@ -4296,11 +4346,56 @@ export function ImportReviewPage({
       removeLocalItem(item);                          // advance cursor immediately
       void pollJobBackground(started.job_id, item, label, keepReviewAfterSuccess);
     } catch (err) {
+      if (item.type === 'library_no_mb' && item.target_kind === 'item' && item.item_id) {
+        const body = apiErrorBody(err);
+        if (body?.code === 'review_confirmation_required' && body.candidate) {
+          setConfirmIntent({
+            kind: 'attach_recording_confirm',
+            item,
+            mbid: representativeId,
+            candidate: body.candidate as ReviewRecordingCandidate,
+          });
+          setAction(item.id, { status: 'idle', message: '' });
+          return;
+        }
+      }
       const message = err instanceof Error ? err.message : String(err);
       const aiWarning = optionalAiWarning(message);
       setAction(item.id, { status: aiWarning ? 'warning' : 'error', message: aiWarning || message });
     }
   }, [pollJobBackground, removeLocalItem, selectedMatches, setAction, suggestions, targetPreviews]);
+
+  // Separate from runApply on purpose: a confirmed-review attach must only
+  // ever be reachable through the explicit confirm dialog (see
+  // ConfirmDialog's 'attach_recording_confirm' branch), never through the
+  // same one-click path used for backend-declared-safe candidates.
+  const runConfirmedAttach = useCallback(async (
+    item: ReviewItem,
+    mbid: string,
+    candidate: ReviewRecordingCandidate,
+    reason: string,
+  ) => {
+    if (!item.item_id || runningJobItemIdsRef.current.has(item.id)) return;
+    setAction(item.id, { status: 'running', message: 'Starting backend job...' });
+    try {
+      const started = await confirmAttachRecording(item.item_id, mbid, candidate.decision_version || '', reason);
+      if (started.changed === false) {
+        setAction(item.id, { status: 'success', message: 'Recording ID already attached; no change needed.' });
+        removeLocalItem(item);
+        return;
+      }
+      if (!started.job_id) throw new Error('Backend did not return a job id');
+      const label = 'Attach recording ID (confirmed review)';
+      setBackgroundJobs((prev) => ({
+        ...prev,
+        [item.id]: { jobId: started.job_id!, status: 'running', label, message: `Job ${started.job_id} queued.`, item },
+      }));
+      removeLocalItem(item);
+      void pollJobBackground(started.job_id, item, label, false);
+    } catch (err) {
+      setAction(item.id, { status: 'error', message: err instanceof Error ? err.message : String(err) });
+    }
+  }, [pollJobBackground, removeLocalItem, setAction]);
 
   const requestDismiss = useCallback((item: ReviewItem) => {
     if (item.type === 'pending_ai' || item.type === 'skipped') { setConfirmIntent({ kind: 'dismiss', item }); return; }
@@ -4453,14 +4548,16 @@ export function ImportReviewPage({
     }
   }, [loadQueue, removeLocalItem, setAction]);
 
-  const confirm = useCallback(() => {
+  const confirm = useCallback((reason?: string) => {
     const intent = confirmIntent;
     setConfirmIntent(null);
     if (!intent) return;
     if (intent.kind === 'apply') void runApply(intent.item, intent.mbid);
     else if (intent.kind === 'dismiss') void runDismiss(intent.item);
-    else void runDeleteFolder(intent.item);
-  }, [confirmIntent, runApply, runDeleteFolder, runDismiss]);
+    else if (intent.kind === 'attach_recording_confirm') {
+      void runConfirmedAttach(intent.item, intent.mbid, intent.candidate, reason || '');
+    } else void runDeleteFolder(intent.item);
+  }, [confirmIntent, runApply, runConfirmedAttach, runDeleteFolder, runDismiss]);
 
   const selectFilter = useCallback((nextFilter: QueueFilter) => {
     setFilter(nextFilter);

--- a/tests/test_import_review_attach_enforcement.py
+++ b/tests/test_import_review_attach_enforcement.py
@@ -120,6 +120,33 @@ def _wait_job(job_id, timeout=10):
     return job
 
 
+def _apply_fake_beet_mutation(item, cmd, mb_details_payload):
+    """Realistic-enough fake beet mutation: attach-recording's persisted-
+    state verification (re-reads the item after the mutation and compares
+    actual mb_trackid/mb_albumid/mb_releasegroupid) requires the fake item
+    to actually change when a mocked beet subprocess "succeeds" -- a fake
+    that always returns rc=0 while leaving the item untouched would make
+    every attach job fail verification."""
+    if "modify" in cmd:
+        for part in cmd:
+            if part.startswith("mb_trackid="):
+                item.mb_trackid = part.split("=", 1)[1]
+            elif part.startswith("mb_albumid="):
+                item.mb_albumid = part.split("=", 1)[1]
+            elif part.startswith("mb_releasegroupid="):
+                item.mb_releasegroupid = part.split("=", 1)[1]
+    elif "mbsync" in cmd:
+        # Mirrors real beets: mbsync fills in release identity from
+        # whatever recording ID is currently on the item.
+        details = mb_details_payload or {}
+        release = details.get("selected_release") or {}
+        if item.mb_trackid:
+            item.mb_albumid = str(release.get("mb_albumid") or details.get("mb_albumid") or item.mb_albumid or "")
+            item.mb_releasegroupid = str(
+                release.get("mb_releasegroupid") or details.get("mb_releasegroupid") or item.mb_releasegroupid or ""
+            )
+
+
 @unittest.skipIf(APP is None, f"app.py could not be imported: {_APP_IMPORT_ERROR}")
 class AttachRecordingEnforcementTests(unittest.TestCase):
     """Shared plumbing: mock the item lookup and the trusted
@@ -132,9 +159,11 @@ class AttachRecordingEnforcementTests(unittest.TestCase):
         self.item = _fake_item()
         self.client = APP.app.test_client()
         self.beet_calls = []
+        self.addCleanup(APP._ATTACH_RECORDING_RESERVED_ITEMS.clear)
 
         def fake_beet_run(cmd, log, **kwargs):
             self.beet_calls.append(cmd)
+            _apply_fake_beet_mutation(self.item, cmd, self._mb_details_payload)
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         self.fake_beet_run = fake_beet_run
@@ -444,9 +473,11 @@ class ManualIdAttachIntegrationTests(unittest.TestCase):
         self.item = _fake_item()
         self.client = APP.app.test_client()
         self.beet_calls = []
+        self.addCleanup(APP._ATTACH_RECORDING_RESERVED_ITEMS.clear)
 
         def fake_beet_run(cmd, log, **kwargs):
             self.beet_calls.append(cmd)
+            _apply_fake_beet_mutation(self.item, cmd, self._mb_details_payload)
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         self._acoustid_candidates = [_acoustid_candidate()]

--- a/tests/test_import_review_attach_enforcement.py
+++ b/tests/test_import_review_attach_enforcement.py
@@ -430,5 +430,140 @@ class AttachRecordingEnforcementTests(unittest.TestCase):
         self.assertEqual(resp.get_json()["code"], "invalid_mode")
 
 
+@unittest.skipIf(APP is None, f"app.py could not be imported: {_APP_IMPORT_ERROR}")
+class ManualIdAttachIntegrationTests(unittest.TestCase):
+    """Integration coverage between the manual MusicBrainz-ID workflow
+    (/api/import-review/manual-id/validate, current main) and attach
+    enforcement (/api/items/<iid>/attach-recording, this branch). A manually
+    entered Recording ID must only ever become attachable by independently
+    reappearing in attach-recording's own trusted-candidate reconstruction --
+    manual validation showing "ok: true" must never itself confer attach
+    eligibility, and there must be no separate manual-attachment endpoint."""
+
+    def setUp(self):
+        self.item = _fake_item()
+        self.client = APP.app.test_client()
+        self.beet_calls = []
+
+        def fake_beet_run(cmd, log, **kwargs):
+            self.beet_calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        self._acoustid_candidates = [_acoustid_candidate()]
+        self._mb_details_payload = _mb_details()
+
+        self._patch(mock.patch.object(APP.lib, "get_item", side_effect=lambda iid: self.item))
+        self._patch(mock.patch.object(APP, "_acoustid_lookup_cached",
+                                       side_effect=lambda path: self._acoustid_candidates))
+        self._patch(mock.patch.object(APP, "_mb_recording_search", return_value=[]))
+        self._patch(mock.patch.object(APP, "_fetch_mb_recording_details",
+                                       side_effect=lambda *a, **k: self._mb_details_payload))
+        self._patch(mock.patch.object(APP, "_beet_run", side_effect=fake_beet_run))
+        self._patch(mock.patch.object(APP, "_invalidate_lib_cache", return_value=None))
+        self._patch(mock.patch.object(APP, "_trigger_plex_refresh", return_value=None))
+
+    def _patch(self, patcher):
+        obj = patcher.start()
+        self.addCleanup(patcher.stop)
+        return obj
+
+    def _manual_validate(self, mbid, item_id=9001):
+        return self.client.post(
+            "/api/import-review/manual-id/validate",
+            json={"musicbrainz_id": mbid, "target_kind": "item", "item_id": item_id},
+        )
+
+    def _attach(self, iid, payload):
+        return self.client.post(f"/api/items/{iid}/attach-recording", json=payload)
+
+    def test_manually_validated_id_that_matches_reconstructed_set_can_be_safely_attached(self):
+        manual_resp = self._manual_validate(RECORDING_ID)
+        self.assertEqual(manual_resp.status_code, 200)
+        manual_body = manual_resp.get_json()
+        self.assertTrue(manual_body["ok"])
+        self.assertEqual(manual_body["selected_recording_candidate"]["mb_trackid"], RECORDING_ID)
+
+        # The manual-validate call above never granted attach eligibility by
+        # itself -- this only succeeds because RECORDING_ID also comes back
+        # from attach-recording's own AcoustID/MB-search reconstruction.
+        resp = self._attach(9001, {"mb_trackid": RECORDING_ID, "mode": "safe"})
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+        self.assertTrue(body["ok"])
+        self.assertTrue(body["changed"])
+
+    def test_manually_validated_id_outside_trusted_set_cannot_bypass_enforcement(self):
+        # AcoustID/MB-search only ever surface RECORDING_ID for this item.
+        # ARBITRARY_UUID resolves fine against MusicBrainz (manual validation
+        # only checks the ID exists) but must still be rejected by
+        # attach-recording -- even with an explicit confirmation -- because
+        # it never appears in attach-recording's own reconstructed set.
+        manual_resp = self._manual_validate(ARBITRARY_UUID)
+        self.assertEqual(manual_resp.status_code, 200)
+        self.assertTrue(manual_resp.get_json()["ok"])
+
+        resp = self._attach(9001, {
+            "mb_trackid": ARBITRARY_UUID,
+            "mode": "confirmed_review",
+            "confirm": True,
+            "confirmation_reason": "I manually validated this on musicbrainz.org",
+            "decision_version": "drv1:doesnotmatter",
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["code"], "candidate_not_in_trusted_set")
+        self.assertEqual(self.beet_calls, [])
+
+    def test_manual_validate_candidate_uses_same_matching_contract_shape_as_attach(self):
+        manual_candidate = self._manual_validate(RECORDING_ID).get_json()["selected_recording_candidate"]
+        _current, candidates, _path, _fn = APP._reconstruct_track_recording_candidates(self.item, 9001)
+        attach_candidate = next(c for c in candidates if c["mb_trackid"] == RECORDING_ID)
+        # Both are produced by _compact_track_ai_candidate() over a
+        # matching_result from the same matching-contract enrichment -- one
+        # shared shape, not a second parallel manual-only contract.
+        for key in ("decision", "matching_contract", "safety_result", "conflicts", "action_eligibility"):
+            self.assertIn(key, manual_candidate)
+            self.assertIn(key, attach_candidate)
+
+    def test_safe_mode_ignores_manual_validate_success_when_local_evidence_conflicts(self):
+        # Manual validation only confirms the ID resolves on MusicBrainz; it
+        # has no opinion on local-tag conflicts, so it reports ok=True even
+        # though this item's artist tag conflicts with the recording.
+        self.item.artist = "Somebody Else Entirely"
+        manual_resp = self._manual_validate(RECORDING_ID)
+        self.assertTrue(manual_resp.get_json()["ok"])
+
+        # That must not translate into safe-attach eligibility.
+        resp = self._attach(9001, {"mb_trackid": RECORDING_ID, "mode": "safe"})
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.get_json()["code"], "review_confirmation_required")
+        self.assertEqual(self.beet_calls, [])
+
+    def test_confirmed_review_rejects_missing_decision_version_not_just_stale(self):
+        # Distinct from the stale-version case: decision_version omitted
+        # entirely must also be rejected for confirmed_review. Safe mode
+        # independently recomputes the whole decision at mutation time, so it
+        # alone may omit it (see PR description for that asymmetry).
+        resp = self._attach(9001, {
+            "mb_trackid": RECORDING_ID,
+            "mode": "confirmed_review",
+            "confirm": True,
+            "confirmation_reason": "reviewed",
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["code"], "matching_decision_stale")
+        self.assertEqual(self.beet_calls, [])
+
+    def test_no_separate_manual_attachment_endpoint_exists(self):
+        # Attach enforcement must not create a second mutation path for
+        # manually-entered IDs -- manual-id/validate is read-only evidence
+        # lookup; the only route that ever writes tags is attach-recording.
+        rules = {str(rule) for rule in APP.app.url_map.iter_rules()}
+        manual_attach_routes = {
+            rule for rule in rules
+            if "manual" in rule.lower() and "attach" in rule.lower()
+        }
+        self.assertEqual(manual_attach_routes, set())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_import_review_attach_enforcement.py
+++ b/tests/test_import_review_attach_enforcement.py
@@ -1,0 +1,434 @@
+"""Behavioral tests for backend-authoritative enforcement at the Import
+Review manual attach endpoint (/api/items/<iid>/attach-recording).
+
+Before this change the endpoint accepted any syntactically valid
+MusicBrainz Recording UUID with no check against the PR16 matching
+contract -- confirmed_conflicts and candidate were only ever logged, never
+enforced, and the frontend's one real call site never even sent them. These
+tests import the real app.py (same isolated-temp-environment pattern as
+tests/test_ai_batch_retry_race.py) and drive the actual Flask route, with
+only the network-touching primitives (AcoustID lookup, MusicBrainz search
+"/ details, beet subprocess calls) mocked -- the matching-contract decision
+logic, the route's enforcement branches, and the transaction/audit/rollback
+plumbing all run for real.
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_TMP_ROOT = Path(tempfile.mkdtemp(prefix="beets_attach_enforcement_"))
+unittest.addModuleCleanup(shutil.rmtree, str(_TMP_ROOT), ignore_errors=True)
+
+_ENV_OVERRIDES = {
+    "BEETSDIR": str(_TMP_ROOT / "config"),
+    "LIB_PATH": str(_TMP_ROOT / "config" / "musiclibrary.blb"),
+    "AI_BATCH_STATE_DIR": str(_TMP_ROOT / "ai_batch_jobs"),
+    "METADATA_CACHE_DIR": str(_TMP_ROOT / "cache"),
+    "BEETS_TRANSACTION_DIR": str(_TMP_ROOT / "transactions"),
+    "BEETS_WEB_AUTH_DISABLED": "1",
+}
+(_TMP_ROOT / "config").mkdir(parents=True, exist_ok=True)
+_env_patcher = mock.patch.dict(os.environ, _ENV_OVERRIDES, clear=False)
+_env_patcher.start()
+unittest.addModuleCleanup(_env_patcher.stop)
+
+
+def setUpModule():
+    # Re-assert immediately before this module's tests run: other test
+    # modules sharing the same process may have mutated BEETS_WEB_AUTH_*
+    # env vars without reverting them (see test_ai_batch_retry_race.py's
+    # identical comment for the full incident this guards against).
+    os.environ.update(_ENV_OVERRIDES)
+
+
+def _import_app():
+    sys.path.insert(0, str(ROOT))
+    import app as app_module
+    return app_module
+
+
+try:
+    APP = _import_app()
+    _APP_IMPORT_ERROR = None
+except Exception as exc:  # pragma: no cover - environment-dependent
+    APP = None
+    _APP_IMPORT_ERROR = exc
+
+
+RECORDING_ID = "11111111-1111-1111-1111-111111111111"
+OTHER_RECORDING_ID = "44444444-4444-4444-4444-444444444444"
+RELEASE_ID = "22222222-2222-2222-2222-222222222222"
+RGID = "33333333-3333-3333-3333-333333333333"
+ARBITRARY_UUID = "55555555-5555-5555-5555-555555555555"
+
+
+def _fake_item(**overrides):
+    base = dict(
+        title="Test Title", artist="Test Artist", album="", albumartist="",
+        year="", genre="", track=0, label="",
+        mb_trackid="", mb_albumid="", mb_releasegroupid="",
+        path="/music/test.mp3", length=200.0,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _acoustid_candidate(**overrides):
+    base = dict(
+        score=95, mb_trackid=RECORDING_ID,
+        mb_url=f"https://musicbrainz.org/recording/{RECORDING_ID}",
+        title="Test Title", artist="Test Artist", album="Test Album",
+        mb_albumid=RELEASE_ID, mb_albumids=[RELEASE_ID],
+        year="2020", duration="",
+    )
+    base.update(overrides)
+    return base
+
+
+def _mb_details(**overrides):
+    release = dict(
+        mb_albumid=RELEASE_ID, album="Test Album", artist="Test Artist",
+        year="2020", mb_releasegroupid=RGID, country="US",
+        release_group_primary_type="Album",
+    )
+    base = dict(
+        recording_id=RECORDING_ID, recording_title="Test Title",
+        recording_artist="Test Artist", artist="Test Artist",
+        linked_releases=[dict(release)],
+        selected_release=dict(release),
+        mb_albumid=RELEASE_ID, mb_releasegroupid=RGID,
+        album="Test Album", year="2020",
+    )
+    base.update(overrides)
+    return base
+
+
+def _wait_job(job_id, timeout=10):
+    deadline = time.time() + timeout
+    job = APP.jobs.get(job_id)
+    while job is not None and job.status == "running" and time.time() < deadline:
+        time.sleep(0.02)
+    return job
+
+
+@unittest.skipIf(APP is None, f"app.py could not be imported: {_APP_IMPORT_ERROR}")
+class AttachRecordingEnforcementTests(unittest.TestCase):
+    """Shared plumbing: mock the item lookup and the trusted
+    AcoustID/MusicBrainz candidate pipeline so each test can deterministically
+    control exactly one matching decision, without real network/subprocess
+    calls. The matching-contract decision logic and the route's enforcement
+    branches run unmocked."""
+
+    def setUp(self):
+        self.item = _fake_item()
+        self.client = APP.app.test_client()
+        self.beet_calls = []
+
+        def fake_beet_run(cmd, log, **kwargs):
+            self.beet_calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        self.fake_beet_run = fake_beet_run
+        self._acoustid_candidates = [_acoustid_candidate()]
+        self._mb_details_payload = _mb_details()
+
+        self._patch(mock.patch.object(APP.lib, "get_item", side_effect=lambda iid: self.item))
+        self._patch(mock.patch.object(APP, "_acoustid_lookup_cached",
+                                       side_effect=lambda path: self._acoustid_candidates))
+        self._patch(mock.patch.object(APP, "_mb_recording_search", return_value=[]))
+        self._patch(mock.patch.object(APP, "_fetch_mb_recording_details",
+                                       side_effect=lambda *a, **k: self._mb_details_payload))
+        self._patch(mock.patch.object(APP, "_beet_run", side_effect=fake_beet_run))
+        self._patch(mock.patch.object(APP, "_invalidate_lib_cache", return_value=None))
+        self._patch(mock.patch.object(APP, "_trigger_plex_refresh", return_value=None))
+
+    def _patch(self, patcher):
+        obj = patcher.start()
+        self.addCleanup(patcher.stop)
+        return obj
+
+    def _post(self, iid, payload):
+        return self.client.post(f"/api/items/{iid}/attach-recording", json=payload)
+
+    def _current_version(self, iid=9001):
+        _current, candidates, _path, _fn = APP._reconstruct_track_recording_candidates(self.item, iid)
+        return next(c for c in candidates if c["mb_trackid"] == RECORDING_ID)["decision_version"]
+
+    # ---- safe path -------------------------------------------------------
+
+    def test_safe_attach_succeeds_writes_audit_and_is_idempotent(self):
+        resp = self._post(9001, {"mb_trackid": RECORDING_ID, "mode": "safe"})
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+        self.assertTrue(body["ok"])
+        self.assertTrue(body["changed"])
+        self.assertEqual(body["mode"], "safe")
+        self.assertEqual(body["recording_id"], RECORDING_ID)
+        audit_id = body["audit_id"]
+        job = _wait_job(body["job_id"])
+        self.assertIsNotNone(job)
+        self.assertEqual(job.status, "success")
+
+        tx = APP.transactions.get(audit_id)
+        self.assertEqual(tx["status"], "Completed")
+        self.assertEqual(tx["operation_type"], "MusicBrainz Match")
+        self.assertTrue(tx["rollback"]["available"])
+        self.assertEqual(tx["rollback"]["operations"][0]["type"], "recording_id_restore")
+        self.assertEqual(tx["rollback"]["operations"][0]["fields"]["mb_trackid"], "")
+
+        modify_calls = [c for c in self.beet_calls if "modify" in c]
+        self.assertTrue(any(f"mb_trackid={RECORDING_ID}" in c for c in modify_calls))
+
+        # Simulate the mutation having landed, then repeat the identical
+        # request: must report no-op success, no new transaction/job.
+        self.item.mb_trackid = RECORDING_ID
+        self.item.mb_albumid = RELEASE_ID
+        self.item.mb_releasegroupid = RGID
+        before_tx_count, _ = APP.transactions.list(limit=500)
+        resp2 = self._post(9001, {"mb_trackid": RECORDING_ID, "mode": "safe"})
+        body2 = resp2.get_json()
+        self.assertTrue(body2["ok"])
+        self.assertFalse(body2["changed"])
+        self.assertEqual(body2["reason"], "already_attached")
+        self.assertNotIn("job_id", body2)
+        after_tx_count, _ = APP.transactions.list(limit=500)
+        self.assertEqual(len(before_tx_count), len(after_tx_count))
+
+    # ---- client authority attacks -----------------------------------------
+
+    def test_client_supplied_safety_fields_are_ignored_for_review_required_candidate(self):
+        # No shared words with "Test Album" -- _similarity() floors any
+        # overlapping-word pair at 0.70, which would stay above the 0.55
+        # album_conflict threshold and defeat the point of this fixture.
+        self.item.album = "Xyzzyxx Plugh Quorbat"
+        payload = {
+            "mb_trackid": RECORDING_ID,
+            "mode": "safe",
+            "attach_without_review": True,
+            "confidence_score": 1.0,
+            "conflicts": [],
+            "matching_contract": {"action_eligibility": {"attach_without_review": True}},
+            "safety_result": "Safe to attach",
+            "safety_key": "safe",
+            "review_required": False,
+            "requires_confirmation": False,
+        }
+        resp = self._post(9001, payload)
+        self.assertEqual(resp.status_code, 409)
+        body = resp.get_json()
+        self.assertFalse(body["ok"])
+        self.assertEqual(body["code"], "review_confirmation_required")
+        self.assertNotIn("job_id", body)
+        self.assertEqual(self.beet_calls, [])
+
+    # ---- identity mismatch --------------------------------------------------
+
+    def test_recording_id_mismatch_when_deterministic_sources_conflict(self):
+        # Candidate claims RECORDING_ID but the MusicBrainz details lookup
+        # disagrees -- resolved_recording_id collapses to "", so nothing can
+        # be requested safely even though the same ID is still displayed.
+        self._mb_details_payload = _mb_details(recording_id=OTHER_RECORDING_ID)
+        resp = self._post(9001, {"mb_trackid": RECORDING_ID, "mode": "safe"})
+        self.assertEqual(resp.status_code, 409)
+        body = resp.get_json()
+        self.assertFalse(body["ok"])
+        self.assertEqual(body["code"], "recording_id_mismatch")
+        self.assertEqual(self.beet_calls, [])
+
+    # ---- review-required path ----------------------------------------------
+
+    def test_review_required_without_confirmation_is_rejected(self):
+        self.item.artist = "Somebody Else Entirely"
+        resp = self._post(9001, {"mb_trackid": RECORDING_ID, "mode": "safe"})
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.get_json()["code"], "review_confirmation_required")
+        self.assertEqual(self.beet_calls, [])
+
+    def test_confirmed_review_succeeds_and_preserves_conflicts_in_audit(self):
+        self.item.artist = "Somebody Else Entirely"
+        version = self._current_version()
+        resp = self._post(9001, {
+            "mb_trackid": RECORDING_ID,
+            "mode": "confirmed_review",
+            "confirm": True,
+            "confirmation_reason": "Reviewed manually, artist tag is stylized differently.",
+            "decision_version": version,
+        })
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["mode"], "confirmed_review")
+        job = _wait_job(body["job_id"])
+        self.assertEqual(job.status, "success")
+        tx = APP.transactions.get(body["audit_id"])
+        self.assertEqual(tx["status"], "Completed")
+        self.assertIn("artist_conflict", tx["metadata"]["conflicts"])
+        self.assertTrue(tx["metadata"]["review_required"])
+        self.assertIn("Reviewed manually", tx["metadata"]["confirmation_reason"])
+
+    def test_confirmed_review_requires_explicit_confirm_boolean(self):
+        version = self._current_version()
+        resp = self._post(9001, {
+            "mb_trackid": RECORDING_ID,
+            "mode": "confirmed_review",
+            "confirmation_reason": "trying to sneak by",
+            "decision_version": version,
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["code"], "review_confirmation_required")
+        self.assertEqual(self.beet_calls, [])
+
+    def test_confirmed_review_requires_a_reason(self):
+        version = self._current_version()
+        resp = self._post(9001, {
+            "mb_trackid": RECORDING_ID,
+            "mode": "confirmed_review",
+            "confirm": True,
+            "decision_version": version,
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["code"], "confirmation_reason_required")
+        self.assertEqual(self.beet_calls, [])
+
+    # ---- arbitrary UUID protection ------------------------------------------
+
+    def test_arbitrary_uuid_outside_trusted_set_rejected_even_with_confirmation(self):
+        resp = self._post(9001, {
+            "mb_trackid": ARBITRARY_UUID,
+            "mode": "confirmed_review",
+            "confirm": True,
+            "confirmation_reason": "I really want this one",
+            "decision_version": "drv1:doesnotmatter",
+        })
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["code"], "candidate_not_in_trusted_set")
+        self.assertEqual(self.beet_calls, [])
+
+    # ---- conflict cases block safe attach -----------------------------------
+
+    def test_hard_conflict_blocks_safe_attach(self):
+        self.item.artist = "A Completely Different Performer"
+        resp = self._post(9001, {"mb_trackid": RECORDING_ID, "mode": "safe"})
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.get_json()["code"], "review_confirmation_required")
+        self.assertEqual(self.beet_calls, [])
+
+    def test_missing_release_group_id_blocks_safe_attach(self):
+        details = _mb_details()
+        details["selected_release"]["mb_releasegroupid"] = ""
+        details["mb_releasegroupid"] = ""
+        details["linked_releases"][0]["mb_releasegroupid"] = ""
+        self._mb_details_payload = details
+        resp = self._post(9001, {"mb_trackid": RECORDING_ID, "mode": "safe"})
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.get_json()["code"], "review_confirmation_required")
+        self.assertEqual(self.beet_calls, [])
+
+    # ---- stale decision -------------------------------------------------------
+
+    def test_stale_decision_version_returns_409_for_safe_mode(self):
+        resp = self._post(9001, {
+            "mb_trackid": RECORDING_ID,
+            "mode": "safe",
+            "decision_version": "drv1:stale-token-from-an-earlier-view",
+        })
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.get_json()["code"], "matching_decision_stale")
+        self.assertEqual(self.beet_calls, [])
+
+    def test_stale_decision_version_returns_409_for_confirmed_review(self):
+        self.item.artist = "Somebody Else Entirely"
+        resp = self._post(9001, {
+            "mb_trackid": RECORDING_ID,
+            "mode": "confirmed_review",
+            "confirm": True,
+            "confirmation_reason": "reviewed",
+            "decision_version": "drv1:stale-token-from-an-earlier-view",
+        })
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.get_json()["code"], "matching_decision_stale")
+        self.assertEqual(self.beet_calls, [])
+
+    # ---- failure / rollback --------------------------------------------------
+
+    def test_tag_write_failure_marks_transaction_failed_not_completed(self):
+        def failing_beet_run(cmd, log, **kwargs):
+            self.beet_calls.append(cmd)
+            if "modify" in cmd:
+                return SimpleNamespace(returncode=1, stdout="", stderr="boom")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(APP, "_beet_run", side_effect=failing_beet_run):
+            resp = self._post(9001, {"mb_trackid": RECORDING_ID, "mode": "safe"})
+            body = resp.get_json()
+            self.assertTrue(body["ok"])  # job accepted, outcome is async
+            job = _wait_job(body["job_id"])
+            self.assertEqual(job.status, "failed")
+            tx = APP.transactions.get(body["audit_id"])
+            self.assertEqual(tx["status"], "Failed")
+
+    # ---- undo ------------------------------------------------------------
+
+    def test_undo_restores_previous_identity_values(self):
+        resp = self._post(9001, {"mb_trackid": RECORDING_ID, "mode": "safe"})
+        body = resp.get_json()
+        job = _wait_job(body["job_id"])
+        self.assertEqual(job.status, "success")
+        audit_id = body["audit_id"]
+
+        rollback_resp = self.client.post(f"/api/transactions/{audit_id}/rollback")
+        self.assertEqual(rollback_resp.status_code, 200)
+        rollback_body = rollback_resp.get_json()
+        self.assertTrue(rollback_body["ok"])
+        rb_job = _wait_job(rollback_body["job_id"])
+        self.assertEqual(rb_job.status, "success")
+
+        tx = APP.transactions.get(audit_id)
+        self.assertEqual(tx["status"], "Rolled Back")
+        restore_calls = [c for c in self.beet_calls if "modify" in c and "mb_trackid=" in " ".join(c)]
+        self.assertTrue(any("mb_trackid=" in part and RECORDING_ID not in part
+                             for call in restore_calls for part in call if part.startswith("mb_trackid=")))
+
+    # ---- serialization safety --------------------------------------------
+
+    def test_response_never_echoes_arbitrary_client_supplied_fields(self):
+        resp = self._post(9001, {
+            "mb_trackid": RECORDING_ID,
+            "mode": "safe",
+            "authorization_header": "Bearer sk-should-not-appear",
+            "raw_provider_payload": {"api_key": "super-secret-value"},
+        })
+        rendered = json.dumps(resp.get_json())
+        self.assertNotIn("sk-should-not-appear", rendered)
+        self.assertNotIn("super-secret-value", rendered)
+        body = resp.get_json()
+        job = _wait_job(body["job_id"])
+        tx = APP.transactions.get(body["audit_id"])
+        tx_rendered = json.dumps(tx)
+        self.assertNotIn("sk-should-not-appear", tx_rendered)
+        self.assertNotIn("super-secret-value", tx_rendered)
+
+    # ---- basic validation --------------------------------------------------
+
+    def test_invalid_uuid_format_rejected(self):
+        resp = self._post(9001, {"mb_trackid": "not-a-uuid", "mode": "safe"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(self.beet_calls, [])
+
+    def test_unknown_mode_rejected(self):
+        resp = self._post(9001, {"mb_trackid": RECORDING_ID, "mode": "yolo"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["code"], "invalid_mode")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_import_review_attach_integrity.py
+++ b/tests/test_import_review_attach_integrity.py
@@ -1,0 +1,618 @@
+"""Behavioral tests for the concurrency, strict-subprocess-outcome,
+persisted-state-verification, and secret-sanitization hardening added on
+top of the base backend-authoritative enforcement covered by
+tests/test_import_review_attach_enforcement.py.
+
+That module already proves candidate reconstruction, safe/confirmed-review
+mode gating, decision_version staleness, and basic transaction/audit
+plumbing are backend-authoritative. This module proves the parts a prior
+review pass flagged as still missing:
+
+  * per-item (not global) reservation so two concurrent attach-recording
+    requests for the SAME item can never race (different items still run
+    fully in parallel);
+  * strict beet subprocess return-code handling (-9 cancelled, 124 timed
+    out, other nonzero failed) that stops immediately and never claims
+    success;
+  * truthful persisted-vs-candidate identity verification (the transaction
+    is only ever "Completed" against what was actually re-read from Beets,
+    never the pre-mutation candidate expectation);
+  * confirmation-reason / reconstruction-exception sanitization so secrets
+    never reach the response, transaction record, or logs.
+
+Reuses the fixtures/module import from test_import_review_attach_enforcement
+(same isolated-temp-environment app import) rather than re-deriving them.
+"""
+import json
+import os
+import threading
+import unittest
+import unittest.mock as mock
+from types import SimpleNamespace
+
+from tests.test_import_review_attach_enforcement import (
+    APP,
+    _APP_IMPORT_ERROR,
+    _ENV_OVERRIDES,
+    _fake_item,
+    _acoustid_candidate,
+    _wait_job,
+    RECORDING_ID,
+    RELEASE_ID,
+    RGID,
+)
+
+
+def setUpModule():
+    # test_import_review_attach_enforcement's own module-level env override
+    # is reverted by its addModuleCleanup once ITS tests finish running --
+    # when this module's tests run afterward in the same process (full
+    # discovery), BEETS_WEB_AUTH_DISABLED and friends would otherwise be
+    # unset again, and every request here would 401/503 on the auth
+    # boundary instead of exercising attach-recording. Re-assert immediately
+    # before this module's tests run (same defensive pattern documented in
+    # test_import_review_attach_enforcement.py / test_ai_batch_retry_race.py).
+    os.environ.update(_ENV_OVERRIDES)
+
+SECOND_RECORDING_ID = "66666666-6666-6666-6666-666666666666"
+SECOND_RELEASE_ID = "77777777-7777-7777-7777-777777777777"
+SECOND_RGID = "88888888-8888-8888-8888-888888888888"
+PRIOR_RECORDING_ID = "99999999-9999-9999-9999-999999999999"
+
+
+def _mb_details_for(recording_id, release_id, rgid):
+    release = dict(
+        mb_albumid=release_id, album="Test Album", artist="Test Artist",
+        year="2020", mb_releasegroupid=rgid, country="US",
+        release_group_primary_type="Album",
+    )
+    return dict(
+        recording_id=recording_id, recording_title="Test Title",
+        recording_artist="Test Artist", artist="Test Artist",
+        linked_releases=[dict(release)], selected_release=dict(release),
+        mb_albumid=release_id, mb_releasegroupid=rgid,
+        album="Test Album", year="2020",
+    )
+
+
+def _iid_from_cmd(cmd):
+    for part in cmd:
+        if isinstance(part, str) and part.startswith("id:"):
+            try:
+                return int(part[3:])
+            except ValueError:
+                return None
+    return None
+
+
+def _stage_of(cmd):
+    for stage in ("modify", "mbsync", "write", "move"):
+        if stage in cmd:
+            return stage
+    return ""
+
+
+def _mutate_fake_item(item, cmd, mb_details_by_recording):
+    if "modify" in cmd:
+        for part in cmd:
+            if part.startswith("mb_trackid="):
+                item.mb_trackid = part.split("=", 1)[1]
+            elif part.startswith("mb_albumid="):
+                item.mb_albumid = part.split("=", 1)[1]
+            elif part.startswith("mb_releasegroupid="):
+                item.mb_releasegroupid = part.split("=", 1)[1]
+    elif "mbsync" in cmd:
+        details = mb_details_by_recording.get(item.mb_trackid) or {}
+        release = details.get("selected_release") or {}
+        if item.mb_trackid:
+            item.mb_albumid = str(release.get("mb_albumid") or details.get("mb_albumid") or item.mb_albumid or "")
+            item.mb_releasegroupid = str(
+                release.get("mb_releasegroupid") or details.get("mb_releasegroupid") or item.mb_releasegroupid or ""
+            )
+
+
+@unittest.skipIf(APP is None, f"app.py could not be imported: {_APP_IMPORT_ERROR}")
+class _AttachIntegrityTestCase(unittest.TestCase):
+    """Shared multi-item plumbing: unlike the base enforcement test file
+    (one item per test), several tests here need two independent items
+    (different-item concurrency) or per-stage/per-item control over beet
+    subprocess outcomes and persisted mutation, so the fixture is keyed by
+    item id throughout."""
+
+    def setUp(self):
+        self.client = APP.app.test_client()
+        self.items = {}
+        self.candidates_by_path = {}
+        self.mb_details = {}
+        self.beet_calls = []
+        self.gates = {}
+        self.stage_rc = {}
+        self.suppress_mutation = set()
+        self.persist_override = {}
+        self.addCleanup(APP._ATTACH_RECORDING_RESERVED_ITEMS.clear)
+
+        def get_item(iid):
+            return self.items.get(iid)
+
+        def acoustid_lookup(path):
+            return self.candidates_by_path.get(path, [])
+
+        def mb_search(*a, **k):
+            return []
+
+        def fetch_details(mbid, *a, **k):
+            return self.mb_details.get(mbid) or _mb_details_for(mbid, RELEASE_ID, RGID)
+
+        def fake_beet_run(cmd, log, **kwargs):
+            self.beet_calls.append(cmd)
+            iid = _iid_from_cmd(cmd)
+            gate = self.gates.get(iid)
+            if gate is not None:
+                gate.wait(timeout=10)
+            stage = _stage_of(cmd)
+            rc = self.stage_rc.get((iid, stage), 0)
+            if rc == 0 and iid not in self.suppress_mutation:
+                item = self.items.get(iid)
+                if item is not None:
+                    _mutate_fake_item(item, cmd, self.mb_details)
+                    if stage == "mbsync" and iid in self.persist_override:
+                        forced = self.persist_override[iid]
+                        if "mb_albumid" in forced:
+                            item.mb_albumid = forced["mb_albumid"]
+                        if "mb_releasegroupid" in forced:
+                            item.mb_releasegroupid = forced["mb_releasegroupid"]
+            stderr = "" if rc == 0 else f"{stage} boom Authorization: Bearer subprocess-stderr-secret"
+            return SimpleNamespace(returncode=rc, stdout="", stderr=stderr)
+
+        self._patch(mock.patch.object(APP.lib, "get_item", side_effect=get_item))
+        self._patch(mock.patch.object(APP, "_acoustid_lookup_cached", side_effect=acoustid_lookup))
+        self._patch(mock.patch.object(APP, "_mb_recording_search", side_effect=mb_search))
+        self._patch(mock.patch.object(APP, "_fetch_mb_recording_details", side_effect=fetch_details))
+        self._patch(mock.patch.object(APP, "_beet_run", side_effect=fake_beet_run))
+        self._patch(mock.patch.object(APP, "_invalidate_lib_cache", return_value=None))
+        self._patch(mock.patch.object(APP, "_trigger_plex_refresh", return_value=None))
+
+    def _patch(self, patcher):
+        obj = patcher.start()
+        self.addCleanup(patcher.stop)
+        return obj
+
+    def add_item(self, iid, *, recording_id=RECORDING_ID, release_id=RELEASE_ID, rgid=RGID, **overrides):
+        item = _fake_item(path=f"/music/item{iid}.mp3", **overrides)
+        self.items[iid] = item
+        resolved_path = APP._item_ai_abs_path(item)
+        self.candidates_by_path[resolved_path] = [
+            _acoustid_candidate(mb_trackid=recording_id, mb_albumid=release_id, mb_albumids=[release_id])
+        ]
+        self.mb_details[recording_id] = _mb_details_for(recording_id, release_id, rgid)
+        return item
+
+    def _post_safe(self, iid, mb_trackid=RECORDING_ID):
+        return self.client.post(f"/api/items/{iid}/attach-recording", json={"mb_trackid": mb_trackid, "mode": "safe"})
+
+    def _post_confirmed(self, iid, mb_trackid=RECORDING_ID, reason="Reviewed manually.", version=None):
+        if version is None:
+            version = self._current_version(iid, mb_trackid)
+        return self.client.post(f"/api/items/{iid}/attach-recording", json={
+            "mb_trackid": mb_trackid, "mode": "confirmed_review", "confirm": True,
+            "confirmation_reason": reason, "decision_version": version,
+        })
+
+    def _current_version(self, iid, mb_trackid=RECORDING_ID):
+        item = self.items[iid]
+        _current, candidates, _path, _fn = APP._reconstruct_track_recording_candidates(item, iid)
+        return next(c for c in candidates if c["mb_trackid"] == mb_trackid)["decision_version"]
+
+    def _stages_called_for(self, iid):
+        out = []
+        for cmd in self.beet_calls:
+            if _iid_from_cmd(cmd) == iid:
+                out.append(_stage_of(cmd))
+        return out
+
+
+# ── Step 12: per-item reservation / concurrency ───────────────────────────────
+
+class ConcurrencyReservationTests(_AttachIntegrityTestCase):
+    def _block_item(self, iid):
+        gate = threading.Event()
+        self.gates[iid] = gate
+        return gate
+
+    def test_a_safe_plus_safe_same_item_second_gets_409(self):
+        self.add_item(9101)
+        gate = self._block_item(9101)
+        resp1 = self._post_safe(9101)
+        self.assertEqual(resp1.status_code, 200)
+        job1_id = resp1.get_json()["job_id"]
+
+        resp2 = self._post_safe(9101)
+        self.assertEqual(resp2.status_code, 409)
+        body2 = resp2.get_json()
+        self.assertFalse(body2["ok"])
+        self.assertEqual(body2["code"], "attachment_in_progress")
+
+        gate.set()
+        job1 = _wait_job(job1_id)
+        self.assertEqual(job1.status, "success")
+
+        txs, _total = APP.transactions.list(limit=500)
+        matching = [t for t in txs if t.get("metadata", {}).get("item_id") == 9101]
+        self.assertEqual(len(matching), 1, "exactly one transaction must exist for this item")
+        # Exactly one transaction/job's worth of modify calls ran for this item.
+        modify_calls = [s for s in self._stages_called_for(9101) if s == "modify"]
+        self.assertEqual(len(modify_calls), 1)
+
+    def test_b_safe_plus_confirmed_review_same_item_second_gets_409(self):
+        self.add_item(9102)
+        gate = self._block_item(9102)
+        resp1 = self._post_safe(9102)
+        self.assertEqual(resp1.status_code, 200)
+        job1_id = resp1.get_json()["job_id"]
+
+        resp2 = self._post_confirmed(9102, version="drv2:doesnotmatter")
+        self.assertEqual(resp2.status_code, 409)
+        self.assertEqual(resp2.get_json()["code"], "attachment_in_progress")
+
+        gate.set()
+        _wait_job(job1_id)
+
+    def test_c_confirmed_review_plus_confirmed_review_same_item_only_one_proceeds(self):
+        self.add_item(9103)
+        gate = self._block_item(9103)
+        version = self._current_version(9103)
+        resp1 = self._post_confirmed(9103, version=version)
+        self.assertEqual(resp1.status_code, 200)
+        job1_id = resp1.get_json()["job_id"]
+
+        resp2 = self._post_confirmed(9103, version=version)
+        self.assertEqual(resp2.status_code, 409)
+        self.assertEqual(resp2.get_json()["code"], "attachment_in_progress")
+
+        gate.set()
+        job1 = _wait_job(job1_id)
+        self.assertEqual(job1.status, "success")
+        modify_calls = [s for s in self._stages_called_for(9103) if s == "modify"]
+        self.assertEqual(len(modify_calls), 1)
+
+    def test_d_different_items_proceed_concurrently_lock_is_not_global(self):
+        self.add_item(9104)
+        self.add_item(9105, recording_id=SECOND_RECORDING_ID, release_id=SECOND_RELEASE_ID, rgid=SECOND_RGID)
+        gate = self._block_item(9104)
+
+        resp1 = self._post_safe(9104)
+        self.assertEqual(resp1.status_code, 200)
+        job1_id = resp1.get_json()["job_id"]
+
+        # Item 9104's job is stalled on the gate right now; a completely
+        # unrelated item must still proceed and finish without waiting.
+        resp2 = self._post_safe(9105, mb_trackid=SECOND_RECORDING_ID)
+        self.assertEqual(resp2.status_code, 200)
+        job2_id = resp2.get_json()["job_id"]
+        job2 = _wait_job(job2_id, timeout=5)
+        self.assertEqual(job2.status, "success")
+
+        gate.set()
+        job1 = _wait_job(job1_id)
+        self.assertEqual(job1.status, "success")
+
+    def test_e_release_after_success_later_request_not_blocked(self):
+        self.add_item(9106)
+        resp1 = self._post_safe(9106)
+        _wait_job(resp1.get_json()["job_id"])
+        self.assertNotIn(9106, APP._ATTACH_RECORDING_RESERVED_ITEMS)
+
+        resp2 = self._post_safe(9106)
+        self.assertNotEqual(resp2.status_code, 409)
+        body2 = resp2.get_json()
+        self.assertTrue(body2["ok"])
+        # Either a fresh job or an idempotent no-op -- never blocked.
+        self.assertNotEqual(body2.get("code"), "attachment_in_progress")
+
+    def test_f_release_after_ordinary_failure(self):
+        self.add_item(9107)
+        self.stage_rc[(9107, "modify")] = 1
+        resp1 = self._post_safe(9107)
+        job1 = _wait_job(resp1.get_json()["job_id"])
+        self.assertEqual(job1.status, "failed")
+        self.assertNotIn(9107, APP._ATTACH_RECORDING_RESERVED_ITEMS)
+
+        del self.stage_rc[(9107, "modify")]
+        resp2 = self._post_safe(9107)
+        self.assertNotEqual(resp2.status_code, 409)
+
+    def test_g_release_after_cancellation(self):
+        self.add_item(9108)
+        self.stage_rc[(9108, "modify")] = -9
+        resp1 = self._post_safe(9108)
+        audit_id = resp1.get_json()["audit_id"]
+        job1 = _wait_job(resp1.get_json()["job_id"])
+        self.assertEqual(job1.status, "failed")  # PythonJob has no separate cancelled state
+        tx = APP.transactions.get(audit_id)
+        self.assertEqual(tx["status"], "Cancelled")
+        self.assertNotIn(9108, APP._ATTACH_RECORDING_RESERVED_ITEMS)
+
+        del self.stage_rc[(9108, "modify")]
+        resp2 = self._post_safe(9108)
+        self.assertNotEqual(resp2.status_code, 409)
+
+    def test_h_job_start_exception_releases_reservation(self):
+        self.add_item(9109)
+        with mock.patch.object(APP.jobs, "start_python", side_effect=RuntimeError("boom")):
+            resp1 = self._post_safe(9109)
+        self.assertEqual(resp1.status_code, 500)
+        self.assertEqual(resp1.get_json()["code"], "attachment_job_start_failed")
+        self.assertNotIn(9109, APP._ATTACH_RECORDING_RESERVED_ITEMS)
+
+        resp2 = self._post_safe(9109)
+        self.assertNotEqual(resp2.status_code, 409)
+
+
+# ── Step 13: strict beet subprocess outcomes ──────────────────────────────────
+
+class SubprocessOutcomeTests(_AttachIntegrityTestCase):
+    def test_attach_stage_outcomes_stop_immediately_and_are_truthful(self):
+        stages = ["modify", "mbsync", "write", "move"]
+        outcomes = [(-9, "Cancelled"), (124, "Failed"), (1, "Failed")]
+        for stage_idx, stage in enumerate(stages):
+            for rc_idx, (rc, expected_status) in enumerate(outcomes):
+                iid = 40000 + stage_idx * 10 + rc_idx
+                with self.subTest(stage=stage, rc=rc):
+                    self.add_item(iid)
+                    self.stage_rc[(iid, stage)] = rc
+                    resp = self._post_safe(iid)
+                    self.assertEqual(resp.status_code, 200)
+                    audit_id = resp.get_json()["audit_id"]
+                    job = _wait_job(resp.get_json()["job_id"])
+                    self.assertEqual(job.status, "failed")
+
+                    tx = APP.transactions.get(audit_id)
+                    self.assertEqual(tx["status"], expected_status)
+                    self.assertNotEqual(tx["status"], "Completed")
+
+                    called = self._stages_called_for(iid)
+                    self.assertEqual(called, stages[:stage_idx + 1], "a later stage ran after a fatal outcome")
+                    self.assertNotIn(iid, APP._ATTACH_RECORDING_RESERVED_ITEMS)
+
+                    rendered = json.dumps(tx)
+                    self.assertNotIn("subprocess-stderr-secret", rendered)
+                    self.assertNotIn("Bearer", rendered)
+
+    def test_rollback_stage_outcomes_never_report_success(self):
+        stages = ["modify", "write", "move"]
+        outcomes = [-9, 124, 1]
+        for stage_idx, stage in enumerate(stages):
+            for rc_idx, rc in enumerate(outcomes):
+                iid = 41000 + stage_idx * 10 + rc_idx
+                with self.subTest(stage=stage, rc=rc):
+                    self.add_item(iid)
+                    resp = self._post_safe(iid)
+                    self.assertEqual(resp.status_code, 200)
+                    audit_id = resp.get_json()["audit_id"]
+                    job = _wait_job(resp.get_json()["job_id"])
+                    self.assertEqual(job.status, "success")
+
+                    self.stage_rc[(iid, stage)] = rc
+                    rb_resp = self.client.post(f"/api/transactions/{audit_id}/rollback")
+                    self.assertEqual(rb_resp.status_code, 200)
+                    rb_job = _wait_job(rb_resp.get_json()["job_id"])
+                    self.assertIn(rb_job.status, ("success", "failed"))
+
+                    tx = APP.transactions.get(audit_id)
+                    self.assertNotEqual(tx["status"], "Rolled Back")
+
+                    rendered = json.dumps(tx)
+                    self.assertNotIn("subprocess-stderr-secret", rendered)
+
+    def test_rollback_mbsync_failure_with_prior_recording_id_fails_restore(self):
+        # Only reachable when the rollback target mb_trackid is non-empty --
+        # attach a second recording ID on top of an item that already had
+        # one, then fail mbsync while rolling the second attach back.
+        iid = 42001
+        self.add_item(iid, recording_id=SECOND_RECORDING_ID, release_id=SECOND_RELEASE_ID, rgid=SECOND_RGID,
+                       mb_trackid=PRIOR_RECORDING_ID, mb_albumid=RELEASE_ID, mb_releasegroupid=RGID)
+        resp = self._post_confirmed(iid, mb_trackid=SECOND_RECORDING_ID,
+                                     reason="Switching recording identity.")
+        self.assertEqual(resp.status_code, 200, resp.get_json())
+        audit_id = resp.get_json()["audit_id"]
+        job = _wait_job(resp.get_json()["job_id"])
+        self.assertEqual(job.status, "success")
+
+        tx = APP.transactions.get(audit_id)
+        self.assertEqual(tx["rollback"]["operations"][0]["fields"]["mb_trackid"], PRIOR_RECORDING_ID)
+
+        self.stage_rc[(iid, "mbsync")] = 1
+        rb_resp = self.client.post(f"/api/transactions/{audit_id}/rollback")
+        _wait_job(rb_resp.get_json()["job_id"])
+        tx_after = APP.transactions.get(audit_id)
+        self.assertNotEqual(tx_after["status"], "Rolled Back")
+        self.assertIn("mbsync", self._stages_called_for(iid)[-3:])
+
+
+# ── Step 14: persisted-state verification ─────────────────────────────────────
+
+class PersistedStateVerificationTests(_AttachIntegrityTestCase):
+    def test_a_correct_persisted_state_matches_reread_item(self):
+        iid = 43001
+        self.add_item(iid)
+        resp = self._post_safe(iid)
+        audit_id = resp.get_json()["audit_id"]
+        job = _wait_job(resp.get_json()["job_id"])
+        self.assertEqual(job.status, "success")
+
+        tx = APP.transactions.get(audit_id)
+        self.assertEqual(tx["status"], "Completed")
+        persisted = tx["metadata"]["persisted_identity"]
+        self.assertEqual(persisted["mb_trackid"], RECORDING_ID)
+        self.assertEqual(persisted["mb_albumid"], RELEASE_ID)
+        self.assertEqual(persisted["mb_releasegroupid"], RGID)
+        self.assertEqual(tx["changes"][0]["new_metadata"], persisted)
+        self.assertEqual(self.items[iid].mb_trackid, RECORDING_ID)
+
+    def test_b_recording_id_fails_to_persist_fails_job_and_transaction(self):
+        iid = 43002
+        self.add_item(iid)
+        self.suppress_mutation.add(iid)
+        resp = self._post_safe(iid)
+        audit_id = resp.get_json()["audit_id"]
+        job = _wait_job(resp.get_json()["job_id"])
+        self.assertEqual(job.status, "failed")
+
+        tx = APP.transactions.get(audit_id)
+        self.assertEqual(tx["status"], "Failed")
+        self.assertNotEqual(tx["status"], "Completed")
+        rendered = json.dumps(tx)
+        self.assertNotIn('"status": "Completed"', rendered)
+
+    def test_c_different_release_id_persisted_completes_but_audits_truthfully(self):
+        iid = 43003
+        self.add_item(iid)
+        self.persist_override[iid] = {"mb_albumid": SECOND_RELEASE_ID}
+        resp = self._post_safe(iid)
+        audit_id = resp.get_json()["audit_id"]
+        job = _wait_job(resp.get_json()["job_id"])
+        self.assertEqual(job.status, "success")
+
+        tx = APP.transactions.get(audit_id)
+        self.assertEqual(tx["status"], "Completed")
+        self.assertTrue(tx["metadata"]["release_identity_mismatch"])
+        self.assertEqual(tx["metadata"]["persisted_identity"]["mb_albumid"], SECOND_RELEASE_ID)
+        self.assertEqual(tx["metadata"]["candidate_identity"]["mb_albumid"], RELEASE_ID)
+        self.assertNotEqual(
+            tx["metadata"]["persisted_identity"]["mb_albumid"],
+            tx["metadata"]["candidate_identity"]["mb_albumid"],
+        )
+
+    def test_d_missing_release_group_id_after_sync_reported_truthfully(self):
+        iid = 43004
+        self.add_item(iid)
+        self.persist_override[iid] = {"mb_releasegroupid": ""}
+        resp = self._post_safe(iid)
+        audit_id = resp.get_json()["audit_id"]
+        job = _wait_job(resp.get_json()["job_id"])
+        self.assertEqual(job.status, "success")
+
+        tx = APP.transactions.get(audit_id)
+        self.assertEqual(tx["status"], "Completed")
+        self.assertTrue(tx["metadata"]["release_group_identity_mismatch"])
+        self.assertEqual(tx["metadata"]["persisted_identity"]["mb_releasegroupid"], "")
+        self.assertEqual(tx["metadata"]["candidate_identity"]["mb_releasegroupid"], RGID)
+
+
+# ── Step 10: new structured error codes ───────────────────────────────────────
+
+class NewStructuredErrorCodeTests(_AttachIntegrityTestCase):
+    def test_item_not_found_returns_review_item_not_found(self):
+        resp = self._post_safe(90001)  # never registered in self.items
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.get_json()["code"], "review_item_not_found")
+
+    def test_missing_recording_id_returns_recording_id_required(self):
+        resp = self.client.post("/api/items/90002/attach-recording", json={"mode": "safe"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["code"], "recording_id_required")
+
+    def test_invalid_uuid_returns_invalid_recording_id(self):
+        resp = self.client.post("/api/items/90003/attach-recording",
+                                 json={"mb_trackid": "not-a-uuid", "mode": "safe"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["code"], "invalid_recording_id")
+
+
+# ── Step 15: secret sanitization ──────────────────────────────────────────────
+
+class SecuritySanitizationTests(_AttachIntegrityTestCase):
+    SECRETS = [
+        "Authorization: Bearer bearer-secret",
+        "Cookie: session=cookie-secret",
+        "api_key=query-secret",
+        "https://user:password@example.test/",
+    ]
+
+    def _assert_no_secrets(self, *blobs):
+        haystacks = [json.dumps(b) if not isinstance(b, str) else b for b in blobs]
+        for blob in haystacks:
+            self.assertNotIn("bearer-secret", blob)
+            self.assertNotIn("cookie-secret", blob)
+            self.assertNotIn("query-secret", blob)
+            self.assertNotIn("password", blob)
+
+    def test_confirmation_reason_secrets_never_survive(self):
+        iid = 50001
+        self.add_item(iid)
+        reason = " / ".join(self.SECRETS)
+        resp = self._post_confirmed(iid, reason=reason)
+        self.assertEqual(resp.status_code, 200, resp.get_json())
+        audit_id = resp.get_json()["audit_id"]
+        job = _wait_job(resp.get_json()["job_id"])
+        self.assertEqual(job.status, "success")
+
+        tx = APP.transactions.get(audit_id)
+        self._assert_no_secrets(resp.get_json(), tx, tx.get("logs"), tx.get("changes"), tx.get("metadata"))
+        self.assertNotIn("bearer-secret", tx["reason"])
+        self.assertNotIn("bearer-secret", tx["changes"][0]["reason"])
+        self.assertNotIn("bearer-secret", tx["metadata"]["confirmation_reason"])
+
+    def test_confirmation_reason_multiline_becomes_single_line_and_bounded(self):
+        iid = 50002
+        self.add_item(iid)
+        reason = "line one\r\nline two\twith a tab\nline three " + ("x" * 600)
+        resp = self._post_confirmed(iid, reason=reason)
+        self.assertEqual(resp.status_code, 200, resp.get_json())
+        audit_id = resp.get_json()["audit_id"]
+        _wait_job(resp.get_json()["job_id"])
+        tx = APP.transactions.get(audit_id)
+        stored = tx["metadata"]["confirmation_reason"]
+        self.assertNotIn("\n", stored)
+        self.assertNotIn("\r", stored)
+        self.assertNotIn("\t", stored)
+        self.assertLessEqual(len(stored), 500)
+
+    def test_confirmation_reason_empty_after_sanitization_is_rejected(self):
+        iid = 50003
+        self.add_item(iid)
+        resp = self._post_confirmed(iid, reason="   \n\t   ")
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["code"], "confirmation_reason_required")
+        self.assertEqual(self.beet_calls, [])
+        self.assertNotIn(iid, APP._ATTACH_RECORDING_RESERVED_ITEMS)
+
+    def test_reconstruction_exception_sanitized_in_response_and_logs(self):
+        iid = 50004
+        self.add_item(iid)
+
+        def raising_lookup(path):
+            raise RuntimeError("boom Authorization: Bearer recon-exc-secret Cookie: session=recon-cookie-secret")
+
+        with mock.patch.object(APP, "_acoustid_lookup_cached", side_effect=raising_lookup), \
+             mock.patch.object(APP.app.logger, "error") as mock_log:
+            resp = self._post_safe(iid)
+
+        self.assertEqual(resp.status_code, 503)
+        body = resp.get_json()
+        self.assertEqual(body["code"], "matching_evidence_unavailable")
+        self.assertNotIn("detail", body)
+        rendered = json.dumps(body)
+        self.assertNotIn("recon-exc-secret", rendered)
+        self.assertNotIn("recon-cookie-secret", rendered)
+
+        self.assertTrue(mock_log.called)
+        logged = " ".join(str(a) for call in mock_log.call_args_list for a in call.args)
+        self.assertNotIn("recon-exc-secret", logged)
+        self.assertNotIn("recon-cookie-secret", logged)
+        self.assertNotIn(iid, APP._ATTACH_RECORDING_RESERVED_ITEMS)
+
+    def test_stderr_secrets_from_failed_stage_never_leak(self):
+        iid = 50005
+        self.add_item(iid)
+        self.stage_rc[(iid, "modify")] = 1
+        resp = self._post_safe(iid)
+        audit_id = resp.get_json()["audit_id"]
+        _wait_job(resp.get_json()["job_id"])
+        tx = APP.transactions.get(audit_id)
+        rendered = json.dumps(tx)
+        self.assertNotIn("subprocess-stderr-secret", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_import_review_attach_integrity.py
+++ b/tests/test_import_review_attach_integrity.py
@@ -26,8 +26,10 @@ Reuses the fixtures/module import from test_import_review_attach_enforcement
 import json
 import os
 import threading
+import time
 import unittest
 import unittest.mock as mock
+import uuid
 from types import SimpleNamespace
 
 from tests.test_import_review_attach_enforcement import (
@@ -612,6 +614,195 @@ class SecuritySanitizationTests(_AttachIntegrityTestCase):
         tx = APP.transactions.get(audit_id)
         rendered = json.dumps(tx)
         self.assertNotIn("subprocess-stderr-secret", rendered)
+
+    def test_long_password_in_confirmation_reason_redacted_not_truncated_away(self):
+        # A prior pass fixed a fail-open bug where the URL-credential regex
+        # was length-capped at 256 chars per segment: a password longer than
+        # that survived redaction entirely (it wasn't merely truncated by
+        # the separate ~500-char confirmation_reason bound -- it was never
+        # matched at all). This proves a long password is actually redacted
+        # by _redact_security_text before the ~500-char bound in
+        # _sanitize_confirmation_reason ever truncates anything.
+        iid = 50006
+        self.add_item(iid)
+        long_password = _unique_secret(350, "longpw")
+        reason = f"See https://svcuser:{long_password}@example.test/path for context."
+        self.assertLess(len(reason), APP._CONFIRMATION_REASON_MAX_LEN,
+                         "test reason must fit under the bound unmodified so truncation isn't a confound")
+        resp = self._post_confirmed(iid, reason=reason)
+        self.assertEqual(resp.status_code, 200, resp.get_json())
+        audit_id = resp.get_json()["audit_id"]
+        _wait_job(resp.get_json()["job_id"])
+        tx = APP.transactions.get(audit_id)
+        stored = tx["metadata"]["confirmation_reason"]
+        self.assertNotIn(long_password, stored)
+        self.assertIn("example.test", stored)
+        self._assert_no_secrets(resp.get_json(), tx, tx.get("logs"), tx.get("changes"), tx.get("metadata"))
+        self.assertNotIn(long_password, json.dumps(tx))
+
+    def test_long_username_in_confirmation_reason_redacted(self):
+        iid = 50007
+        self.add_item(iid)
+        long_username = _unique_secret(300, "longuser")
+        reason = f"Credential was https://{long_username}:shortpw@example.test/ -- reviewed and reattached."
+        resp = self._post_confirmed(iid, reason=reason)
+        self.assertEqual(resp.status_code, 200, resp.get_json())
+        audit_id = resp.get_json()["audit_id"]
+        _wait_job(resp.get_json()["job_id"])
+        tx = APP.transactions.get(audit_id)
+        stored = tx["metadata"]["confirmation_reason"]
+        self.assertNotIn(long_username, stored)
+        self.assertNotIn("shortpw", stored)
+        self.assertIn("example.test", stored)
+
+    def test_candidate_reconstruction_exception_long_password_not_leaked(self):
+        iid = 50008
+        self.add_item(iid)
+        long_password = _unique_secret(400, "reconpw")
+
+        def raising_lookup(path):
+            raise RuntimeError(f"boom https://svcuser:{long_password}@internal.example/api")
+
+        with mock.patch.object(APP, "_acoustid_lookup_cached", side_effect=raising_lookup), \
+             mock.patch.object(APP.app.logger, "error") as mock_log:
+            resp = self._post_safe(iid)
+
+        self.assertEqual(resp.status_code, 503)
+        body = resp.get_json()
+        self.assertEqual(body["code"], "matching_evidence_unavailable")
+        rendered = json.dumps(body)
+        self.assertNotIn(long_password, rendered)
+
+        self.assertTrue(mock_log.called)
+        logged = " ".join(str(a) for call in mock_log.call_args_list for a in call.args)
+        self.assertNotIn(long_password, logged)
+
+        txs, _total = APP.transactions.list(limit=500)
+        self.assertNotIn(long_password, json.dumps(txs))
+        self.assertNotIn(iid, APP._ATTACH_RECORDING_RESERVED_ITEMS)
+
+
+# ── URL-credential redaction: direct unit coverage + adversarial perf ─────────
+
+def _unique_secret(length, tag):
+    """A unique, deterministic-enough-for-assertions secret value of an
+    exact character length, built from a random UUID rather than a
+    predictable literal like "password" -- so a passing assertion proves the
+    redactor actually matched this specific generated value, not merely that
+    some common keyword vanished. Only uses characters that are legal in
+    both the URL username and password grammar exercised here (no '/', '@',
+    ':', or whitespace)."""
+    base = f"{tag}-{uuid.uuid4().hex}-{uuid.uuid4().hex}"
+    if len(base) >= length:
+        return base[:length]
+    return (base * ((length // len(base)) + 1))[:length]
+
+
+@unittest.skipIf(APP is None, f"app.py could not be imported: {_APP_IMPORT_ERROR}")
+class URLCredentialRedactionUnitTests(unittest.TestCase):
+    """Direct coverage of _redact_security_text() / _URL_CREDENTIALS_RE,
+    independent of the attach-recording HTTP flow. A prior review pass
+    capped the username/password segments at 256 chars each to satisfy a
+    CodeQL polynomial-backtracking warning, but that cap made the regex
+    fail to match -- and therefore fail to redact -- any credential longer
+    than 256 chars. The fix removes the cap; because the username character
+    class already excludes ':', the ':' delimiter between username and
+    password is unambiguous without a length bound, so removing the cap
+    does not reintroduce backtracking risk."""
+
+    def test_short_url_credentials_are_redacted(self):
+        secret_user = _unique_secret(8, "u")
+        secret_pass = _unique_secret(8, "p")
+        text = f"failed against https://{secret_user}:{secret_pass}@example.test/path"
+        redacted = APP._redact_security_text(text)
+        self.assertNotIn(secret_user, redacted)
+        self.assertNotIn(secret_pass, redacted)
+        self.assertIn("https://", redacted)
+        self.assertIn("example.test", redacted)
+        self.assertIn(APP._REDACTED_SECRET, redacted)
+
+    def test_long_username_over_256_chars_is_redacted(self):
+        long_username = _unique_secret(300, "user")
+        self.assertGreater(len(long_username), 256)
+        text = f"https://{long_username}:shortpw@example.test/"
+        redacted = APP._redact_security_text(text)
+        self.assertNotIn(long_username, redacted)
+        self.assertNotIn("shortpw", redacted)
+        self.assertIn("example.test", redacted)
+        self.assertIn(APP._REDACTED_SECRET, redacted)
+
+    def test_long_password_over_256_chars_is_redacted(self):
+        long_password = _unique_secret(400, "pass")
+        self.assertGreater(len(long_password), 256)
+        text = f"https://shortuser:{long_password}@example.test/"
+        redacted = APP._redact_security_text(text)
+        self.assertNotIn(long_password, redacted)
+        self.assertNotIn("shortuser", redacted)
+        self.assertIn("example.test", redacted)
+        self.assertIn(APP._REDACTED_SECRET, redacted)
+
+    def test_both_username_and_password_over_256_chars_are_redacted(self):
+        long_username = _unique_secret(500, "bothuser")
+        long_password = _unique_secret(500, "bothpass")
+        text = f"https://{long_username}:{long_password}@example.test/"
+        redacted = APP._redact_security_text(text)
+        self.assertNotIn(long_username, redacted)
+        self.assertNotIn(long_password, redacted)
+        self.assertIn("example.test", redacted)
+
+    def test_scheme_and_host_remain_readable_after_redaction(self):
+        secret_user = _unique_secret(20, "ru")
+        secret_pass = _unique_secret(300, "rp")
+        text = f"https://{secret_user}:{secret_pass}@svc.internal.example.test:8443/path?x=1"
+        redacted = APP._redact_security_text(text)
+        self.assertIn("https://", redacted)
+        self.assertIn("svc.internal.example.test", redacted)
+        self.assertIn(":8443/path?x=1", redacted)
+
+    def test_redaction_is_idempotent_on_repeated_application(self):
+        secret_user = _unique_secret(20, "iu")
+        secret_pass = _unique_secret(300, "ip")
+        text = f"https://{secret_user}:{secret_pass}@example.test/"
+        once = APP._redact_security_text(text)
+        twice = APP._redact_security_text(once)
+        thrice = APP._redact_security_text(twice)
+        self.assertEqual(once, twice)
+        self.assertEqual(twice, thrice)
+        self.assertNotIn(secret_user, thrice)
+        self.assertNotIn(secret_pass, thrice)
+
+    def test_adversarial_colon_heavy_input_completes_quickly(self):
+        # Regression guard for the original CodeQL-flagged catastrophic
+        # backtracking: an attacker-controlled string with many ':'
+        # characters between "://" and a trailing "@" used to risk
+        # exponential/polynomial-time matching attempts if username and
+        # password segments could both stretch across the same ':'.
+        # Because the username class excludes ':', the engine can only ever
+        # take the username up to the *first* ':' and must hand everything
+        # else to the (':'-permitting) password segment in one pass -- this
+        # must stay true, and stay fast, whether or not either segment is
+        # length-capped.
+        text = "https://" + ("a:" * 50000) + "@example.test/"
+        start = time.monotonic()
+        redacted = APP._redact_security_text(text)
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, 1.0,
+                         f"redaction of adversarial input took {elapsed:.3f}s -- possible backtracking regression")
+        self.assertIn("example.test", redacted)
+        self.assertIn(APP._REDACTED_SECRET, redacted)
+        self.assertNotIn("a:a:a", redacted)
+
+    def test_adversarial_input_with_no_trailing_at_sign_completes_quickly(self):
+        # Same adversarial shape but with NO terminating '@', so the regex
+        # engine must give up on the match entirely after scanning -- the
+        # worst case for a backtracking-prone pattern. Must still be fast.
+        text = "https://" + ("a:" * 50000) + "not-a-credential-suffix"
+        start = time.monotonic()
+        redacted = APP._redact_security_text(text)
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, 1.0,
+                         f"redaction of unterminated adversarial input took {elapsed:.3f}s -- possible backtracking regression")
+        self.assertEqual(redacted, APP._CONTROL_CHAR_RE.sub("?", text))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Rebase note (2026-07-22)

Rebased cleanly onto current `main` (`30fb80942a8a311cde570a9176f68204227c40e7`), which now includes PR #18 (dependency security remediation), #20 (fresh-install Beets plugin packaging), #21 (manual MusicBrainz ID validation + optional-AI UX), #23 (CodeQL exception sanitization), #24 (truthful/redacted Beets plugin diagnostics), and #25 (shared Bearer/Basic redaction fix in `_redact_security_text`). New head: `9174c3bfa03698110b9106121f398daf71b15fb1`.

Only one rebase conflict, in `frontend/src/features/importReview/ImportReviewPage.tsx`'s `runApply` catch block: current `main` (PR #21) added an `optionalAiWarning(message)` fallback so AI-unavailability errors surface as warnings instead of hard errors; this branch's original commit replaced the same catch block to intercept `review_confirmation_required` and open the confirm-review dialog. Resolved by keeping both, in order -- check for `review_confirmation_required` first (attach-recording specific), then fall through to the existing `optionalAiWarning` handling for every other error. `app.py`, `backend/matching_contract.py`, `frontend/src/api/client.ts`, and `frontend/src/api/types.ts` merged automatically with no conflicts; diffed each against `main` post-rebase to confirm the merge was purely additive (no unrelated `main` behavior reverted, no second matching-contract implementation introduced -- `backend/matching_contract.py`'s only change is the new, additive `compute_decision_version()` helper; `build_recording_matching_decision` is untouched).

Changed files after rebase, unchanged from the original PR's scope: `app.py`, `backend/matching_contract.py`, `frontend/src/api/client.ts`, `frontend/src/api/types.ts`, `frontend/src/features/importReview/ImportReviewPage.tsx`, `tests/test_import_review_attach_enforcement.py`.

## Fourth review pass (2026-07-22) -- concurrency + integrity hardening

New head: **`f71cd2c6fedc0843a9c43c8b40ebc7bd25046ebd`**. Builds on the rebase above; fixes the seven blockers from that pass's review: no per-item reservation (race), lenient beet subprocess outcomes, secret leakage (raw exceptions + unsanitized confirmation reason), untruthful "Completed" claims, a weak `decision_version` fingerprint, missing structured error codes on early validation, and thin test coverage for all of the above.

### Per-item reservation (concurrency)

`_reserve_attach_recording_item()` / `_release_attach_recording_item()` (`app.py`) maintain a process-local `set` of reserved Beets item ids guarded by `_ATTACH_RECORDING_RESERVATIONS_LOCK` -- deliberately **not** the global `_IMPORT_JOB_LOCK` (rejected in the prior pass as too broad) and not a global attachment lock. `/api/items/<iid>/attach-recording` reserves the item immediately after basic payload validation (before the idempotency check), re-reads the Beets item once the reservation is held, and reruns candidate reconstruction / decision / idempotency checks against that fresh read -- never a snapshot taken before the reservation. The reservation is released:
- in the request handler's `finally` for every early-validation/error return (`job_started` stays `False`);
- in the async job's own `finally`, covering success, ordinary failure, cancellation, and timeout;
- if `jobs.start_python()` itself raises (job-creation failure).

A second request for the **same** item while the first is in flight gets `409 attachment_in_progress` immediately, without touching candidate reconstruction or `beet`. Two requests for **different** items proceed fully in parallel -- no global serialization.

### Strict beet subprocess outcomes

`_beet_run()` can return `0` (success), `-9` (cancelled), `124` (timeout), or another nonzero (failure). Previously only `modify` failure was fatal; `mbsync`/`write`/`move` failures were logged as warnings and treated as success. Now a shared helper enforces strict semantics for all four stages, in both the attach job and the recording-ID rollback executor:

```python
class AttachRecordingCancelled(RuntimeError): ...

def _require_attach_stage_success(result, stage: str) -> None:
    if result.returncode == 0: return
    if result.returncode == -9: raise AttachRecordingCancelled(f"{stage} cancelled")
    if result.returncode == 124: raise RuntimeError(f"{stage} timed out")
    raise RuntimeError(f"{stage} failed")
```

Any non-zero outcome stops the sequence immediately (no later stage runs). Cancellation marks the transaction `Cancelled` (a status the transaction model already supports); timeout/failure mark it `Failed`. Never `Completed` for either. No raw stderr, command lines, or paths surface in the transaction/response -- only the stage name and outcome kind.

### Rollback truthfulness

`_run_item_recording_id_restore()` now returns `True` only when every required stage (`modify`, conditional `mbsync`, `write`, `move`) actually returned `0`; any cancellation/timeout/failure returns `False` and the "Restored recording identity" log line is never appended for it. The existing `/api/transactions/<id>/rollback` executor already treats a `False` restore as `failed_count += 1`, so it now correctly lands on `Partially Rolled Back` (never `Rolled Back`) when the restore didn't actually complete -- previously it always reported success once `modify` returned a "tolerated" code. The metadata-only-rollback limitation (no filesystem snapshot) is unchanged.

### Secret leakage removed

- The route no longer returns `"detail": str(exc)` from a candidate-reconstruction failure -- only `{"error": "Unable to rebuild trusted MusicBrainz/AcoustID evidence for this item.", "code": "matching_evidence_unavailable"}` (503). The real exception is logged internally via `app.logger.error` with the exception type name plus `_redact_security_text(str(exc))[:300]` (control chars stripped, secret-shaped substrings redacted, length-bounded).
- New `_sanitize_confirmation_reason()` (`app.py`) is applied to `confirmation_reason` before it touches anything: strips/normalizes `\r`/`\n`/tabs to a single line, runs `_redact_security_text()`, collapses whitespace, bounds to 500 chars, and an empty result after sanitization correctly triggers the existing `confirmation_reason_required` error. The sanitized value is what's stored in the transaction reason, per-change reason, transaction metadata, and job logs -- the raw value is never stored or logged.
- `_redact_security_text()` gained a new `_URL_CREDENTIALS_RE` pass that redacts userinfo credentials embedded directly in a URL (`https://user:password@host/`) -- the existing `key: value` pattern never matched that shape.
- `_beet_run`'s stderr is intentionally never included in any user-visible or logged text for these two workflows.

### Persisted-state verification (no more claiming candidate-expected identity)

After all four beet stages return `0`, the job invalidates the library cache, re-reads the item, and reads the **actual** `mb_trackid`/`mb_albumid`/`mb_releasegroupid`:
- if the actual `mb_trackid` doesn't equal the requested Recording ID, the transaction is marked `Failed` (never `Completed`) -- the attachment is not claimed to have succeeded;
- Release/Release-Group ID are compared against the candidate's expected values; a mismatch adds a truthful log warning and `release_identity_mismatch` / `release_group_identity_mismatch` transaction-metadata flags, but does **not** fail the job by itself (Recording ID correct + a differing-but-legitimate release context is allowed) -- the audit records the *actual* values, never silently substituting the candidate's expectation.

The transaction's `changes[0]` entry is updated post-verification so `current_metadata` stays the real before-snapshot, `new_metadata`/`metadata_diff` reflect the actual persisted identity, and `metadata.candidate_identity` / `metadata.persisted_identity` are stored separately (also mirrored at the transaction's top-level `metadata`):

```python
{"candidate_identity": {...requested...}, "persisted_identity": {...actually re-read...}}
```

`Completed` is only ever set after this verification succeeds.

### `decision_version` (drv2)

`compute_decision_version()` (`backend/matching_contract.py`) now fingerprints a much wider, still-sanitized projection: item id, resolved/evaluated Recording IDs, Release/Release-Group IDs, conflicts, warnings, review/confirmation flags, safety key, confidence score, `action_eligibility.{attach_without_review,destructive_use}`, eligibility reason, candidate source, and AcoustID fingerprint provenance (`attempted`/`matched`/`status`/`mapped_recording_id`). Schema marker bumped `drv1:` -> `drv2:`. No raw provider payloads, secrets, timestamps, or candidate display order are included. A `drv1:` value submitted against the new schema simply never equals a freshly computed `drv2:` value, so it's correctly rejected via the existing `matching_decision_stale` comparison -- no separate schema-version-detection branch was needed. Safe mode is unaffected: it still fully recomputes the decision at mutation time and only checks the version when one is supplied.

### New structured error codes

- `review_item_not_found` (404) -- item missing, checked both before and after the reservation is acquired.
- `recording_id_required` (400) -- `mb_trackid` missing.
- `invalid_recording_id` (400) -- `mb_trackid` fails UUID format validation.
- `attachment_in_progress` (409) -- per-item reservation held by another in-flight request.
- `attachment_job_start_failed` (500, additive/new) -- `jobs.start_python()` raised; reservation is released.

All previously-existing codes (`invalid_mode`, `candidate_not_in_trusted_set`, `matching_evidence_unavailable`, `matching_decision_stale`, `recording_id_mismatch`, `review_confirmation_required`, `confirmation_reason_required`) are unchanged.

### Frontend (minimal, as scoped)

`ImportReviewPage.tsx`'s `runApply`/`runConfirmedAttach` catch handlers now special-case `attachment_in_progress` (shown as a concise warning, never opens the confirm dialog) and `matching_decision_stale` (shown as a clear "refresh the review item" warning) ahead of the generic error fallback. No safety/eligibility calculation was added client-side; the confirm dialog itself is unchanged.

### Post-push CodeQL fix

CI's CodeQL scan flagged the new `_URL_CREDENTIALS_RE` (added for the URL-userinfo-credential redaction above) as a polynomial-time regex on attacker-controlled input: both the username and password segments were unbounded `[^\s/@]+` classes that both included `:`, so a string with many repeated `a:` runs had multiple ambiguous ways to split at each colon. Fixed by excluding `:` from the username segment (removing the ambiguity that caused backtracking) and capping both segments to 256 chars as defense in depth. Verified with a 50,000-repetition adversarial input (sub-5ms) and reran the full attach suite (46 tests) 5x plus `test_security_hardening` -- all green. CodeQL now passes clean on the new head.

## Fifth review pass (2026-07-23) -- long-credential fail-open fix + rebase onto `main` (now containing PR #26)

New head: **`14ee6320c298cf12dea32bdfc5ce2c605248b2d5`**.

### Long-URL-credential redaction fail-open, fixed

The fourth pass's CodeQL fix capped `_URL_CREDENTIALS_RE`'s username/password segments at 256 chars each to resolve a polynomial-backtracking warning. That cap was itself a bug: it made the regex **fail to match** (and therefore fail to redact) any URL credential longer than 256 chars, so a long username or password embedded in a confirmation reason, transaction reason/metadata, change record, or a sanitized internal exception log would survive verbatim. Fixed by removing the length cap entirely rather than tuning it:

```python
_URL_CREDENTIALS_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^\s/@:]+:[^\s/@]+@")
```

The username character class already excludes `:` -- that exclusion, not a length cap, is what makes the `:` delimiter between username and password unambiguous and is what actually rules out the original catastrophic-backtracking shape (two adjacent unbounded runs both able to stretch across the same `:`). With the username forced to stop at the first `:`, the engine takes it in one pass with no backtracking, regardless of how long the remainder is. The ambiguous form that allowed `:` in the *username* (the original root cause) was not reintroduced.

Added to `tests/test_import_review_attach_integrity.py`:
- `URLCredentialRedactionUnitTests` -- direct coverage of `_redact_security_text()`: short credentials, long (300-500 char) username, long (300-500 char) password, both long simultaneously, scheme/host readability preserved, idempotent on repeated application, and two adversarial-performance tests (a 100,000-char colon-heavy credential run, with and without a terminating `@`) each asserting completion in well under 1 second.
- Three new tests in `SecuritySanitizationTests` covering the confirmation-reason path specifically: a 350-char password and a 300-char username each embedded in a reason that still fits under the existing 500-char bound (proving redaction, not truncation, removed the secret), and a candidate-reconstruction exception carrying a 400-char password verified absent from the API response, the `app.logger.error` call, and transaction state.
- All new secret values are per-test UUID-derived and unique (never the literal word "password"); assertions check for the exact generated value's absence, not just a keyword.

Actual measured redaction time on the 100,000-char adversarial input: ~0.8ms (with trailing `@example.test/`) and ~11ms (unterminated, worst case for a backtracking-prone pattern) -- both far under the 1-second bound asserted in the test.

### Rebase onto `main` (PR #26 merged)

`main` has since merged PR #26 (screenshot-tour docs), which this branch's own top commit (`514adb3`, "docs: add app screenshot tour") duplicated. `git rebase origin/main` auto-detected that commit's patch as already upstream and dropped it on its own (git reported "dropping ... patch contents already upstream"; no manual `--skip` or conflict resolution was needed). The screenshot files themselves are untouched -- they come from `main` post-rebase and remain present and intact in the working tree (`screenshots/README.md`, `import-review-queue.jpg`, `import-source.jpg`, `jobs.jpg`, `library-changes.jpg`, `library.jpg`, `playlists.jpg`, `settings.jpg`, `submissions.jpg`); they simply no longer appear as a duplicate/second copy in this PR's diff. No other conflicts. Final scope vs. `main` is unchanged from the post-fourth-pass rebase: `app.py`, `backend/matching_contract.py`, `frontend/src/api/client.ts`, `frontend/src/api/types.ts`, `frontend/src/features/importReview/ImportReviewPage.tsx`, `tests/test_import_review_attach_enforcement.py`, `tests/test_import_review_attach_integrity.py`.

## What changes

- `/api/items/<iid>/attach-recording` now reconstructs the trusted AcoustID/MusicBrainz candidate set for the item at request time (mirroring `/api/items/<iid>/ai-suggest`'s pipeline) and derives the PR #16 matching-contract decision itself. It never trusts a client-supplied safety/confidence/eligibility field.
- Two explicit backend-controlled modes:
  - **`safe`** (default): requires the requested Recording ID to equal the backend-resolved ID, `attach_without_review == true`, no `review_required`/`requires_confirmation`, and no conflicts.
  - **`confirmed_review`**: requires `confirm: true`, a non-empty `confirmation_reason`, and a `decision_version` matching the current recomputed decision. The Recording ID must still be present in the current trusted candidate set. Confirmation only ever authorizes attaching that Recording ID -- never any destructive follow-on action.
- Arbitrary UUIDs outside the current trusted candidate set are rejected in both modes -- including UUIDs a user just successfully validated through the manual MusicBrainz ID workflow (PR #21). Manual ID validation is read-only evidence lookup; it never grants attach eligibility by itself, and there is no separate manual-attachment endpoint. A manually entered Recording ID can only be attached by independently reappearing in this same AcoustID/MusicBrainz-search trusted-candidate reconstruction.
- Stale decisions (candidate state changed since displayed) return `409 matching_decision_stale`.
- Every attach mutation is audited via the existing `TransactionStore` (`operation_type="MusicBrainz Match"`), with a before/after identity diff and a new `recording_id_restore` rollback operation wired into the existing `/api/transactions/<id>/rollback` executor (restores prior Recording/Release/Release-Group IDs and re-syncs/re-writes/re-moves the file).
- The endpoint is idempotent: if the item's tags already match the requested identity, it returns `{"ok": true, "changed": false, "reason": "already_attached"}` without starting a job or writing a new audit record.
- Frontend: `attachRecording()` now always sends `mode: "safe"`; a new `confirmAttachRecording()` call plus a dedicated confirm dialog (showing conflicts/warnings and requiring a typed reason) handle the `review_confirmation_required` case. The frontend never recalculates safety/eligibility -- it only displays backend-provided values.

## What does not change

- Playlist matching, Library Cleanup, Replacement, MusicBrainz/AcoustID submission, Plex sync, downloaders, and all other matching callers -- still unmigrated, out of scope for this PR.
- The unrelated `yt-dlp` background `NameError`.
- `backend/matching_contract.py`'s existing decision logic (`build_recording_matching_decision`) -- only the new `compute_decision_version()` helper was added, strictly for this consumer.
- The matching contract / job architecture / global job system are untouched; no redesign of the attach dialog.

## Known limitations

- Rollback restores identity fields and re-runs modify+mbsync+write+move, but (like the rest of this job architecture) does not restore file-level backups; it's a metadata/identity rollback, not a full filesystem snapshot restore.

(The previously-documented same-item concurrency race is now fixed -- see "Per-item reservation" above -- and is no longer an accepted limitation.)

## Test plan

- [x] `tests/test_import_review_attach_enforcement.py`: 23 tests (unchanged count; fixtures updated so the shared fake `_beet_run` actually mutates the fake item on `modify`/`mbsync`, required by the new persisted-state verification, plus reservation-state cleanup between tests).
- [x] `tests/test_import_review_attach_integrity.py`: 34 tests (was 23; +11 new in the fifth pass) -- per-item reservation/concurrency (a-h: safe+safe, safe+confirmed, confirmed+confirmed same-item 409; different-item parallelism; release-after-success/failure/cancellation/job-start-failure), strict subprocess outcomes (all 4 attach stages x {cancel,timeout,failure} = 12 subtests, plus rollback stage-outcome and rollback-mbsync-with-prior-id coverage), persisted-state verification (correct/failed-to-persist/different-release-id/missing-RGID), the 3 new structured error codes, secret sanitization (Bearer/Cookie/api_key/URL-credential injection into confirmation reason and reconstruction exceptions, multiline/oversized/empty-after-sanitization reasons, stderr-secret leakage), and (new) direct + confirmation-reason + reconstruction-exception coverage of the long-URL-credential fail-open fix plus two adversarial-performance regression tests.
- [x] Combined attach suite (**57 tests**, up from 46) run 5x consecutively: **OK every time, zero flakiness.**
- [x] Security-focused (`test_security_hardening`, `test_routes_setup`, `test_import_review_manual_id_workflow`, `test_import_review_recording_id_frontend`): **79 tests, OK.**
- [x] Matching/transaction regression modules (`test_matching_contract`, `test_transaction_engine`, `test_transaction_integration`, `test_ai_batch_retry_race`, `test_ai_batch_import_reliability`, `test_review_queue_singleton_items`): **267 tests, OK.**
- [x] Full `unittest discover -s tests -p "test_*.py"` run twice post-rebase: **1202 tests, OK (1 skipped)** both times (count includes the 11 new tests above; up from 1191 pre-fifth-pass).
- [x] `py_compile app.py backend/matching_contract.py`, `security_secret_scan.py`, `validate_compose_security.py`, `git diff --check origin/main...HEAD`, `git status --short` all clean.
- [x] Frontend (`npm ci`/`npm run typecheck`/`npm run lint`/`npm run build`) all clean. `npm audit --audit-level=high`: **1 high-severity finding** (Next.js 16.0.0-16.2.10 advisory cluster, fix available via `next@16.2.11`) -- pre-existing on `main`, not introduced by this PR (`frontend/package.json`/`package-lock.json` are untouched in this branch's diff); left as-is per this pass's scope (redaction fix + rebase cleanup only, no unrelated dependency bumps).
- [x] Docker: `RUN_DOCKER_SMOKE=1 python -m unittest tests.test_beets_fresh_install_plugins.BeetsFreshInstallDockerSmokeTests` -- image built successfully and smoke test passed (OK, 1 test, ~179s).



## Sixth review pass (2026-07-23) -- rebase onto main (PR #30 merged, Next.js 16.2.11)

New base: `ca2f4054650eb4af209073df990643b5cb168ff1` (PR #30, "fix: bump Next.js to 16.2.11 for high-severity advisory cluster"). New head: **`d432c5e0ebb5442eed6a2c6b6621e3cac2afaa90`**. `git rebase origin/main` was clean -- no conflicts; `app.py`, `backend/matching_contract.py`, both frontend client/types files, `ImportReviewPage.tsx`, and both test files carried forward unchanged against the new base. `frontend/package.json`/`package-lock.json` and the screenshot assets remain absent from this PR's diff (they're `main`-only, via PR #30/#26).

`npm audit --audit-level=high`: **0 vulnerabilities** (previously 1 high, inherited from pre-#30 `main`).

Full validation re-run against the new base:
- Combined attach suite (57 tests), run 5 consecutive times: **OK every time.**
- Targeted regression modules (`test_matching_contract`, `test_import_review_recording_id_frontend`, `test_import_review_manual_id_workflow`, `test_review_queue_singleton_items`, `test_ai_batch_retry_race`, `test_ai_batch_import_reliability`, `test_routes_setup`, `test_security_hardening`, `test_transaction_engine`, `test_transaction_integration`): **346 tests, OK.**
- Full `unittest discover -s tests -p "test_*.py"`, run twice: **1215 tests, OK (1 skipped)** both times.
- `py_compile`, `security_secret_scan.py`, `validate_compose_security.py`, `git diff --check origin/main...HEAD`, `git status --short`: all clean.
- Frontend (`npm ci`/`typecheck`/`lint`/`build`): all clean.
- Docker (`RUN_DOCKER_SMOKE=1`, `BeetsFreshInstallDockerSmokeTests`): OK.
- All 16 CI checks green on the new head (CodeQL x3, build x2, compose-verification x2, frontend-lint x2, frontend-typecheck x2, python-tests x2, security x2).

PR remains open and draft for final independent review; not merged.
