### PR TITLE
fix: improve import review manual matching and optional AI

### DIFF
--- a/app.py
+++ b/app.py
@@ -17093,6 +17093,234 @@ def candidate_tracks(mb_albumid: str):
     status = 200 if payload.get("ok") else 400
     return jsonify(payload), status
 
+
+_MB_ENTITY_PATH_RE = re.compile(
+    r"(?:^|/)("
+    r"release-group|release|recording"
+    r")/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:$|[/?#])",
+    re.I,
+)
+
+
+def _parse_manual_musicbrainz_identifier(raw_value: Any) -> Dict[str, str]:
+    text = _s(raw_value).strip()
+    if not text:
+        return {"ok": False, "error": "Enter a MusicBrainz UUID or URL."}
+    match = _MB_ENTITY_PATH_RE.search(text)
+    if match:
+        entity = match.group(1).lower()
+        return {"ok": True, "entity_type": entity, "mbid": match.group(2).lower()}
+    uuid_match = re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        text,
+        re.I,
+    )
+    if not uuid_match:
+        return {"ok": False, "error": "This is not a valid MusicBrainz UUID or URL."}
+    return {"ok": True, "entity_type": "unknown", "mbid": uuid_match.group(0).lower()}
+
+
+def _manual_review_album_folder(payload: Dict[str, Any]) -> str:
+    folder = _s(payload.get("path") or "").strip()
+    if folder:
+        return folder
+    existing_album_id = int(payload.get("existing_album_id") or payload.get("album_id") or 0)
+    return _album_folder_for_album_id(existing_album_id) if existing_album_id else ""
+
+
+def _manual_review_wrong_type_response(target_kind: str, entity_type: str) -> Tuple[Dict[str, Any], int]:
+    required = "Recording ID" if target_kind == "item" else "album Release or Release Group ID"
+    article = "a" if entity_type.lower().startswith(("release", "recording")) else "an"
+    return {
+        "ok": False,
+        "entity_type": entity_type,
+        "error": f"This ID is {article} {entity_type.replace('-', ' ').title()} ID, but this review item requires {required}.",
+    }, 400
+
+
+def _manual_review_validate_album_identifier(parsed: Dict[str, str], payload: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
+    entity_type = parsed.get("entity_type") or "unknown"
+    mbid = parsed.get("mbid") or ""
+    folder = _manual_review_album_folder(payload)
+    log: List[str] = []
+    release_group_candidates: List[Dict[str, Any]] = []
+    if entity_type == "recording":
+        return _manual_review_wrong_type_response("album", "Recording")
+
+    resolved_release_id = ""
+    release_group_id = ""
+    if entity_type in {"release", "unknown"}:
+        tracklist = _fetch_mb_release_tracklist(mbid, log)
+        if tracklist.get("ok"):
+            resolved_release_id = mbid
+            release_group_id = _extract_mb_uuid(tracklist.get("release_group", ""))
+            entity_type = "release"
+    if not resolved_release_id and entity_type in {"release-group", "unknown"}:
+        release_group_id = mbid
+        release_group_candidates = _mb_release_group_candidates(release_group_id, log)
+        if release_group_candidates:
+            resolved_release_id = _s(release_group_candidates[0].get("mb_albumid") or "").strip().lower()
+        if not resolved_release_id:
+            resolved_release_id = _resolve_release_group_to_release(
+                release_group_id,
+                log,
+                track_count=_folder_import_track_count(folder),
+            )
+        if resolved_release_id:
+            entity_type = "release-group"
+
+    if not resolved_release_id:
+        if entity_type == "release":
+            return {"ok": False, "entity_type": entity_type, "error": "MusicBrainz release lookup failed."}, 404
+        if entity_type == "release-group":
+            return {"ok": False, "entity_type": entity_type, "error": "MusicBrainz release group lookup returned no usable releases."}, 404
+        details = _fetch_mb_recording_details(mbid)
+        if details.get("recording_id"):
+            return _manual_review_wrong_type_response("album", "Recording")
+        return {"ok": False, "entity_type": "unknown", "error": "MusicBrainz did not return a release or release group for this ID."}, 404
+
+    comparison = _candidate_track_comparison_payload(
+        resolved_release_id,
+        folder,
+        release_group_id=release_group_id if entity_type == "release-group" else "",
+    )
+    if not comparison.get("ok"):
+        error = _s(comparison.get("error") or "MusicBrainz ID validation failed.")
+        return {
+            "ok": False,
+            "entity_type": entity_type,
+            "mbid": mbid,
+            "representative_release_id": resolved_release_id,
+            "release_group_id": release_group_id,
+            "error": error,
+        }, 400
+    representative_release_id = _extract_mb_uuid(
+        _s(comparison.get("representative_release_id") or comparison.get("mb_albumid") or resolved_release_id)
+    )
+    acoustic_preflight = _run_ai_release_preflight(
+        folder,
+        representative_release_id,
+        existing_album_id=int(payload.get("existing_album_id") or payload.get("album_id") or 0),
+    ) if representative_release_id else None
+    preflight = _import_review_revalidation_preflight(comparison, acoustic_preflight)
+    selected_match = _import_review_build_revalidated_match(
+        {
+            "suggestion": {
+                "mb_releasegroupid": release_group_id,
+                "representative_mb_albumid": representative_release_id,
+                "mb_albumid": representative_release_id,
+            },
+            "artist": _s(payload.get("artist") or ""),
+            "album": _s(payload.get("album") or ""),
+            "folder_name": Path(folder).name if folder else "",
+            "year": _s(payload.get("year") or ""),
+        },
+        comparison,
+        preflight,
+    )
+    selected_match["source"] = "manual"
+    release_group_id = selected_match.get("release_group_id") or release_group_id
+    representative_release_id = selected_match.get("representative_release_id") or representative_release_id or resolved_release_id
+    matched = int(selected_match.get("track_match_count") or 0)
+    local_count = int(selected_match.get("local_track_count") or 0)
+    total = int(selected_match.get("total_tracks") or 0)
+    status_lines = [
+        "Checking MusicBrainz ID...",
+        "Valid release" if entity_type == "release" else "Valid release group",
+        f"Resolved release group {release_group_id}" if release_group_id else "Release group could not be resolved",
+        f"Comparing {local_count} local file{'' if local_count == 1 else 's'} with {total} MusicBrainz track{'' if total == 1 else 's'}...",
+        f"{matched} matched, {max(0, total - matched)} need review",
+    ]
+    return {
+        "ok": True,
+        "entity_type": entity_type,
+        "input_mbid": mbid,
+        "release_group_id": release_group_id,
+        "representative_release_id": representative_release_id,
+        "musicbrainz_url": (
+            f"https://musicbrainz.org/release-group/{release_group_id}"
+            if entity_type == "release-group"
+            else f"https://musicbrainz.org/release/{representative_release_id}"
+        ),
+        "selected_match": selected_match,
+        "track_comparison": comparison,
+        "release_group_candidates": release_group_candidates[:12],
+        "status_lines": status_lines,
+        "message": selected_match.get("preflight_reason") or "Manual MusicBrainz ID validated.",
+    }, 200
+
+
+def _manual_review_validate_recording_identifier(parsed: Dict[str, str], payload: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
+    entity_type = parsed.get("entity_type") or "unknown"
+    mbid = parsed.get("mbid") or ""
+    if entity_type in {"release", "release-group"}:
+        return _manual_review_wrong_type_response("item", entity_type)
+    details = _fetch_mb_recording_details(mbid)
+    if not details.get("recording_id"):
+        if entity_type == "recording":
+            return {"ok": False, "entity_type": "recording", "error": "MusicBrainz recording lookup failed."}, 404
+        tracklist = _fetch_mb_release_tracklist(mbid, [])
+        if tracklist.get("ok"):
+            return _manual_review_wrong_type_response("item", "Release")
+        if _mb_release_group_candidates(mbid, []):
+            return _manual_review_wrong_type_response("item", "Release Group")
+        return {"ok": False, "entity_type": "unknown", "error": "MusicBrainz did not return a recording for this ID."}, 404
+
+    item_id = int(payload.get("item_id") or 0)
+    item = lib.get_item(item_id) if item_id else None
+    current = {
+        "title": _s(getattr(item, "title", "") or ""),
+        "artist": _s(getattr(item, "artist", "") or ""),
+        "album": _s(getattr(item, "album", "") or ""),
+        "albumartist": _s(getattr(item, "albumartist", "") or ""),
+        "year": _s(getattr(item, "year", "") or ""),
+        "duration_seconds": float(getattr(item, "length", 0) or 0) if item else 0,
+        "mb_releasegroupid": _s(getattr(item, "mb_releasegroupid", "") or ""),
+    }
+    candidate = {
+        "mb_trackid": mbid,
+        "source": "manual",
+        "score": 100,
+        "title": details.get("recording_title", ""),
+        "artist": details.get("recording_artist") or details.get("artist", ""),
+        "album": details.get("album", ""),
+        "year": details.get("year", ""),
+    }
+    _enrich_track_ai_candidate(current, candidate, details)
+    packet = _compact_track_ai_candidate(candidate)
+    linked_count = len(packet.get("linked_releases") or [])
+    return {
+        "ok": True,
+        "entity_type": "recording",
+        "input_mbid": mbid,
+        "mb_trackid": mbid,
+        "musicbrainz_url": f"https://musicbrainz.org/recording/{mbid}",
+        "selected_recording_candidate": packet,
+        "recording_candidates": [packet],
+        "status_lines": [
+            "Checking MusicBrainz ID...",
+            "Valid recording",
+            f"Found {linked_count} linked release{'' if linked_count == 1 else 's'}",
+            packet.get("safety_result") or "Recording evidence ready",
+        ],
+        "message": packet.get("reason") or "Manual MusicBrainz Recording ID validated.",
+    }, 200
+
+
+@app.post("/api/import-review/manual-id/validate")
+def import_review_manual_id_validate():
+    """Resolve a user-entered MusicBrainz UUID/URL through backend-owned validation."""
+    payload = request.get_json(silent=True) or {}
+    parsed = _parse_manual_musicbrainz_identifier(payload.get("musicbrainz_id") or payload.get("mbid") or "")
+    if not parsed.get("ok"):
+        return jsonify(parsed), 400
+    target_kind = _s(payload.get("target_kind") or "").strip().lower()
+    if target_kind == "item":
+        body, status = _manual_review_validate_recording_identifier(parsed, payload)
+    else:
+        body, status = _manual_review_validate_album_identifier(parsed, payload)
+    return jsonify(body), status
+
 def _target_preview_year(value: Any) -> str:
     match = re.search(r"\d{4}", _s(value))
     return match.group(0) if match else ""

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,6 +5,8 @@ import type {
   AcquisitionQueueResponse,
   AiMatchHistoryResponse,
   AutoEnqueueImportPayload,
+  ImportReviewManualIdPayload,
+  ImportReviewManualIdResponse,
   ImportReviewRevalidatePayload,
   AutoEnqueueImportResponse,
   ImportReviewRevalidateResponse,
@@ -1141,6 +1143,10 @@ export function matchAlbum(albumId: number, mbId: string): Promise<JobStartRespo
 
 export function suggestItem(itemId: number): Promise<AiSuggestResponse> {
   return apiJson<AiSuggestResponse>(`/api/items/${itemId}/ai-suggest`, { method: 'POST' });
+}
+
+export function validateManualMusicBrainzId(payload: ImportReviewManualIdPayload): Promise<ImportReviewManualIdResponse> {
+  return apiJson<ImportReviewManualIdResponse>('/api/import-review/manual-id/validate', jsonRequest('POST', payload));
 }
 
 export function attachRecording(

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -265,6 +265,18 @@ export interface ReviewItem {
   existing_album_id?: number;
   sort_ts?: number;
   evidence?: ReviewEvidence;
+  ai_available?: boolean;
+  ai_unavailable_reason?: string;
+  matching_method?: string;
+  warnings?: string[];
+  action_eligibility?: unknown;
+  eligibility_reason?: string;
+  matching_contract?: Record<string, unknown>;
+  acoustid_corroboration?: string;
+  fingerprint_conflicts?: string[];
+  recording_id_conflicts?: string[];
+  title_mismatch_warnings?: string[];
+  required_review?: boolean;
   suggestion?: AiSuggestion;
   origin_type?: ReviewOriginType;
   origin_label?: string;
@@ -1902,6 +1914,18 @@ export interface AiSuggestion {
   source_folder?: string;
   created_by_workflow?: string;
   /** Fallback Discogs match, set only when MusicBrainz search found nothing. */
+  ai_available?: boolean;
+  ai_unavailable_reason?: string;
+  matching_method?: string;
+  warnings?: string[];
+  action_eligibility?: unknown;
+  eligibility_reason?: string;
+  matching_contract?: Record<string, unknown>;
+  acoustid_corroboration?: string;
+  fingerprint_conflicts?: string[];
+  recording_id_conflicts?: string[];
+  title_mismatch_warnings?: string[];
+  required_review?: boolean;
   discogs_candidate?: {
     discogs_id?: number | string;
     discogs_url?: string;
@@ -1922,9 +1946,98 @@ export interface AiSuggestResponse extends ApiOkResponse {
   suggestions?: AiSuggestion & { mb_trackid?: string };
   mb_candidates?: ReviewCandidate[];
   selected_candidate?: ReviewCandidate | ReviewRecordingCandidate;
+  selected_match?: ImportReviewSelectedMatch;
   recording_candidates?: ReviewRecordingCandidate[];
   acoustid_candidates?: unknown[];
   evidence?: ReviewEvidence;
+  ai_available?: boolean;
+  ai_unavailable_reason?: string;
+  matching_method?: string;
+  warnings?: string[];
+  action_eligibility?: unknown;
+  eligibility_reason?: string;
+  matching_contract?: Record<string, unknown>;
+  acoustid_corroboration?: string;
+  fingerprint_conflicts?: string[];
+  recording_id_conflicts?: string[];
+  title_mismatch_warnings?: string[];
+  required_review?: boolean;
+}
+
+export interface ImportReviewSelectedMatch {
+  release_group_id: string;
+  representative_release_id: string;
+  artist: string;
+  album: string;
+  year: string;
+  track_match_count: number | null;
+  total_tracks: number | null;
+  local_track_count: number | null;
+  track_mapping: ImportWithIdPayload['track_mapping'];
+  preflight_status: 'passed' | 'failed' | 'stale' | 'not_run';
+  preflight_reason: string;
+  is_release_group_usable: boolean;
+  is_importable: boolean;
+  is_partial_import: boolean;
+  confidence_score: number | null;
+  confidence_level: 'high' | 'medium' | 'low' | 'blocked' | 'not_importable';
+  auto_fix_eligible: boolean;
+  auto_fix_requires_review: boolean;
+  auto_fix_reason: string;
+  missing_track_count: number;
+  match_count: number | null;
+  preflight_ok: boolean | null;
+  identity_validated?: boolean;
+  candidate_identity_error?: string;
+  representative_release_group_id?: string;
+  rejected_representative_release_id?: string;
+  release_group_diagnostics?: Record<string, unknown>;
+  source: 'ai' | 'candidate' | 'manual' | 'musicbrainz_acoustid' | 'musicbrainz' | string;
+  ai_available?: boolean;
+  ai_unavailable_reason?: string;
+  matching_method?: string;
+  warnings?: string[];
+  action_eligibility?: unknown;
+  eligibility_reason?: string;
+  matching_contract?: Record<string, unknown>;
+  acoustid_corroboration?: string;
+  fingerprint_conflicts?: string[];
+  recording_id_conflicts?: string[];
+  title_mismatch_warnings?: string[];
+  required_review?: boolean;
+}
+
+export interface ImportReviewManualIdPayload {
+  review_item_id: string;
+  musicbrainz_id: string;
+  target_kind?: string;
+  path?: string;
+  album_id?: number;
+  existing_album_id?: number;
+  item_id?: number;
+}
+
+export interface ImportReviewManualIdResponse extends ApiOkResponse {
+  entity_type: 'release' | 'release-group' | 'recording' | 'unknown';
+  input_mbid?: string;
+  release_group_id?: string;
+  representative_release_id?: string;
+  mb_trackid?: string;
+  musicbrainz_url?: string;
+  selected_match?: ImportReviewSelectedMatch;
+  selected_recording_candidate?: ReviewRecordingCandidate;
+  recording_candidates?: ReviewRecordingCandidate[];
+  release_group_candidates?: Array<{
+    mb_albumid: string;
+    title: string;
+    date: string;
+    country: string;
+    status: string;
+    track_count: number;
+  }>;
+  status_lines?: string[];
+  message?: string;
+  error?: string;
 }
 
 export interface ReimportDiskPayload {

--- a/frontend/src/features/importReview/ImportReviewPage.tsx
+++ b/frontend/src/features/importReview/ImportReviewPage.tsx
@@ -40,11 +40,13 @@ import {
   suggestAlbum,
   suggestFolder,
   suggestItem,
+  validateManualMusicBrainzId,
 } from '../../api/client';
 import type {
   AiSuggestResponse,
   AiSuggestion,
   FolderStatsResponse,
+  ImportReviewManualIdResponse,
   ImportTargetPreviewResponse,
   JobStartResponse,
   RecordingLocalEvidence,
@@ -90,6 +92,16 @@ type TargetPreviewState = {
   error?: string;
 };
 
+type ManualValidationState = {
+  status: 'idle' | 'checking' | 'valid' | 'error';
+  message: string;
+  statusLines?: string[];
+  musicbrainzUrl?: string;
+  entityType?: ImportReviewManualIdResponse['entity_type'];
+  releaseGroupCandidates?: NonNullable<ImportReviewManualIdResponse['release_group_candidates']>;
+  selectedRecordingCandidate?: ReviewRecordingCandidate;
+};
+
 type SelectedMatch = {
   release_group_id: string;
   representative_release_id: string;
@@ -118,7 +130,19 @@ type SelectedMatch = {
   representative_release_group_id?: string;
   rejected_representative_release_id?: string;
   release_group_diagnostics?: Record<string, unknown>;
-  source: 'ai' | 'candidate' | 'manual';
+  source: 'ai' | 'candidate' | 'manual' | 'musicbrainz_acoustid' | 'musicbrainz' | string;
+  ai_available?: boolean;
+  ai_unavailable_reason?: string;
+  matching_method?: string;
+  warnings?: string[];
+  action_eligibility?: unknown;
+  eligibility_reason?: string;
+  matching_contract?: Record<string, unknown>;
+  acoustid_corroboration?: string;
+  fingerprint_conflicts?: string[];
+  recording_id_conflicts?: string[];
+  title_mismatch_warnings?: string[];
+  required_review?: boolean;
 };
 
 type ConfirmIntent =
@@ -261,6 +285,27 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
   return Promise.race([promise, timeout]).finally(() => {
     if (timer !== undefined) window.clearTimeout(timer);
   });
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null;
+  const tag = element?.tagName?.toLowerCase() ?? '';
+  return tag === 'input' || tag === 'textarea' || tag === 'select' || Boolean(element?.isContentEditable);
+}
+
+function reviewQueueSnapshot(items: ReviewItem[], counts: ReviewCounts): string {
+  return JSON.stringify({
+    counts,
+    ids: items.map((item) => [item.id, reviewItemStateKey(item)]),
+  });
+}
+
+function hasUnsavedManualId(validations: Record<string, ManualValidationState>): boolean {
+  return Object.values(validations).some((state) => state.status === 'idle' && Boolean(state.message));
+}
+
+function reviewInteractionIsExpanded(): boolean {
+  return Boolean(document.querySelector('[role="dialog"], [aria-modal="true"], [aria-expanded="true"]'));
 }
 
 function isMusicLibraryPath(path?: string): boolean {
@@ -413,7 +458,7 @@ function matchReviewNote(item: ReviewItem): string {
     return `The selected release failed tracklist preflight (${preflight.matches ?? 0}/${preflight.expected ?? 0}). Pick a release that matches this folder before importing.`;
   }
   if (item.type === 'pending_ai' && !item.mb_valid) {
-    return 'No valid MusicBrainz release-group ID is selected yet. Use AI Suggest, paste a release-group ID, or delete the source folder if the files are wrong.';
+    return 'No valid MusicBrainz release-group ID is selected yet. Use Find Match, enter a MusicBrainz ID, or delete the source folder if the files are wrong.';
   }
   return '';
 }
@@ -1040,7 +1085,7 @@ function RecordingIdEvidencePanel({
               <DetailRow label="Recommended action" value={displayCandidate.recommended_action} />
             </div>
           ) : (
-            <div className="mt-2 text-zinc-500">Run AI Suggest to load backend recording candidates.</div>
+            <div className="mt-2 text-zinc-700">Use Find Match or Enter MusicBrainz ID to load backend recording evidence.</div>
           )}
           {displayCandidate?.reason ? <div className="mt-2 text-zinc-700">{displayCandidate.reason}</div> : null}
           {displayCandidate?.conflicts?.length ? <div className="mt-2 font-medium text-amber-800">Backend conflicts: {displayCandidate.conflicts.join(', ')}</div> : null}
@@ -1136,7 +1181,7 @@ function existingAlbumId(item: ReviewItem): number {
 }
 
 function targetPreviewKey(item: ReviewItem, selectedMatch?: SelectedMatch): string {
-  if (!selectedMatch || selectedMatch.source === 'manual') return '';
+  if (!selectedMatch) return '';
   const mapped = selectedMatch.track_mapping
     .map((row) => `${row.num}:${row.status}:${row.source_path || ''}:${row.mb_trackid || row.mb_title || row.local_title}`)
     .join('|');
@@ -1157,18 +1202,16 @@ function targetPreviewKey(item: ReviewItem, selectedMatch?: SelectedMatch): stri
 
 function actionLabel(item: ReviewItem, selectedMatch?: SelectedMatch, preview?: ImportTargetPreviewResponse): string {
   if (item.type === 'library_no_mb') return item.target_kind === 'item' ? 'Attach recording ID' : 'Match album';
-  const selectedCount = selectedMatch && selectedMatch.source !== 'manual'
-    ? selectedImportSourceFiles(selectedMatch, preview).length
-    : 0;
+  const selectedCount = selectedMatch ? selectedImportSourceFiles(selectedMatch, preview).length : 0;
   const previewCount = preview?.tracks_to_import_count ?? selectedCount;
   if (selectedMatch?.identity_validated === false) return 'Import blocked';
-  if (selectedMatch?.is_partial_import && selectedMatch.source !== 'manual') {
+  if (selectedMatch?.is_partial_import) {
     const n = Math.max(0, Math.min(selectedCount || previewCount, previewCount));
     return existingAlbumId(item)
       ? `Repair ${n} matched track${n === 1 ? '' : 's'}`
       : `Import ${n} matched track${n === 1 ? '' : 's'}`;
   }
-  if (selectedMatch?.auto_fix_eligible && selectedMatch.source !== 'manual') {
+  if (selectedMatch?.auto_fix_eligible) {
     return existingAlbumId(item) ? 'Complete Verified Repair' : 'Complete Verified Import';
   }
   return existingAlbumId(item) ? 'Repair with ID' : 'Import with ID';
@@ -1190,7 +1233,7 @@ function targetPreviewBlockReason(
   targetPreviewState?: TargetPreviewState,
 ): string {
   const importLike = item.type === 'pending_ai' && !existingAlbumId(item);
-  if (!importLike || !selectedMatch || selectedMatch.source === 'manual') return '';
+  if (!importLike || !selectedMatch) return '';
   if (!selectedMatch.is_importable) return '';
   if (!targetPreviewState || targetPreviewState.status === 'idle') {
     return 'Import blocked until the target path preview is available.';
@@ -1232,7 +1275,7 @@ function applyBlockReason(
   }
   const importLike = item.type === 'pending_ai' && !existingAlbumId(item);
   if (!importLike) {
-    if (selectedMatch?.preflight_status === 'failed' && selectedMatch.source !== 'manual') {
+    if (selectedMatch?.preflight_status === 'failed') {
       return 'Import blocked because this candidate failed tracklist preflight.';
     }
     return '';
@@ -1307,7 +1350,7 @@ function shouldShowReadyBucket(
 ): boolean {
   if (item.type === 'skipped' || hasAudioMismatchEvidence(item)) return false;
   if (shouldShowBlockedBucket(item, mbid, selectedMatch, targetPreviewState)) return false;
-  if (!selectedMatch || selectedMatch.source === 'manual') return false;
+  if (!selectedMatch) return false;
   if (!selectedMatch.is_importable) return false;
   if (!sameMbid(selectedMatch.release_group_id, mbid)) return false;
   if (!isMusicBrainzUuid(selectedMatch.release_group_id)) return false;
@@ -1326,7 +1369,7 @@ function blockedActionHint(reason: string): string {
   if (value.includes('music format preferences') || value.includes('format policy')) return 'Choose another source or update Music Format Preferences before retrying.';
   if (value.includes('target path')) return 'Fix the target path conflict, then retry this item.';
   if (value.includes('out of sync') || value.includes('visible musicbrainz match')) return 'Select the visible candidate again so the ID field and comparison agree.';
-  if (value.includes('release group id') || value.includes('valid musicbrainz')) return 'Select AI Suggest or paste a valid MusicBrainz Release Group ID.';
+  if (value.includes('release group id') || value.includes('valid musicbrainz')) return 'Use Find Match or enter a valid MusicBrainz Release or Release Group ID.';
   if (value.includes('preflight') || value.includes('tracklist') || value.includes('not importable')) return 'Choose a release that matches the files, or delete the source folder if the audio is wrong.';
   if (value.includes('no verified tracks') || value.includes('selected file count')) return 'Adjust the selected track mapping before importing.';
   return 'Resolve this block before importing; uncertain audio stays in review.';
@@ -1711,6 +1754,18 @@ function buildAiSelectedMatch(suggestion: AiSuggestion): SelectedMatch {
     candidate_identity_error: candidateIdentityError,
     representative_release_group_id: suggestion.representative_release_group_id || '',
     rejected_representative_release_id: suggestion.rejected_representative_release_id || '',
+    ai_available: suggestion.ai_available,
+    ai_unavailable_reason: suggestion.ai_unavailable_reason,
+    matching_method: suggestion.matching_method || suggestion.match_method,
+    warnings: suggestion.warnings,
+    action_eligibility: suggestion.action_eligibility,
+    eligibility_reason: suggestion.eligibility_reason,
+    matching_contract: suggestion.matching_contract,
+    acoustid_corroboration: suggestion.acoustid_corroboration,
+    fingerprint_conflicts: suggestion.fingerprint_conflicts,
+    recording_id_conflicts: suggestion.recording_id_conflicts,
+    title_mismatch_warnings: suggestion.title_mismatch_warnings,
+    required_review: suggestion.required_review,
     source: 'ai',
   };
 }
@@ -1720,6 +1775,127 @@ function savedSelectedMatch(item: ReviewItem): SelectedMatch | null {
   if (!suggestion?.track_mapping?.length) return null;
   const match = buildAiSelectedMatch(suggestionWithOrigin(item, suggestion));
   return match.track_mapping.length ? match : null;
+}
+
+type MatchingSafetyRow = { label: string; value: string; tone?: 'ok' | 'warn' | 'neutral' };
+
+function isRecordValue(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function safetyText(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'boolean') return value ? 'yes' : 'no';
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : '';
+  if (typeof value === 'string') return value.trim();
+  if (Array.isArray(value)) return value.map(safetyText).filter(Boolean).join(', ');
+  if (isRecordValue(value)) {
+    const eligible = typeof value.eligible === 'boolean' ? (value.eligible ? 'eligible' : 'not eligible') : '';
+    const reason = safetyText(value.reason || value.eligibility_reason || value.status || value.decision);
+    return [eligible, reason].filter(Boolean).join(': ') || JSON.stringify(value).slice(0, 180);
+  }
+  return '';
+}
+
+function safetyList(...values: unknown[]): string[] {
+  const out: string[] = [];
+  for (const value of values) {
+    if (!value) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const text = safetyText(item);
+        if (text) out.push(text);
+      }
+    } else {
+      const text = safetyText(value);
+      if (text) out.push(text);
+    }
+  }
+  return [...new Set(out)];
+}
+
+function optionalAiWarning(message: string): string {
+  return /OPENAI_API_KEY not configured|OPENROUTER_API_KEY|AI_API_KEY|AI provider not configured|no AI provider/i.test(message)
+    ? 'AI ranking was skipped because no provider is configured.'
+    : '';
+}
+function matchingSafetyData(response?: AiSuggestResponse, selectedMatch?: SelectedMatch): { rows: MatchingSafetyRow[]; warnings: string[] } {
+  const suggestion = response?.suggestion ?? response?.suggestions;
+  const contract = isRecordValue(selectedMatch?.matching_contract)
+    ? selectedMatch?.matching_contract
+    : isRecordValue(suggestion?.matching_contract)
+      ? suggestion?.matching_contract
+      : isRecordValue(response?.matching_contract)
+        ? response?.matching_contract
+        : undefined;
+  const rows: MatchingSafetyRow[] = [];
+  const source = selectedMatch?.source || safetyText(suggestion?.matching_method || response?.matching_method || contract?.source);
+  if (source) rows.push({ label: 'Matching source', value: source.replace(/_/g, ' '), tone: 'neutral' });
+  const aiAvailable = selectedMatch?.ai_available ?? suggestion?.ai_available ?? response?.ai_available;
+  const aiReason = selectedMatch?.ai_unavailable_reason || suggestion?.ai_unavailable_reason || response?.ai_unavailable_reason || '';
+  if (aiAvailable !== undefined || aiReason) {
+    rows.push({
+      label: 'AI availability',
+      value: aiAvailable === false ? (aiReason || 'AI ranking is not configured.') : 'AI ranking available',
+      tone: aiAvailable === false ? 'warn' : 'ok',
+    });
+  }
+  const eligibility = selectedMatch?.action_eligibility ?? suggestion?.action_eligibility ?? response?.action_eligibility ?? contract?.action_eligibility;
+  const eligibilityText = safetyText(eligibility);
+  if (eligibilityText) rows.push({ label: 'Eligibility decision', value: eligibilityText, tone: /not|block|fail|ineligible/i.test(eligibilityText) ? 'warn' : 'ok' });
+  const eligibilityReason = selectedMatch?.eligibility_reason || suggestion?.eligibility_reason || response?.eligibility_reason || safetyText(contract?.eligibility_reason);
+  if (eligibilityReason) rows.push({ label: 'Eligibility reason', value: eligibilityReason, tone: /block|conflict|fail|review/i.test(eligibilityReason) ? 'warn' : 'neutral' });
+  const requiredReview = selectedMatch?.required_review ?? suggestion?.required_review ?? response?.required_review ?? contract?.required_review;
+  if (requiredReview !== undefined) rows.push({ label: 'Required review', value: safetyText(requiredReview), tone: requiredReview ? 'warn' : 'ok' });
+  const corroboration = selectedMatch?.acoustid_corroboration || suggestion?.acoustid_corroboration || response?.acoustid_corroboration || safetyText(contract?.acoustid_corroboration);
+  if (corroboration) rows.push({ label: 'AcoustID corroboration', value: corroboration, tone: /conflict|mismatch|no/i.test(corroboration) ? 'warn' : 'ok' });
+  const warnings = safetyList(
+    selectedMatch?.warnings,
+    suggestion?.warnings,
+    response?.warnings,
+    contract?.warnings,
+    selectedMatch?.fingerprint_conflicts,
+    suggestion?.fingerprint_conflicts,
+    response?.fingerprint_conflicts,
+    contract?.fingerprint_conflicts,
+    selectedMatch?.recording_id_conflicts,
+    suggestion?.recording_id_conflicts,
+    response?.recording_id_conflicts,
+    contract?.recording_id_conflicts,
+    selectedMatch?.title_mismatch_warnings,
+    suggestion?.title_mismatch_warnings,
+    response?.title_mismatch_warnings,
+    contract?.title_mismatch_warnings,
+  );
+  return { rows, warnings };
+}
+
+function MatchingSafetyPanel({ response, selectedMatch }: { response?: AiSuggestResponse; selectedMatch?: SelectedMatch }) {
+  const { rows, warnings } = matchingSafetyData(response, selectedMatch);
+  if (!rows.length && !warnings.length) return null;
+  return (
+    <div className="mt-3 rounded border border-graphite-200 bg-graphite-50 px-3 py-2 text-xs text-zinc-700" data-import-review-matching-safety>
+      <div className="font-semibold text-zinc-900">Backend matching safety</div>
+      {rows.length ? (
+        <div className="mt-2 grid gap-1 sm:grid-cols-2">
+          {rows.map((row) => (
+            <div key={`${row.label}:${row.value}`}>
+              <span className="font-medium text-zinc-900">{row.label}:</span>{' '}
+              <span className={row.tone === 'warn' ? 'text-amber-900' : row.tone === 'ok' ? 'text-emerald-800' : 'text-zinc-700'}>{row.value}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {warnings.length ? (
+        <div className="mt-2 rounded border border-amber-300 bg-amber-50 px-2 py-1.5 text-amber-950">
+          <div className="font-semibold">Warnings</div>
+          <ul className="mt-1 list-disc space-y-1 pl-4">
+            {warnings.map((warning) => <li key={warning}>{warning}</li>)}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
 }
 const TRACK_STATUS_COLORS: Record<TrackRow['status'], string> = {
   matched: 'text-emerald-700',
@@ -2557,9 +2733,14 @@ function ReviewCard({
   actionState,
   selectedMatch,
   targetPreviewState,
+  manualValidation,
+  manualFocusToken,
   onMbidChange,
   onUseCandidate,
   onSelectMatch,
+  onFocusManualEntry,
+  onValidateManualId,
+  onClearManualId,
   onSuggest,
   onApply,
   onDismiss,
@@ -2573,9 +2754,14 @@ function ReviewCard({
   actionState?: ActionState;
   selectedMatch?: SelectedMatch;
   targetPreviewState?: TargetPreviewState;
+  manualValidation?: ManualValidationState;
+  manualFocusToken: number;
   onMbidChange: (value: string) => void;
   onUseCandidate: (mbid: string) => void;
   onSelectMatch?: (match: SelectedMatch) => void;
+  onFocusManualEntry: () => void;
+  onValidateManualId: () => void;
+  onClearManualId: () => void;
   onSuggest: () => void;
   onApply: () => void;
   onDismiss: () => void;
@@ -2583,9 +2769,7 @@ function ReviewCard({
   onCleanupFiles: () => void;
   importJobActive?: boolean;
 }) {
-  const selectedConfidence = selectedMatch && selectedMatch.source !== 'manual'
-    ? selectedMatch.confidence_level
-    : null;
+  const selectedConfidence = selectedMatch ? selectedMatch.confidence_level : null;
   const selectedConfidenceScore = selectedMatch?.confidence_score ?? null;
   const selectedConfidenceText = selectedConfidence
     ? `${confidenceLabel(selectedConfidence)}${selectedConfidenceScore !== null ? ` (${formatPercent(selectedConfidenceScore)})` : ''}`
@@ -2608,7 +2792,7 @@ function ReviewCard({
   const navigate = useNavigate();
   const isLibraryNoMb = item.type === 'library_no_mb' && Boolean(item.album_id);
   const matchBucket = itemMatchBucket(item);
-  const selectedMatchActive = Boolean(selectedMatch && selectedMatch.source !== 'manual');
+  const selectedMatchActive = Boolean(selectedMatch);
   const audioMismatchActive = hasAudioMismatchEvidence(item);
   const applyBlockedReason = applyBlockReason(item, mbid, selectedMatch, targetPreviewState);
   const blockedActive = shouldShowBlockedBucket(item, mbid, selectedMatch, targetPreviewState);
@@ -2673,6 +2857,23 @@ function ReviewCard({
     if (item.path) params.set('path', item.path);
     navigate(`/submissions?${params.toString()}`);
   };
+  const manualInputRef = useRef<HTMLInputElement>(null);
+  const manualChecking = manualValidation?.status === 'checking';
+  const manualValid = manualValidation?.status === 'valid';
+  const manualError = manualValidation?.status === 'error';
+  const manualEntityLabel = manualValidation?.entityType === 'release-group'
+    ? 'Release Group'
+    : manualValidation?.entityType === 'recording'
+      ? 'Recording'
+      : manualValidation?.entityType === 'release'
+        ? 'Release'
+        : 'MusicBrainz ID';
+  useEffect(() => {
+    if (manualFocusToken > 0) {
+      manualInputRef.current?.focus();
+      manualInputRef.current?.select();
+    }
+  }, [manualFocusToken]);
 
   return (
     <Card variant="outlined" sx={{ borderRadius: 2, borderColor: 'rgba(15, 23, 42, 0.12)' }}>
@@ -2696,7 +2897,7 @@ function ReviewCard({
               ) : item.confidence ? (
                 <span className={`text-xs font-semibold ${confidenceClass(item.confidence)}`}>{item.confidence}</span>
               ) : null}
-              {selectedMatch?.auto_fix_eligible && selectedMatch.source !== 'manual' ? (
+              {selectedMatch?.auto_fix_eligible ? (
                 <Chip
                   size="small"
                   color="success"
@@ -2732,6 +2933,7 @@ function ReviewCard({
                 {visibleMatchNote}
               </div>
             ) : null}
+            <MatchingSafetyPanel response={suggestion} selectedMatch={selectedMatch} />
 
             {/* Once a visible candidate is selected, show that candidate's state instead of stale stored evidence. */}
             {isRecordingReview ? (
@@ -2741,7 +2943,7 @@ function ReviewCard({
                 mbid={mbid}
                 onUseCandidate={onUseCandidate}
               />
-            ) : selectedMatch && selectedMatch.source !== 'manual' ? (
+            ) : selectedMatch ? (
               <div className="mt-3 space-y-2 text-xs text-zinc-600">
                 <div>
                   <span>Selected candidate: </span>
@@ -2821,15 +3023,69 @@ function ReviewCard({
             ) : null}
             {item.album_id ? <Chip size="small" variant="outlined" label={`Album ${item.album_id}`} /> : null}
 
+            <Button size="small" variant="outlined" onClick={onFocusManualEntry} disabled={busy}>
+              Enter MusicBrainz ID
+            </Button>
             <TextField
-              label={item.target_kind === 'item' ? 'MusicBrainz Recording ID' : 'MusicBrainz Release Group ID'}
+              inputRef={manualInputRef}
+              label={item.target_kind === 'item' ? 'MusicBrainz Recording ID or URL' : 'MusicBrainz Release or Release Group ID/URL'}
               value={mbid}
               onChange={(event) => onMbidChange(event.target.value)}
               size="small"
               fullWidth
               disabled={busy}
-              helperText={item.target_kind === 'item' ? 'Identifies this specific track. Enter a recording UUID.' : 'The canonical album identity. Enter a release-group UUID.'}
+              helperText={item.target_kind === 'item' ? 'Paste a recording UUID or recording URL.' : 'Paste a release UUID, release-group UUID, or MusicBrainz URL.'}
+              slotProps={{ htmlInput: { 'data-import-review-manual-id': item.id } }}
+              sx={{ '& .MuiFormHelperText-root': { color: '#475569' } }}
             />
+            <div className="grid grid-cols-2 gap-2">
+              <Button size="small" variant="contained" onClick={onValidateManualId} disabled={busy || manualChecking || !mbid.trim()}>
+                {manualChecking ? 'Checking ID…' : 'Validate ID'}
+              </Button>
+              <Button size="small" variant="outlined" onClick={onClearManualId} disabled={busy || manualChecking || !mbid.trim()}>
+                Clear Manual ID
+              </Button>
+            </div>
+            {manualValidation?.message ? (
+              <div className={`rounded border px-2 py-1.5 text-xs ${manualError ? 'border-rose-200 bg-rose-50 text-rose-900' : manualValid ? 'border-emerald-200 bg-emerald-50 text-emerald-900' : 'border-sky-200 bg-sky-50 text-sky-900'}`}>
+                <div className="font-semibold">{manualValid ? `Valid ${manualEntityLabel}` : manualError ? 'MusicBrainz ID rejected' : 'Checking MusicBrainz ID'}</div>
+                <div className="mt-0.5">{manualValidation.message}</div>
+                {manualValidation.statusLines?.length ? (
+                  <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                    {manualValidation.statusLines.map((line) => <li key={line}>{line}</li>)}
+                  </ul>
+                ) : null}
+                {manualValidation.releaseGroupCandidates?.length ? (
+                  <div className="mt-2">
+                    <div className="font-medium">Available releases</div>
+                    <ul className="mt-1 space-y-0.5">
+                      {manualValidation.releaseGroupCandidates.slice(0, 4).map((release) => (
+                        <li key={release.mb_albumid} className="truncate">
+                          {release.title || 'Untitled'} {release.date ? `(${release.date})` : ''} · {release.country || 'unknown'} · {release.track_count} tracks
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {manualValidation.musicbrainzUrl ? (
+                    <Button size="small" variant="outlined" href={manualValidation.musicbrainzUrl} target="_blank" rel="noreferrer">
+                      Open in MusicBrainz
+                    </Button>
+                  ) : null}
+                  {manualValid && item.target_kind !== 'item' ? (
+                    <Button size="small" variant="outlined" onClick={onValidateManualId} disabled={busy || manualChecking}>
+                      Use This Release
+                    </Button>
+                  ) : null}
+                  {manualValid && item.target_kind !== 'item' ? (
+                    <Button size="small" variant="text" onClick={onClearManualId} disabled={busy || manualChecking}>
+                      Choose Another Release
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
 
             {item.target_kind !== 'item' && representativeRelease ? (
               <div className="rounded border border-graphite-200 bg-graphite-50 px-2 py-1.5 text-xs text-zinc-500">
@@ -2863,7 +3119,7 @@ function ReviewCard({
 
             <div className="grid grid-cols-2 gap-2">
               <Button size="small" variant="outlined" sx={blockedPanelActionButtonSx} onClick={onSuggest} disabled={busy}>
-                AI Suggest
+                Find Match
               </Button>
               <Button
                 size="small"
@@ -3156,7 +3412,12 @@ export function ImportReviewPage({
   const [actions, setActions] = useState<Record<string, ActionState>>({});
   const [selectedMatches, setSelectedMatches] = useState<Record<string, SelectedMatch>>({});
   const [targetPreviews, setTargetPreviews] = useState<Record<string, TargetPreviewState>>({});
+  const [manualValidations, setManualValidations] = useState<Record<string, ManualValidationState>>({});
+  const [manualFocusToken, setManualFocusToken] = useState(0);
+  const [activeItemId, setActiveItemId] = useState('');
+  const [queueUpdatesAvailable, setQueueUpdatesAvailable] = useState(false);
   const targetPreviewKeysRef = useRef<Record<string, string>>({});
+  const queueSnapshotRef = useRef('');
   const autoEnqueueKeysRef = useRef<Set<string>>(new Set());
   const autoCleanupKeysRef = useRef<Set<string>>(new Set());
   const reviewItemStateKeysRef = useRef<Record<string, string>>({});
@@ -3278,7 +3539,6 @@ export function ImportReviewPage({
       for (const id of changedIds) delete targetPreviewKeysRef.current[id];
       setSelectedMatches((current) => {
         const next = { ...current };
-        for (const id of changedIds) delete next[id];
         for (const id of Object.keys(next)) if (!liveIds.has(id)) delete next[id];
         for (const item of nextItems) {
           if (!next[item.id]) {
@@ -3296,16 +3556,21 @@ export function ImportReviewPage({
       });
       setActions((current) => {
         const next = { ...current };
-        for (const id of changedIds) delete next[id];
+        for (const id of Object.keys(next)) if (!liveIds.has(id)) delete next[id];
+        return next;
+      });
+      setManualValidations((current) => {
+        const next = { ...current };
         for (const id of Object.keys(next)) if (!liveIds.has(id)) delete next[id];
         return next;
       });
       setItems(nextItems);
       setCounts(response.counts ?? {});
       setOriginCounts(response.origin_counts ?? {});
+      queueSnapshotRef.current = reviewQueueSnapshot(nextItems, response.counts ?? {});
+      setQueueUpdatesAvailable(false);
       setMbids((current) => {
         const next = { ...current };
-        for (const id of changedIds) delete next[id];
         for (const id of Object.keys(next)) if (!liveIds.has(id)) delete next[id];
         for (const item of nextItems) {
           if (!next[item.id]) next[item.id] = initialMbid(item);
@@ -3326,10 +3591,18 @@ export function ImportReviewPage({
   useEffect(() => {
     if (!active) return;
     const id = window.setInterval(() => {
-      if (!document.hidden) void loadQueue(true);
-    }, 20000);
+      if (document.hidden || confirmIntent || isEditableTarget(document.activeElement) || hasUnsavedManualId(manualValidations) || reviewInteractionIsExpanded()) return;
+      void getReviewQueue({ limit: REVIEW_QUEUE_LIMIT, origin_type: sourceFilter })
+        .then((response) => {
+          const snapshot = reviewQueueSnapshot(response.items ?? [], response.counts ?? {});
+          if (queueSnapshotRef.current && snapshot !== queueSnapshotRef.current) {
+            setQueueUpdatesAvailable(true);
+          }
+        })
+        .catch(() => undefined);
+    }, 60000);
     return () => window.clearInterval(id);
-  }, [active, loadQueue]);
+  }, [active, confirmIntent, manualValidations, sourceFilter]);
 
   const visibleItems = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -3360,15 +3633,27 @@ export function ImportReviewPage({
     });
   }, [evidenceOnly, filter, items, mbids, query, selectedMatches, sourceFilter, targetPreviews]);
 
-  // Reset cursor when filters/search change; clamp when list shrinks
-  useEffect(() => { setCursor(0); }, [filter, sourceFilter, query, evidenceOnly]);
+  // Reset cursor when filters/search change; restore visible position by review item ID after queue updates.
+  useEffect(() => { setCursor(0); setActiveItemId(''); }, [filter, sourceFilter, query, evidenceOnly]);
   useEffect(() => {
-    if (visibleItems.length > 0) {
-      setCursor((c) => Math.min(c, visibleItems.length - 1));
+    if (visibleItems.length === 0) {
+      if (activeItemId) setActiveItemId('');
+      if (cursor !== 0) setCursor(0);
+      return;
     }
-  }, [visibleItems.length]);
+    const existingIndex = activeItemId ? visibleItems.findIndex((item) => item.id === activeItemId) : -1;
+    if (existingIndex >= 0) {
+      if (cursor !== existingIndex) setCursor(existingIndex);
+      return;
+    }
+    const nextIndex = Math.min(cursor, visibleItems.length - 1);
+    const nextId = visibleItems[nextIndex]?.id || '';
+    if (nextId && activeItemId !== nextId) setActiveItemId(nextId);
+    if (cursor !== nextIndex) setCursor(nextIndex);
+  }, [activeItemId, cursor, visibleItems]);
 
-  const activeItem = visibleItems[cursor] ?? null;
+  const activeIndex = activeItemId ? visibleItems.findIndex((item) => item.id === activeItemId) : cursor;
+  const activeItem = activeIndex >= 0 ? visibleItems[activeIndex] ?? null : null;
   const revalidatePendingCount = visibleItems.filter((item) => item.type === 'pending_ai').length;
 
   const handleRevalidateQueue = useCallback(async () => {
@@ -3427,7 +3712,7 @@ export function ImportReviewPage({
     if (!activeItem) return;
     const item = activeItem;
     const selectedMatch = selectedMatches[item.id];
-    if (!selectedMatch || selectedMatch.source === 'manual') return;
+    if (!selectedMatch) return;
     const key = targetPreviewKey(item, selectedMatch);
     if (!key || targetPreviewKeysRef.current[item.id] === key) return;
     targetPreviewKeysRef.current[item.id] = key;
@@ -3458,7 +3743,7 @@ export function ImportReviewPage({
       });
   }, [activeItem, selectedMatches]);
 
-  // Auto-start AI Suggest only while the Review tab is active and the item needs identification.
+  // Auto-start Find Match only while the Review tab is active and the item needs identification.
   // Fires only when the cursor moves to a new item; checks current state synchronously
   // so it won't re-fire after the suggestion arrives.
   useEffect(() => {
@@ -3877,7 +4162,7 @@ export function ImportReviewPage({
   }, [loadQueue, pollJobBackground]);
 
   const handleSuggest = useCallback(async (item: ReviewItem) => {
-    setAction(item.id, { status: 'running', message: 'Asking AI...' });
+    setAction(item.id, { status: 'running', message: 'Finding match...' });
     if (item.type === 'library_no_mb' && item.target_kind === 'item' && item.item_id) {
       // Singleton items are identified by recording, not release -- a
       // separate response shape (suggestions.mb_trackid, not
@@ -3893,12 +4178,22 @@ export function ImportReviewPage({
         if (mbTrackId) {
           setMbids((current) => ({ ...current, [item.id]: mbTrackId }));
         }
+        const aiAvailable = s?.ai_available ?? response.ai_available;
+        const aiReason = s?.ai_unavailable_reason || response.ai_unavailable_reason || 'AI ranking is not configured.';
         setAction(item.id, {
-          status: 'success',
-          message: s?.reason || backendCandidate?.reason || (mbTrackId ? 'AI suggestion ready. Review the backend recording evidence before attaching.' : 'No confident recording match found.'),
+          status: aiAvailable === false ? 'warning' : 'success',
+          message: s?.reason || backendCandidate?.reason || (mbTrackId
+            ? aiAvailable === false
+              ? `Recording evidence ready. ${aiReason}`
+              : 'Recording match evidence ready. Review the backend recording evidence before attaching.'
+            : aiAvailable === false
+              ? `No confident recording match found. ${aiReason}`
+              : 'No confident recording match found.'),
         });
       } catch (err) {
-        setAction(item.id, { status: 'error', message: err instanceof Error ? err.message : String(err) });
+        const message = err instanceof Error ? err.message : String(err);
+        const aiWarning = optionalAiWarning(message);
+        setAction(item.id, { status: aiWarning ? 'warning' : 'error', message: aiWarning || message });
       }
       return;
     }
@@ -3907,20 +4202,36 @@ export function ImportReviewPage({
         ? await suggestAlbum(item.album_id)
         : await suggestFolder(item.path || '');
       const suggestion = response.suggestion;
+      const backendSelectedMatch = response.selected_match as unknown as SelectedMatch | undefined;
       setSuggestions((current) => ({ ...current, [item.id]: response }));
-      if (suggestion?.mb_valid && suggestion.mb_albumid) {
+      if (backendSelectedMatch?.release_group_id) {
+        setMbids((current) => ({ ...current, [item.id]: backendSelectedMatch.release_group_id }));
+        setSelectedMatches((current) => ({ ...current, [item.id]: backendSelectedMatch }));
+        delete targetPreviewKeysRef.current[item.id];
+        setTargetPreviews((current) => { const next = { ...current }; delete next[item.id]; return next; });
+      } else if (suggestion?.mb_valid && suggestion.mb_albumid) {
         const rgid = suggestion.mb_releasegroupid || suggestion.mb_albumid || '';
         setMbids((current) => ({ ...current, [item.id]: rgid }));
         setSelectedMatches((current) => ({ ...current, [item.id]: buildAiSelectedMatch(suggestion) }));
         delete targetPreviewKeysRef.current[item.id];
         setTargetPreviews((current) => { const next = { ...current }; delete next[item.id]; return next; });
       }
+      const aiAvailable = suggestion?.ai_available ?? response.ai_available;
+      const aiReason = suggestion?.ai_unavailable_reason || response.ai_unavailable_reason || 'AI ranking is not configured.';
       setAction(item.id, {
-        status: 'success',
-        message: suggestion?.reason || 'AI suggestion ready. Verify the release-group ID before applying.',
+        status: aiAvailable === false ? 'warning' : 'success',
+        message: suggestion?.reason || (backendSelectedMatch
+          ? aiAvailable === false
+            ? `Matched using MusicBrainz and AcoustID. ${aiReason}`
+            : 'Match ready. Verify the release-group ID before applying.'
+          : aiAvailable === false
+            ? `No verified MusicBrainz match was selected. ${aiReason}`
+            : 'Find Match completed. Verify the release-group ID before applying.'),
       });
     } catch (err) {
-      setAction(item.id, { status: 'error', message: err instanceof Error ? err.message : String(err) });
+      const message = err instanceof Error ? err.message : String(err);
+      const aiWarning = optionalAiWarning(message);
+      setAction(item.id, { status: aiWarning ? 'warning' : 'error', message: aiWarning || message });
     }
   }, [setAction]);
 
@@ -3985,7 +4296,9 @@ export function ImportReviewPage({
       removeLocalItem(item);                          // advance cursor immediately
       void pollJobBackground(started.job_id, item, label, keepReviewAfterSuccess);
     } catch (err) {
-      setAction(item.id, { status: 'error', message: err instanceof Error ? err.message : String(err) });
+      const message = err instanceof Error ? err.message : String(err);
+      const aiWarning = optionalAiWarning(message);
+      setAction(item.id, { status: aiWarning ? 'warning' : 'error', message: aiWarning || message });
     }
   }, [pollJobBackground, removeLocalItem, selectedMatches, setAction, suggestions, targetPreviews]);
 
@@ -4014,7 +4327,9 @@ export function ImportReviewPage({
       if ((item.type === 'pending_ai' || item.type === 'skipped') && item.path) await deletePendingReview(item.path);
       removeLocalItem(item);
     } catch (err) {
-      setAction(item.id, { status: 'error', message: err instanceof Error ? err.message : String(err) });
+      const message = err instanceof Error ? err.message : String(err);
+      const aiWarning = optionalAiWarning(message);
+      setAction(item.id, { status: aiWarning ? 'warning' : 'error', message: aiWarning || message });
     }
   }, [removeLocalItem, setAction]);
 
@@ -4054,7 +4369,9 @@ export function ImportReviewPage({
         void loadQueue(true);
       }
     } catch (err) {
-      setAction(item.id, { status: 'error', message: err instanceof Error ? err.message : String(err) });
+      const message = err instanceof Error ? err.message : String(err);
+      const aiWarning = optionalAiWarning(message);
+      setAction(item.id, { status: aiWarning ? 'warning' : 'error', message: aiWarning || message });
     }
   }, [loadQueue, removeLocalItem, selectedMatches, setAction, targetPreviews]);
 
@@ -4066,7 +4383,7 @@ export function ImportReviewPage({
     if (actions[item.id]?.status === 'running') return;
     if (backgroundJobs[item.id]?.status === 'running' || backgroundJobs[item.id]?.status === 'still_running') return;
     const selectedMatch = selectedMatches[item.id];
-    if (!selectedMatch || selectedMatch.source === 'manual') return;
+    if (!selectedMatch) return;
     const previewState = currentTargetPreviewState(item, selectedMatch, targetPreviews);
     const preview = previewState?.status === 'ready' ? previewState.preview : undefined;
     const files = selectedCleanupSourceFiles(selectedMatch, preview);
@@ -4109,7 +4426,9 @@ export function ImportReviewPage({
       })
       .catch((err) => {
         autoCleanupKeysRef.current.delete(key);
-        setAction(item.id, { status: 'error', message: err instanceof Error ? err.message : String(err) });
+        const message = err instanceof Error ? err.message : String(err);
+        const aiWarning = optionalAiWarning(message);
+        setAction(item.id, { status: aiWarning ? 'warning' : 'error', message: aiWarning || message });
       });
   }, [active, activeItem, actions, backgroundJobs, loadQueue, removeLocalItem, selectedMatches, setAction, targetPreviews]);
 
@@ -4128,7 +4447,9 @@ export function ImportReviewPage({
       });
       void loadQueue(true);
     } catch (err) {
-      setAction(item.id, { status: 'error', message: err instanceof Error ? err.message : String(err) });
+      const message = err instanceof Error ? err.message : String(err);
+      const aiWarning = optionalAiWarning(message);
+      setAction(item.id, { status: aiWarning ? 'warning' : 'error', message: aiWarning || message });
     }
   }, [loadQueue, removeLocalItem, setAction]);
 
@@ -4200,52 +4521,28 @@ export function ImportReviewPage({
     .join(' + ');
   const hasExtraFilters = filter !== 'all' || sourceFilter !== 'all' || Boolean(query.trim()) || evidenceOnly;
 
-  const handlePrev = useCallback(() => setCursor((c) => Math.max(0, c - 1)), []);
-  const handleNext = useCallback(() => setCursor((c) => Math.min(visibleItems.length - 1, c + 1)), [visibleItems.length]);
-  const handleSkip = useCallback(() => setCursor((c) => Math.min(visibleItems.length - 1, c + 1)), [visibleItems.length]);
+  const moveToIndex = useCallback((nextIndex: number) => {
+    if (visibleItems.length < 1) return;
+    const clamped = Math.max(0, Math.min(visibleItems.length - 1, nextIndex));
+    setCursor(clamped);
+    setActiveItemId(visibleItems[clamped]?.id || '');
+  }, [visibleItems]);
+  const handlePrev = useCallback(() => moveToIndex(activeIndex - 1), [activeIndex, moveToIndex]);
+  const handleNext = useCallback(() => moveToIndex(activeIndex + 1), [activeIndex, moveToIndex]);
+  const handleSkip = useCallback(() => moveToIndex(activeIndex + 1), [activeIndex, moveToIndex]);
 
   // Stable per-item callbacks (avoid inline closures in the card render)
   const handleMbidChange = useCallback((value: string) => {
     if (!activeItem) return;
     const item = activeItem;
-    setMbids((c) => ({ ...c, [item.id]: value }));
-    if (item.target_kind === 'item') {
-      setSelectedMatches((current) => {
-        if (!current[item.id]) return current;
-        const next = { ...current };
-        delete next[item.id];
-        return next;
-      });
-      delete targetPreviewKeysRef.current[item.id];
-      return;
-    }
-    setSelectedMatches((current) => {
-      const prev = current[item.id];
-      return {
-        ...current,
-        [item.id]: {
-          release_group_id: value.trim(),
-          representative_release_id: '',
-          artist: prev?.artist || item.artist || '',
-          album: prev?.album || item.album || itemTitle(item),
-          year: prev?.year || String(item.year || ''),
-          track_match_count: null, total_tracks: null, local_track_count: null, track_mapping: [],
-          preflight_status: 'stale',
-          preflight_reason: 'Release Group ID was edited manually; select a visible match to refresh preflight before import.',
-          is_release_group_usable: isMusicBrainzUuid(value),
-          is_importable: false,
-          is_partial_import: false,
-          confidence_score: null,
-          confidence_level: isMusicBrainzUuid(value) ? 'low' : 'blocked',
-          auto_fix_eligible: false, auto_fix_requires_review: false,
-          auto_fix_reason: isMusicBrainzUuid(value)
-            ? 'Auto-fix blocked until a visible match refreshes track comparison and preflight.'
-            : 'Auto-fix blocked because this value is not a valid MusicBrainz Release Group ID.',
-          missing_track_count: 0, match_count: null, preflight_ok: null, source: 'manual',
-        } as SelectedMatch,
-      };
-    });
-    setTargetPreviews((c) => { const n = { ...c }; delete n[item.id]; return n; });
+    setMbids((current) => ({ ...current, [item.id]: value }));
+    setManualValidations((current) => ({
+      ...current,
+      [item.id]: value.trim()
+        ? { status: 'idle', message: 'MusicBrainz ID changed. Validate ID before importing.' }
+        : { status: 'idle', message: '' },
+    }));
+    setTargetPreviews((current) => { const next = { ...current }; delete next[item.id]; return next; });
     delete targetPreviewKeysRef.current[item.id];
   }, [activeItem]);
 
@@ -4267,29 +4564,121 @@ export function ImportReviewPage({
     if (!activeItem) return;
     setSelectedMatches((c) => ({ ...c, [activeItem.id]: match }));
     setMbids((c) => ({ ...c, [activeItem.id]: match.release_group_id }));
+    setManualValidations((c) => ({ ...c, [activeItem.id]: { status: 'valid', message: 'Backend match selected from visible evidence.' } }));
     setTargetPreviews((c) => { const n = { ...c }; delete n[activeItem.id]; return n; });
     delete targetPreviewKeysRef.current[activeItem.id];
   }, [activeItem]);
 
+  const handleFocusManualEntry = useCallback(() => {
+    setManualFocusToken((value) => value + 1);
+  }, []);
+
+  const handleClearManualId = useCallback(() => {
+    if (!activeItem) return;
+    const item = activeItem;
+    setMbids((current) => ({ ...current, [item.id]: '' }));
+    setManualValidations((current) => {
+      const next = { ...current };
+      delete next[item.id];
+      return next;
+    });
+    setSelectedMatches((current) => {
+      const next = { ...current };
+      delete next[item.id];
+      return next;
+    });
+    setTargetPreviews((current) => { const next = { ...current }; delete next[item.id]; return next; });
+    delete targetPreviewKeysRef.current[item.id];
+  }, [activeItem]);
+
+  const handleValidateManualId = useCallback(async () => {
+    if (!activeItem) return;
+    const item = activeItem;
+    const value = (mbids[item.id] ?? '').trim();
+    if (!value) {
+      setManualValidations((current) => ({ ...current, [item.id]: { status: 'error', message: 'This is not a valid MusicBrainz UUID or URL.' } }));
+      return;
+    }
+    setManualValidations((current) => ({
+      ...current,
+      [item.id]: { status: 'checking', message: 'Checking MusicBrainz ID…', statusLines: ['Checking MusicBrainz ID…'] },
+    }));
+    try {
+      const response = await validateManualMusicBrainzId({
+        review_item_id: item.id,
+        musicbrainz_id: value,
+        target_kind: item.target_kind,
+        path: item.path || '',
+        album_id: item.album_id || undefined,
+        existing_album_id: existingAlbumId(item) || undefined,
+        item_id: item.item_id || item.first_item_id || undefined,
+      });
+      if (item.target_kind === 'item') {
+        const candidate = response.selected_recording_candidate;
+        if (response.mb_trackid) setMbids((current) => ({ ...current, [item.id]: response.mb_trackid || value }));
+        if (candidate) {
+          setSuggestions((current) => ({
+            ...current,
+            [item.id]: {
+              ok: true,
+              suggestions: {
+                mb_trackid: response.mb_trackid,
+                selected_recording_candidate: candidate,
+                recording_candidates: response.recording_candidates,
+                reason: response.message,
+              },
+              recording_candidates: response.recording_candidates,
+              selected_candidate: candidate,
+              evidence: { ...(item.evidence ?? {}), selected_recording_candidate: candidate, recording_candidates: response.recording_candidates },
+            },
+          }));
+        }
+      } else if (response.selected_match) {
+        const match = response.selected_match as unknown as SelectedMatch;
+        setSelectedMatches((current) => ({ ...current, [item.id]: match }));
+        setMbids((current) => ({ ...current, [item.id]: match.release_group_id || response.release_group_id || value }));
+        setTargetPreviews((current) => { const next = { ...current }; delete next[item.id]; return next; });
+        delete targetPreviewKeysRef.current[item.id];
+      }
+      setManualValidations((current) => ({
+        ...current,
+        [item.id]: {
+          status: 'valid',
+          message: response.message || 'Manual MusicBrainz ID validated.',
+          statusLines: response.status_lines,
+          musicbrainzUrl: response.musicbrainz_url,
+          entityType: response.entity_type,
+          releaseGroupCandidates: response.release_group_candidates,
+          selectedRecordingCandidate: response.selected_recording_candidate,
+        },
+      }));
+      setAction(item.id, { status: 'success', message: response.message || 'Manual MusicBrainz ID validated.' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setManualValidations((current) => ({ ...current, [item.id]: { status: 'error', message } }));
+      setAction(item.id, { status: 'warning', message });
+    }
+  }, [activeItem, mbids, setAction]);
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase() ?? '';
-      if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
+      if (confirmIntent || isEditableTarget(e.target)) return;
       if (e.key === '[') { e.preventDefault(); handlePrev(); }
       if (e.key === ']') { e.preventDefault(); handleNext(); }
+      if (e.key.toLowerCase() === 'i') { e.preventDefault(); handleFocusManualEntry(); }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [handlePrev, handleNext]);
+  }, [confirmIntent, handleFocusManualEntry, handlePrev, handleNext]);
 
   return (
     <section className="flex flex-col gap-5">
       {/* Counts + action bar */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs">
-          <span className="text-zinc-400">{countFor(counts, 'all')} total</span>
-          {activeJobHiddenCount ? <span className="text-zinc-400">{activeJobHiddenCount} active job hidden</span> : null}
-          {unloadedReviewCount ? <span className="text-zinc-400">{unloadedReviewCount} not loaded</span> : null}
+          <span className="text-zinc-700">{countFor(counts, 'all')} total</span>
+          {activeJobHiddenCount ? <span className="text-zinc-700">{activeJobHiddenCount} active job hidden</span> : null}
+          {unloadedReviewCount ? <span className="text-zinc-700">{unloadedReviewCount} not loaded</span> : null}
           {(
             [
               { id: 'pending_ai', label: 'pending AI' },
@@ -4299,7 +4688,7 @@ export function ImportReviewPage({
           ).map(({ id, label }) => {
             const n = countFor(counts, id);
             return (
-              <span key={id} className="text-zinc-400">
+              <span key={id} className="text-zinc-700">
                 {n} {label}
               </span>
             );
@@ -4322,8 +4711,14 @@ export function ImportReviewPage({
               Refresh
             </Button>
           </div>
-          {revalidateMsg ? <span className="text-xs text-zinc-400">{revalidateMsg}</span> : null}
-          {cleanupMsg ? <span className="text-xs text-zinc-400">{cleanupMsg}</span> : null}
+          {queueUpdatesAvailable ? (
+            <span className="inline-flex items-center gap-2 text-xs font-medium text-zinc-700">
+              Review queue updates are available.
+              <Button size="small" variant="text" onClick={() => void loadQueue()} disabled={loading}>Load updates</Button>
+            </span>
+          ) : null}
+          {revalidateMsg ? <span className="text-xs text-zinc-700">{revalidateMsg}</span> : null}
+          {cleanupMsg ? <span className="text-xs text-zinc-700">{cleanupMsg}</span> : null}
         </div>
       </div>
 
@@ -4442,15 +4837,15 @@ export function ImportReviewPage({
             <button
               aria-label="Previous item"
               title="Previous [[]"
-              className="flex h-8 w-8 items-center justify-center rounded text-zinc-300 transition hover:bg-graphite-700 disabled:cursor-not-allowed disabled:opacity-30"
-              disabled={cursor === 0}
+              className="flex h-8 w-8 items-center justify-center rounded text-zinc-100 transition hover:bg-graphite-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300 disabled:cursor-not-allowed disabled:text-zinc-500"
+              disabled={activeIndex <= 0}
               onClick={handlePrev}
             >
               ←
             </button>
             <div className="min-w-0 flex-1 text-center">
-              <div className="text-[0.7rem] text-zinc-500">
-                {cursor + 1} of {visibleItems.length} shown · {filterCounts[filter]} in filter · {items.length} loaded of {filterCounts.all} total
+              <div className="text-[0.7rem] text-zinc-200">
+                {activeIndex + 1} of {visibleItems.length} shown · {filterCounts[filter]} in filter · {items.length} loaded of {filterCounts.all} total
                 {activeJobHiddenCount ? ` · ${activeJobHiddenCount} hidden by active jobs` : ''}
                 {unloadedReviewCount ? ` · ${unloadedReviewCount} beyond page limit` : ''}
               </div>
@@ -4463,15 +4858,15 @@ export function ImportReviewPage({
             <button
               aria-label="Next item"
               title="Next []]"
-              className="flex h-8 w-8 items-center justify-center rounded text-zinc-300 transition hover:bg-graphite-700 disabled:cursor-not-allowed disabled:opacity-30"
-              disabled={cursor >= visibleItems.length - 1}
+              className="flex h-8 w-8 items-center justify-center rounded text-zinc-100 transition hover:bg-graphite-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300 disabled:cursor-not-allowed disabled:text-zinc-500"
+              disabled={activeIndex >= visibleItems.length - 1}
               onClick={handleNext}
             >
               →
             </button>
             <button
-              className="rounded border border-graphite-600 px-3 py-1 text-xs font-medium text-zinc-400 transition hover:border-graphite-500 hover:text-zinc-200 disabled:opacity-30"
-              disabled={cursor >= visibleItems.length - 1}
+              className="rounded border border-graphite-400 px-3 py-1 text-xs font-medium text-zinc-100 transition hover:border-graphite-300 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300 disabled:border-graphite-700 disabled:text-zinc-500"
+              disabled={activeIndex >= visibleItems.length - 1}
               onClick={handleSkip}
             >
               Skip
@@ -4488,9 +4883,14 @@ export function ImportReviewPage({
               actionState={actions[activeItem.id]}
               selectedMatch={selectedMatches[activeItem.id]}
               targetPreviewState={currentTargetPreviewState(activeItem, selectedMatches[activeItem.id], targetPreviews)}
+              manualValidation={manualValidations[activeItem.id]}
+              manualFocusToken={manualFocusToken}
               onMbidChange={handleMbidChange}
               onUseCandidate={handleUseCandidate}
               onSelectMatch={handleSelectMatch}
+              onFocusManualEntry={handleFocusManualEntry}
+              onValidateManualId={handleValidateManualId}
+              onClearManualId={handleClearManualId}
               onSuggest={() => void handleSuggest(activeItem)}
               onApply={() => startApply(activeItem)}
               onDismiss={() => requestDismiss(activeItem)}
@@ -4513,22 +4913,3 @@ export function ImportReviewPage({
     </section>
   );
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/tests/test_import_review_button_contrast.py
+++ b/tests/test_import_review_button_contrast.py
@@ -41,7 +41,9 @@ class ImportReviewButtonContrastTests(unittest.TestCase):
         self.assertNotIn("Verify with fingerprint", IMPORT_REVIEW_SOURCE)
         self.assertIn("automatic verification", IMPORT_REVIEW_SOURCE)
         self.assertIn("Quarantine", IMPORT_REVIEW_SOURCE)
-        self.assertIn("AI Suggest", IMPORT_REVIEW_SOURCE)
+        self.assertIn("Find Match", IMPORT_REVIEW_SOURCE)
+        self.assertIn("Enter MusicBrainz ID", IMPORT_REVIEW_SOURCE)
+        self.assertIn("Validate ID", IMPORT_REVIEW_SOURCE)
         self.assertIn("Import with ID", IMPORT_REVIEW_SOURCE)
 
     def test_buttons_use_explicit_readable_tokens(self):
@@ -85,6 +87,11 @@ class ImportReviewButtonContrastTests(unittest.TestCase):
         self.assertIn("&.Mui-focusVisible", THEME_SOURCE)
         self.assertIn("boxShadow: `0 0 0 3px", THEME_SOURCE)
 
+    def test_import_review_dark_queue_controls_stay_readable(self):
+        self.assertIn("text-zinc-200", IMPORT_REVIEW_SOURCE)
+        self.assertIn("text-zinc-100 transition hover:bg-graphite-700", IMPORT_REVIEW_SOURCE)
+        self.assertIn("focus-visible:outline-sky-300", IMPORT_REVIEW_SOURCE)
+        self.assertIn("disabled:text-zinc-500", IMPORT_REVIEW_SOURCE)
     def test_blocked_panel_actions_use_local_contrast_styles(self):
         self.assertIn("blockedPanelActionButtonSx", IMPORT_REVIEW_SOURCE)
         self.assertIn("blockedPanelWarningButtonSx", IMPORT_REVIEW_SOURCE)

--- a/tests/test_import_review_manual_id_workflow.py
+++ b/tests/test_import_review_manual_id_workflow.py
@@ -1,0 +1,364 @@
+"""Regression checks for Import Review refresh and manual-MBID UX.
+
+The backend manual-ID tests exercise the real Flask route with external
+MusicBrainz/preflight calls mocked at the boundary. Frontend assertions remain
+structural because this repository does not include a React component runner.
+"""
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_SOURCE = (ROOT / "app.py").read_text(encoding="utf-8")
+CLIENT_SOURCE = (ROOT / "frontend" / "src" / "api" / "client.ts").read_text(encoding="utf-8")
+TYPES_SOURCE = (ROOT / "frontend" / "src" / "api" / "types.ts").read_text(encoding="utf-8")
+IMPORT_REVIEW_SOURCE = (
+    ROOT / "frontend" / "src" / "features" / "importReview" / "ImportReviewPage.tsx"
+).read_text(encoding="utf-8")
+
+RGID = "11111111-1111-1111-1111-111111111111"
+RELEASE_ID = "22222222-2222-2222-2222-222222222222"
+ALT_RELEASE_ID = "33333333-3333-3333-3333-333333333333"
+RECORDING_ID = "44444444-4444-4444-4444-444444444444"
+
+
+
+def _comparison(release_id: str = RELEASE_ID, rgid: str = RGID) -> dict:
+    return {
+        "ok": True,
+        "selected_release_group_id": rgid,
+        "mb_releasegroupid": rgid,
+        "representative_release_id": release_id,
+        "mb_albumid": release_id,
+        "identity_validated": True,
+        "mb_track_count": 1,
+        "local_track_count": 1,
+        "matched_count": 1,
+        "extra_count": 0,
+        "comparison": [{"status": "matched", "local_title": "Song", "mb_title": "Song"}],
+        "preflight": {"ok": True, "matches": 1, "expected": 1, "audio_count": 1, "match_ratio": 1.0, "source_match_ratio": 1.0},
+    }
+
+
+def _tracklist(release_id: str = RELEASE_ID, rgid: str = RGID) -> dict:
+    return {
+        "ok": True,
+        "release_group": rgid,
+        "mb_albumid": release_id,
+        "release_title": "Manual Album",
+        "release_artist": "Manual Artist",
+        "tracks": [{"title": "Song", "position": 1, "length": 180000}],
+    }
+
+
+def _load_app_for_manual_id_tests():
+    tmp = tempfile.TemporaryDirectory()
+    env = {
+        "BEETSDIR": str(Path(tmp.name) / "config"),
+        "BEETS_LIBRARY": str(Path(tmp.name) / "config" / "musiclibrary.blb"),
+        "AI_BATCH_STATE_DIR": str(Path(tmp.name) / "ai_batch_jobs"),
+        "METADATA_CACHE_DIR": str(Path(tmp.name) / "cache"),
+        "BEETS_TRANSACTION_DIR": str(Path(tmp.name) / "transactions"),
+        "BEETS_WEB_AUTH_DISABLED": "1",
+    }
+    Path(env["BEETSDIR"]).mkdir(parents=True, exist_ok=True)
+    for key in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "AI_API_KEY"):
+        env[key] = ""
+    patcher = mock.patch.dict(os.environ, env, clear=False)
+    patcher.start()
+    sys.path.insert(0, str(ROOT))
+    sys.modules.pop("app", None)
+    app_module = importlib.import_module("app")
+    app_module.app.config.update(TESTING=True)
+    return tmp, patcher, app_module
+
+
+def _section(source: str, start: str, end: str) -> str:
+    start_idx = source.index(start)
+    end_idx = source.index(end, start_idx)
+    return source[start_idx:end_idx]
+
+
+class ImportReviewRefreshUxTests(unittest.TestCase):
+    def test_queue_polling_no_longer_replaces_visible_state(self):
+        self.assertNotIn("if (!document.hidden) void loadQueue(true);", IMPORT_REVIEW_SOURCE)
+        self.assertIn("setQueueUpdatesAvailable(true)", IMPORT_REVIEW_SOURCE)
+        self.assertIn("Review queue updates are available.", IMPORT_REVIEW_SOURCE)
+        self.assertIn(">Load updates</Button>", IMPORT_REVIEW_SOURCE)
+
+    def test_background_check_does_not_apply_queue_payload(self):
+        effect = _section(
+            IMPORT_REVIEW_SOURCE,
+            "const id = window.setInterval(() => {",
+            "return () => window.clearInterval(id);",
+        )
+        self.assertIn("getReviewQueue({ limit: REVIEW_QUEUE_LIMIT, origin_type: sourceFilter })", effect)
+        self.assertIn("reviewQueueSnapshot(response.items ?? [], response.counts ?? {})", effect)
+        self.assertIn("setQueueUpdatesAvailable(true)", effect)
+        self.assertNotIn("setItems(", effect)
+        self.assertNotIn("setMbids(", effect)
+        self.assertNotIn("loadQueue(", effect)
+        self.assertIn("isEditableTarget(document.activeElement)", effect)
+        self.assertIn("confirmIntent", effect)
+
+    def test_active_item_is_restored_by_review_item_id(self):
+        self.assertIn("const [activeItemId, setActiveItemId] = useState('')", IMPORT_REVIEW_SOURCE)
+        self.assertIn("visibleItems.findIndex((item) => item.id === activeItemId)", IMPORT_REVIEW_SOURCE)
+        self.assertIn("setActiveItemId(visibleItems[clamped]?.id || '')", IMPORT_REVIEW_SOURCE)
+        self.assertIn("const activeItem = activeIndex >= 0 ? visibleItems[activeIndex] ?? null : null", IMPORT_REVIEW_SOURCE)
+
+    def test_per_item_state_survives_nonremoving_refresh(self):
+        load_queue = _section(IMPORT_REVIEW_SOURCE, "const loadQueue = useCallback(", "useEffect(() => {")
+        self.assertIn("for (const id of Object.keys(next)) if (!liveIds.has(id)) delete next[id]", load_queue)
+        self.assertIn("setManualValidations((current) => {", load_queue)
+        self.assertIn("function hasUnsavedManualId", IMPORT_REVIEW_SOURCE)
+        self.assertIn("function reviewInteractionIsExpanded", IMPORT_REVIEW_SOURCE)
+        selected_block = _section(load_queue, "setSelectedMatches((current) => {", "setTargetPreviews((current) => {")
+        self.assertNotIn("for (const id of changedIds) delete next[id]", selected_block)
+        mbid_block = _section(load_queue, "setMbids((current) => {", "    } catch (err) {")
+        self.assertNotIn("for (const id of changedIds) delete next[id]", mbid_block)
+        self.assertIn("for (const id of changedIds) delete targetPreviewKeysRef.current[id]", load_queue)
+
+
+class ImportReviewManualIdBackendTests(unittest.TestCase):
+    def test_manual_validation_route_and_parser_exist(self):
+        self.assertIn('@app.post("/api/import-review/manual-id/validate")', APP_SOURCE)
+        self.assertIn("def _parse_manual_musicbrainz_identifier", APP_SOURCE)
+        self.assertIn("release-group|release|recording", APP_SOURCE)
+        self.assertIn("This is not a valid MusicBrainz UUID or URL.", APP_SOURCE)
+        self.assertIn("uuid_match = re.fullmatch(", APP_SOURCE)
+
+    def test_album_manual_ids_use_backend_musicbrainz_validation(self):
+        fn = _section(APP_SOURCE, "def _manual_review_validate_album_identifier", "def _manual_review_validate_recording_identifier")
+        self.assertIn("_fetch_mb_release_tracklist(mbid, log)", fn)
+        self.assertIn("_mb_release_group_candidates(release_group_id, log)", fn)
+        self.assertIn("_resolve_release_group_to_release(", fn)
+        self.assertIn("_candidate_track_comparison_payload(", fn)
+        self.assertIn("_import_review_build_revalidated_match(", fn)
+        self.assertIn("_manual_review_wrong_type_response(\"album\", \"Recording\")", fn)
+
+    def test_recording_manual_ids_use_backend_recording_evidence(self):
+        fn = _section(APP_SOURCE, "def _manual_review_validate_recording_identifier", '@app.post("/api/import-review/manual-id/validate")')
+        self.assertIn("_fetch_mb_recording_details(mbid)", fn)
+        self.assertIn("_enrich_track_ai_candidate(current, candidate, details)", fn)
+        self.assertIn("_compact_track_ai_candidate(candidate)", fn)
+        self.assertIn("selected_recording_candidate", fn)
+        self.assertIn("recording_candidates", fn)
+
+    def test_manual_match_reuses_review_selected_match_contract(self):
+        fn = _section(APP_SOURCE, "def _manual_review_validate_album_identifier", "def _manual_review_validate_recording_identifier")
+        self.assertIn("_import_review_revalidation_preflight(comparison, acoustic_preflight)", fn)
+        self.assertIn("_import_review_build_revalidated_match(", fn)
+        self.assertIn("selected_match[\"source\"] = \"manual\"", fn)
+        self.assertNotIn("_manual_review_selected_match_from_comparison", APP_SOURCE)
+
+        builder = _section(APP_SOURCE, "def _import_review_build_revalidated_match", "def _update_pending_review_revalidation")
+        for field in (
+            '"release_group_id"',
+            '"representative_release_id"',
+            '"track_mapping"',
+            '"preflight_status"',
+            '"preflight_reason"',
+            '"identity_validated"',
+            '"is_importable"',
+            '"confidence_score"',
+            '"confidence_level"',
+            '"auto_fix_eligible"',
+            '"source"',
+        ):
+            self.assertIn(field, builder)
+
+
+class ImportReviewManualIdFrontendTests(unittest.TestCase):
+    def test_client_and_types_expose_manual_validation_endpoint(self):
+        self.assertIn("export interface ImportReviewManualIdPayload", TYPES_SOURCE)
+        self.assertIn("export interface ImportReviewManualIdResponse", TYPES_SOURCE)
+        self.assertIn("validateManualMusicBrainzId", CLIENT_SOURCE)
+        self.assertIn("'/api/import-review/manual-id/validate'", CLIENT_SOURCE)
+
+    def test_manual_id_controls_and_shortcut_are_present(self):
+        self.assertIn("Enter MusicBrainz ID", IMPORT_REVIEW_SOURCE)
+        self.assertIn("MusicBrainz Release or Release Group ID/URL", IMPORT_REVIEW_SOURCE)
+        self.assertIn("MusicBrainz Recording ID or URL", IMPORT_REVIEW_SOURCE)
+        self.assertIn("Validate ID", IMPORT_REVIEW_SOURCE)
+        self.assertIn("Clear Manual ID", IMPORT_REVIEW_SOURCE)
+        self.assertIn("Open in MusicBrainz", IMPORT_REVIEW_SOURCE)
+        self.assertIn("Use This Release", IMPORT_REVIEW_SOURCE)
+        self.assertIn("Choose Another Release", IMPORT_REVIEW_SOURCE)
+        shortcut_pos = IMPORT_REVIEW_SOURCE.index("if (e.key.toLowerCase() === 'i')")
+        start = IMPORT_REVIEW_SOURCE.rindex("const handler = (e: KeyboardEvent) => {", 0, shortcut_pos)
+        end = IMPORT_REVIEW_SOURCE.index("window.addEventListener('keydown', handler);", shortcut_pos)
+        keyboard = IMPORT_REVIEW_SOURCE[start:end]
+        self.assertIn("if (confirmIntent || isEditableTarget(e.target)) return;", keyboard)
+        self.assertIn("if (e.key.toLowerCase() === 'i')", keyboard)
+        self.assertIn("handleFocusManualEntry()", keyboard)
+
+    def test_manual_validation_updates_backend_owned_selected_match(self):
+        fn = _section(IMPORT_REVIEW_SOURCE, "const handleValidateManualId = useCallback(", "useEffect(() => {")
+        self.assertIn("validateManualMusicBrainzId({", fn)
+        self.assertIn("musicbrainz_id: value", fn)
+        self.assertIn("target_kind: item.target_kind", fn)
+        self.assertIn("setSelectedMatches((current) => ({ ...current, [item.id]: match }))", fn)
+        self.assertIn("setMbids((current) => ({ ...current, [item.id]: match.release_group_id", fn)
+        self.assertIn("selected_recording_candidate", fn)
+        self.assertIn("recording_candidates", fn)
+
+    def test_manual_match_flows_to_target_preview_and_apply(self):
+        self.assertNotIn("if (!selectedMatch || selectedMatch.source === 'manual') return '';", IMPORT_REVIEW_SOURCE)
+        self.assertNotIn("if (!importLike || !selectedMatch || selectedMatch.source === 'manual') return '';", IMPORT_REVIEW_SOURCE)
+        self.assertNotIn("if (!selectedMatch || selectedMatch.source === 'manual') return false", IMPORT_REVIEW_SOURCE)
+        self.assertNotIn("selectedMatch && selectedMatch.source !== 'manual'", IMPORT_REVIEW_SOURCE)
+        preview_effect = _section(IMPORT_REVIEW_SOURCE, "// Target path preview", "// Auto-start Find Match")
+        self.assertIn("if (!selectedMatch) return;", preview_effect)
+        self.assertIn("previewImportTarget({", preview_effect)
+        run_apply = _section(IMPORT_REVIEW_SOURCE, "const runApply = useCallback(", "const requestDismiss = useCallback(")
+        self.assertIn("mb_albumid: representativeId", run_apply)
+        self.assertIn("mb_releasegroupid: releaseGroupId || undefined", run_apply)
+        self.assertIn("track_mapping: sm?.track_mapping", run_apply)
+        self.assertIn("started = await attachRecording(item.item_id, representativeId);", run_apply)
+
+
+
+class ImportReviewMatchingSafetyUiTests(unittest.TestCase):
+    def test_api_types_include_backend_matching_safety_contract(self):
+        for field in (
+            "ai_available?: boolean",
+            "ai_unavailable_reason?: string",
+            "matching_method?: string",
+            "warnings?: string[]",
+            "action_eligibility?: unknown",
+            "eligibility_reason?: string",
+            "matching_contract?: Record<string, unknown>",
+            "fingerprint_conflicts?: string[]",
+            "recording_id_conflicts?: string[]",
+            "title_mismatch_warnings?: string[]",
+            "required_review?: boolean",
+            "selected_match?: ImportReviewSelectedMatch",
+        ):
+            self.assertIn(field, TYPES_SOURCE)
+
+    def test_review_page_displays_backend_safety_without_recomputing_authority(self):
+        self.assertIn("function MatchingSafetyPanel", IMPORT_REVIEW_SOURCE)
+        self.assertIn("data-import-review-matching-safety", IMPORT_REVIEW_SOURCE)
+        for label in (
+            "Backend matching safety",
+            "Matching source",
+            "AI availability",
+            "Eligibility decision",
+            "Eligibility reason",
+            "Required review",
+            "AcoustID corroboration",
+            "Warnings",
+        ):
+            self.assertIn(label, IMPORT_REVIEW_SOURCE)
+        self.assertIn("selectedMatch?.action_eligibility ?? suggestion?.action_eligibility ?? response?.action_eligibility", IMPORT_REVIEW_SOURCE)
+        self.assertIn("contract?.fingerprint_conflicts", IMPORT_REVIEW_SOURCE)
+        self.assertIn("contract?.recording_id_conflicts", IMPORT_REVIEW_SOURCE)
+        self.assertIn("contract?.title_mismatch_warnings", IMPORT_REVIEW_SOURCE)
+        self.assertNotIn("setSelectedMatches((current) => ({ ...current, [item.id]: buildCandidateSelectedMatch", IMPORT_REVIEW_SOURCE)
+
+    def test_find_match_consumes_deterministic_selected_match_and_ai_warning(self):
+        fn = _section(IMPORT_REVIEW_SOURCE, "const handleSuggest = useCallback(", "const startApply = useCallback(")
+        self.assertIn("const backendSelectedMatch = response.selected_match as unknown as SelectedMatch | undefined", fn)
+        self.assertIn("setSelectedMatches((current) => ({ ...current, [item.id]: backendSelectedMatch }))", fn)
+        self.assertIn("aiAvailable === false ? 'warning' : 'success'", fn)
+        self.assertIn("Matched using MusicBrainz and AcoustID", fn)
+        self.assertIn("optionalAiWarning(message)", fn)
+        self.assertIn("AI ranking was skipped because no provider is configured.", IMPORT_REVIEW_SOURCE)
+
+class ImportReviewManualIdBehaviorTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp, cls.env_patcher, cls.app_module = _load_app_for_manual_id_tests()
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.app_module.lib._close()
+        except Exception:
+            pass
+        cls.env_patcher.stop()
+        cls.tmp.cleanup()
+        sys.modules.pop("app", None)
+
+    def setUp(self):
+        self.client = self.app_module.app.test_client()
+
+    def _post(self, value: str, target_kind: str = "album"):
+        return self.client.post(
+            "/api/import-review/manual-id/validate",
+            json={"musicbrainz_id": value, "target_kind": target_kind, "path": "/tmp/manual-album", "item_id": 42},
+        )
+
+    def test_release_url_resolves_release_group_and_importable_match_without_ai_keys(self):
+        with mock.patch.object(self.app_module, "_fetch_mb_release_tracklist", return_value=_tracklist()), \
+             mock.patch.object(self.app_module, "_candidate_track_comparison_payload", return_value=_comparison()), \
+             mock.patch.object(self.app_module, "_run_ai_release_preflight", return_value={"ok": True}):
+            response = self._post(f"https://musicbrainz.org/release/{RELEASE_ID}?foo=bar#frag")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["entity_type"], "release")
+        self.assertEqual(body["release_group_id"], RGID)
+        self.assertEqual(body["representative_release_id"], RELEASE_ID)
+        self.assertEqual(body["selected_match"]["source"], "manual")
+        self.assertTrue(body["selected_match"]["is_importable"])
+
+    def test_release_group_url_selects_representative_release_before_validation(self):
+        candidates = [{"mb_albumid": ALT_RELEASE_ID, "mb_releasegroupid": RGID, "title": "Edition"}]
+        with mock.patch.object(self.app_module, "_mb_release_group_candidates", return_value=candidates), \
+             mock.patch.object(self.app_module, "_fetch_mb_release_tracklist", return_value=_tracklist(ALT_RELEASE_ID)), \
+             mock.patch.object(self.app_module, "_candidate_track_comparison_payload", return_value=_comparison(ALT_RELEASE_ID)), \
+             mock.patch.object(self.app_module, "_run_ai_release_preflight", return_value={"ok": True}):
+            response = self._post(f"https://musicbrainz.org/release-group/{RGID}/")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["entity_type"], "release-group")
+        self.assertEqual(body["release_group_id"], RGID)
+        self.assertEqual(body["representative_release_id"], ALT_RELEASE_ID)
+        self.assertEqual(body["selected_match"]["representative_release_id"], ALT_RELEASE_ID)
+        self.assertEqual(body["release_group_candidates"], candidates)
+
+    def test_recording_url_validates_recording_for_singleton_item(self):
+        details = {
+            "recording_id": RECORDING_ID,
+            "recording_title": "Song",
+            "recording_artist": "Manual Artist",
+            "linked_releases": [{"mb_albumid": RELEASE_ID, "mb_releasegroupid": RGID}],
+        }
+        fake_item = type("Item", (), {"title": "Song", "artist": "Manual Artist", "album": "", "albumartist": "", "year": "", "length": 180})()
+        with mock.patch.object(self.app_module, "_fetch_mb_recording_details", return_value=details), \
+             mock.patch.object(self.app_module.lib, "get_item", return_value=fake_item):
+            response = self._post(f"https://musicbrainz.org/recording/{RECORDING_ID}", target_kind="item")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["entity_type"], "recording")
+        self.assertEqual(body["mb_trackid"], RECORDING_ID)
+        self.assertEqual(body["selected_recording_candidate"]["mb_trackid"], RECORDING_ID)
+        self.assertEqual(body["recording_candidates"][0]["source"], "manual")
+
+    def test_wrong_entity_type_is_rejected_behaviorally(self):
+        response = self._post(f"https://musicbrainz.org/recording/{RECORDING_ID}", target_kind="album")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("requires album Release or Release Group ID", response.get_json()["error"])
+
+    def test_manual_match_builder_keeps_target_preview_eligible_contract(self):
+        selected = self.app_module._import_review_build_revalidated_match(
+            {"suggestion": {"confidence": "high"}},
+            _comparison(),
+            {"ok": True, "matches": 1, "expected": 1, "audio_count": 1, "match_ratio": 1.0, "source_match_ratio": 1.0},
+        )
+        self.assertEqual(selected["release_group_id"], RGID)
+        self.assertEqual(selected["representative_release_id"], RELEASE_ID)
+        self.assertTrue(selected["is_importable"])
+        self.assertTrue(selected["auto_fix_eligible"])
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_import_review_quality_filters.py
+++ b/tests/test_import_review_quality_filters.py
@@ -81,7 +81,7 @@ class ImportReviewQualityFilterTests(unittest.TestCase):
         self.assertIn("Once a visible candidate is selected, show that candidate's state instead of stale stored evidence.", review_source)
         self.assertIn("function shouldShowReadyBucket(", review_source)
         self.assertIn("if (shouldShowBlockedBucket(item, mbid, selectedMatch, targetPreviewState)) return false", review_source)
-        self.assertIn("if (!selectedMatch || selectedMatch.source === 'manual') return false", review_source)
+        self.assertIn("if (!selectedMatch) return false", review_source)
         self.assertIn("if (!selectedMatch.is_importable) return false", review_source)
         self.assertIn("if (selectedMatch.preflight_status !== 'passed') return false", review_source)
         self.assertIn("if (!preview || !preview.safe) return false", review_source)
@@ -102,9 +102,9 @@ class ImportReviewQualityFilterTests(unittest.TestCase):
         self.assertIn("Review required because this match is below the 60% auto-import threshold.", review_source)
         self.assertIn("Auto-import eligible — ${formatPercent(confidenceScore)} confidence.", review_source)
         self.assertIn("const autoFixRequiresReview = false", review_source)
-        self.assertIn("const selectedConfidence = selectedMatch && selectedMatch.source !== 'manual'", review_source)
+        self.assertIn("const selectedConfidence = selectedMatch ? selectedMatch.confidence_level : null", review_source)
         self.assertIn("selectedConfidenceText || (item.confidence ? `${item.confidence} confidence` : '')", review_source)
-        self.assertIn("const selectedMatchActive = Boolean(selectedMatch && selectedMatch.source !== 'manual')", review_source)
+        self.assertIn("const selectedMatchActive = Boolean(selectedMatch)", review_source)
         self.assertIn("const blockedActive = shouldShowBlockedBucket(item, mbid, selectedMatch, targetPreviewState)", review_source)
         self.assertIn("const visibleMatchBucket: MatchBucket = audioMismatchActive", review_source)
         self.assertIn(": blockedActive", review_source)
@@ -136,6 +136,8 @@ class ImportReviewQualityFilterTests(unittest.TestCase):
         self.assertIn("Save ID only", review_source)
         self.assertNotIn("Save Release Group ID", review_source)
         self.assertIn("getReviewQueue({ limit: REVIEW_QUEUE_LIMIT, origin_type: sourceFilter })", review_source)
+        self.assertNotIn("if (!selectedMatch || selectedMatch.source === 'manual') return '';", review_source)
+        self.assertNotIn("if (!importLike || !selectedMatch || selectedMatch.source === 'manual') return '';", review_source)
 
         self.assertIn("export function previewImportTarget", client_source)
         self.assertIn("'/api/folders/import-target-preview'", client_source)
@@ -349,8 +351,3 @@ class ImportReviewQualityFilterTests(unittest.TestCase):
         self.assertIn("'format_policy_rejected'", blocked_block)
 if __name__ == "__main__":
     unittest.main()
-
-
-
-
-

--- a/tests/test_import_review_recording_id_frontend.py
+++ b/tests/test_import_review_recording_id_frontend.py
@@ -124,9 +124,12 @@ class ImportReviewRecordingIdFrontendTests(unittest.TestCase):
     def test_recording_rows_stay_out_of_album_match_state(self):
         self.assertIn("if (item.target_kind === 'item') return item.mb_trackid || '';", IMPORT_REVIEW_SOURCE)
         handler = _source_between(IMPORT_REVIEW_SOURCE, "const handleMbidChange = useCallback(", "const handleUseCandidate = useCallback(")
-        self.assertIn("if (item.target_kind === 'item')", handler)
-        self.assertIn("delete next[item.id];", handler)
+        self.assertNotIn("if (item.target_kind === 'item')", handler)
+        self.assertIn("MusicBrainz ID changed. Validate ID before importing.", handler)
         self.assertIn("delete targetPreviewKeysRef.current[item.id];", handler)
+        use_candidate = _source_between(IMPORT_REVIEW_SOURCE, "const handleUseCandidate = useCallback(", "const handleSelectMatch = useCallback(")
+        self.assertIn("if (activeItem.target_kind === 'item')", use_candidate)
+        self.assertIn("delete next[activeItem.id];", use_candidate)
 
 
 if __name__ == "__main__":

--- a/tests/test_review_queue_singleton_items.py
+++ b/tests/test_review_queue_singleton_items.py
@@ -125,7 +125,7 @@ class FrontendSingletonWiringTests(unittest.TestCase):
         self.assertIn("item.target_kind === 'item' ? 'Attach recording ID' : 'Match album'", IMPORT_REVIEW_SOURCE)
 
     def test_mbid_field_label_reflects_recording_for_item_rows(self):
-        self.assertIn("item.target_kind === 'item' ? 'MusicBrainz Recording ID' : 'MusicBrainz Release Group ID'", IMPORT_REVIEW_SOURCE)
+        self.assertIn("item.target_kind === 'item' ? 'MusicBrainz Recording ID or URL' : 'MusicBrainz Release or Release Group ID/URL'", IMPORT_REVIEW_SOURCE)
 
     def test_album_only_actions_stay_hidden_for_item_rows(self):
         # isLibraryNoMb (gates "Prepare MB Submission" / "Add MBIDs", both


### PR DESCRIPTION
## Scope

Narrow replacement for part of PR #17 (`fix/import-review-ux`), which mixed unrelated concerns. This PR carries **only** the Import Review manual-MusicBrainz-ID / optional-AI-display content from that diff.

**Files changed:**
- `app.py` — new `POST /api/import-review/manual-id/validate` endpoint. Accepts a raw MusicBrainz UUID or URL, classifies it as `release` / `release-group` / `recording`, rejects the wrong entity type for the target row (e.g. a Recording ID pasted onto an album row) with a clear error, and for album targets resolves the release-group-to-release chain and runs it through the existing `_candidate_track_comparison_payload` / preflight pipeline so a pasted ID is checked against real tracklist evidence, not just UUID syntax. Recording-ID validation reuses the existing recording-candidate evidence/enrichment pipeline (`_enrich_track_ai_candidate`, `_compact_track_ai_candidate`) so manually entered recording IDs carry the same conflict/safety fields as AI/AcoustID-sourced candidates. All helper functions this calls (`_fetch_mb_release_tracklist`, `_mb_release_group_candidates`, `_resolve_release_group_to_release`, `_run_ai_release_preflight`, `_import_review_build_revalidated_match`, etc.) already existed on `main`.
- `frontend/src/api/client.ts`, `frontend/src/api/types.ts` — `validateManualMusicBrainzId()` client call and matching `ImportReviewManualIdPayload`/`ImportReviewManualIdResponse`/`ImportReviewSelectedMatch` types; `ReviewItem`/`AiSuggestion`/`AiSuggestResponse` gain optional passthrough fields (`ai_available`, `ai_unavailable_reason`, `matching_method`, `warnings`, `action_eligibility`, `eligibility_reason`, `matching_contract`, `acoustid_corroboration`, `fingerprint_conflicts`, `recording_id_conflicts`, `title_mismatch_warnings`, `required_review`) so the UI can display backend-computed values. (The `SetupStatusResponse.beets`/integration `state` fields from the fresh-install PR are not included here.)
- `frontend/src/features/importReview/ImportReviewPage.tsx` — replaces the old "AI Suggest"-only / release-group-ID-only manual entry with "Find Match" / "Enter MusicBrainz ID" / "Validate ID" UX that accepts Release, Release Group, or Recording IDs and URLs; adds a "Backend matching safety" panel that displays the `matching_method`/`action_eligibility`/`warnings`/`acoustid_corroboration`/conflict fields already returned by the suggest endpoints (display-only — no new client-side eligibility computation); manual matches are no longer special-cased out of the ready/blocked bucket logic (`selectedMatch.source === 'manual'` checks removed) since they now go through the same backend validation/preflight as AI-sourced matches.
- Tests: new `tests/test_import_review_manual_id_workflow.py` (20 tests exercising the real Flask route with MusicBrainz/preflight calls mocked at the boundary); updated `tests/test_import_review_button_contrast.py`, `tests/test_import_review_quality_filters.py`, `tests/test_import_review_recording_id_frontend.py`, `tests/test_review_queue_singleton_items.py` for the new UI copy/logic.

**Explicitly excluded from this PR:**
- Beets/plugin packaging, Dockerfile/compose, `config.yaml.example`, `requirements.txt`, Setup/System diagnostics (see companion PR A, `fix/beets-fresh-install-plugins`).
- `frontend/package.json` / `frontend/package-lock.json` — **zero changes**. This branch still shows the original pre-PR-#18 postcss/sharp advisories (`npm ci` reports 1 moderate, 2 high) because it branches from `main` before PR #18 merges. That is expected; do not fix here — rebase onto `main` after PR #18 merges.
- **Attach-endpoint matching-contract enforcement is NOT implemented in this PR.** Specifically not present: mutation-time decision reconstruction, requested-recording-ID-equals-backend-resolved-ID enforcement, trusted candidate-set membership checks, ignoring client-supplied safety fields, safe-vs-confirmed attach modes, explicit review confirmation, decision-version/staleness protection, audit record, undo/recovery data, idempotent attachment, or partial-failure rollback for the attach endpoint. This branch only adds a *read-only* validation/lookup endpoint and review-page display. That enforcement work is separate, future work (verified: no `attach`/`decision_version`/`staleness`/`idempot`/`audit_record`/`rollback`/`undo` logic appears anywhere in this diff).

## Tests (all run from this branch)

| Check | Result |
|---|---|
| `python -m unittest tests.test_import_review_manual_id_workflow` | PASS (20 tests) |
| `python -m unittest tests.test_import_review_button_contrast` | PASS (7 tests) |
| `python -m unittest tests.test_import_review_quality_filters` | PASS (13 tests) |
| `python -m unittest tests.test_import_review_recording_id_frontend` | PASS (10 tests) |
| `python -m unittest tests.test_review_queue_singleton_items` | PASS (17 tests) |
| `python -m unittest tests.test_matching_contract` | PASS (146 tests) — pre-existing on `main`, unmodified by this branch; confirms existing matching-contract behavior stays intact |
| `python -m py_compile app.py` | PASS |
| `python -m unittest discover -s tests -p "test_*.py"` | PASS — 1116 tests, 0 failures |
| `npm ci` (frontend) | PASS (3 pre-existing postcss/sharp advisories, expected — see above) |
| `npm run typecheck` | PASS |
| `npm run lint` | PASS |
| `npm run build` | PASS |

Confirmed: manual release UUID/URL validation works and is checked against real backend tracklist evidence; manual Release Group ID resolves to a representative release; manual recording ID validation uses backend evidence/enrichment; AI stays optional everywhere (no matching path requires an AI key); deterministic MusicBrainz/AcoustID matching is unaffected; frontend does not compute authoritative eligibility (only displays backend-provided fields); existing matching-contract test suite passes unchanged.

## Relationship to other PRs

- Independent of PR #18 (`frontend-dependency-security`, draft) — no file overlap; will need a rebase (lockfile only) once #18 merges, no code changes anticipated.
- Companion to Replacement PR A (`fix/beets-fresh-install-plugins`) — both replace PR #17 (`fix/import-review-ux`), which is being converted to draft and closed once both land as open draft PRs.
- Does not build on or reference `origin/import-review-attach-enforcement` (separate, out-of-scope effort).