### PR TITLE
fix: sanitize CodeQL exception responses

### DIFF
--- a/app.py
+++ b/app.py
@@ -16970,7 +16970,8 @@ def _candidate_track_comparison_payload(
     try:
         candidates = _candidate_track_local_candidates(folder)
     except Exception as ex:
-        return {"ok": False, "error": f"Local folder scan failed: {ex}"}
+        app.logger.error("Import Review local folder scan failed: %s", type(ex).__name__)
+        return {"ok": False, "error": "Track comparison could not be completed."}
 
     selected_rgid = _extract_mb_uuid(release_group_id)
     rep_id = _extract_mb_uuid(mb_albumid)
@@ -17074,7 +17075,7 @@ def _candidate_track_comparison_payload(
     if not tracklist.get("ok"):
         return {
             "ok": False,
-            "error": tracklist.get("error", "MB tracklist fetch failed"),
+            "error": "MusicBrainz lookup failed.",
         }
     return _candidate_track_build_comparison(
         mb_albumid,
@@ -17138,6 +17139,22 @@ def _manual_review_wrong_type_response(target_kind: str, entity_type: str) -> Tu
     }, 400
 
 
+def _manual_review_public_comparison_error(error: Any) -> str:
+    text = _s(error or "").strip()
+    lower = text.lower()
+    if not text:
+        return "Track comparison could not be completed."
+    if "none of the local tracks match" in lower:
+        return "The ID is valid, but none of the local tracks match this release."
+    if "release group lookup returned no usable releases" in lower:
+        return "MusicBrainz release group lookup returned no usable releases."
+    if "representative release id rejected" in lower or "does not belong to selected release group" in lower:
+        return "The selected Release does not belong to the expected Release Group."
+    if "no representative release" in lower:
+        return "No representative release under the selected Release Group could be loaded."
+    return "Track comparison could not be completed."
+
+
 def _manual_review_validate_album_identifier(parsed: Dict[str, str], payload: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
     entity_type = parsed.get("entity_type") or "unknown"
     mbid = parsed.get("mbid") or ""
@@ -17185,14 +17202,13 @@ def _manual_review_validate_album_identifier(parsed: Dict[str, str], payload: Di
         release_group_id=release_group_id if entity_type == "release-group" else "",
     )
     if not comparison.get("ok"):
-        error = _s(comparison.get("error") or "MusicBrainz ID validation failed.")
         return {
             "ok": False,
             "entity_type": entity_type,
             "mbid": mbid,
             "representative_release_id": resolved_release_id,
             "release_group_id": release_group_id,
-            "error": error,
+            "error": _manual_review_public_comparison_error(comparison.get("error")),
         }, 400
     representative_release_id = _extract_mb_uuid(
         _s(comparison.get("representative_release_id") or comparison.get("mb_albumid") or resolved_release_id)
@@ -17315,10 +17331,14 @@ def import_review_manual_id_validate():
     if not parsed.get("ok"):
         return jsonify(parsed), 400
     target_kind = _s(payload.get("target_kind") or "").strip().lower()
-    if target_kind == "item":
-        body, status = _manual_review_validate_recording_identifier(parsed, payload)
-    else:
-        body, status = _manual_review_validate_album_identifier(parsed, payload)
+    try:
+        if target_kind == "item":
+            body, status = _manual_review_validate_recording_identifier(parsed, payload)
+        else:
+            body, status = _manual_review_validate_album_identifier(parsed, payload)
+    except Exception as ex:
+        app.logger.error("Manual MusicBrainz validation failed: %s", type(ex).__name__)
+        return jsonify({"ok": False, "error": "MusicBrainz validation could not be completed."}), 500
     return jsonify(body), status
 
 def _target_preview_year(value: Any) -> str:
@@ -29336,15 +29356,17 @@ def _fetch_mb_release_tracklist(mb_albumid: str, log: Optional[List[str]] = None
             transient = code in transient_codes or "timed out" in reason or "temporarily" in reason
             if transient and attempt < 3:
                 if log is not None:
+                    public_reason = code if code is not None else "transient network error"
                     log.append(
-                        f"  MB fetch transient error ({code or reason or ex}); "
+                        f"  MB fetch transient error ({public_reason}); "
                         f"retrying {attempt + 1}/3"
                     )
                 time.sleep(1.5 * attempt)
                 continue
             if log is not None:
-                log.append(f"  MB fetch failed: {ex}")
-            return {"ok": False, "error": str(ex), "tracks": []}
+                log.append("  MB fetch failed: MusicBrainz lookup failed.")
+            app.logger.error("MusicBrainz release lookup failed: %s", type(ex).__name__)
+            return {"ok": False, "error": "MusicBrainz lookup failed.", "tracks": []}
 
     release_artist_info = _playlist_artist_credit_info(mb_data.get("artist-credit") or [])
     release_artist = release_artist_info.get("albumartist", "")

--- a/routes_setup.py
+++ b/routes_setup.py
@@ -458,6 +458,8 @@ def _check_path(path_value: str, *, require_writable: bool) -> Dict[str, Any]:
 
 
 
+_BEETS_DIAGNOSTIC_COMMAND_FAILED = "Beets diagnostic command failed."
+
 _BEETS_PLUGIN_FAILURE_PATTERNS = (
     "error loading plugin",
     "modulenotfounderror",
@@ -571,7 +573,8 @@ def _run_beet_diagnostic(args: List[str], config_path: Path | None = None, timeo
             "stderr": _redact_diagnostic_text(proc.stderr or ""),
         }
     except Exception as ex:
-        return {"available": True, "path": beet_bin, "returncode": None, "stdout": "", "stderr": str(ex)}
+        app.logger.error("Beets diagnostic command failed: %s", type(ex).__name__)
+        return {"available": True, "path": beet_bin, "returncode": None, "stdout": "", "stderr": _BEETS_DIAGNOSTIC_COMMAND_FAILED}
 
 
 def _diagnostic_failure_lines(text: str) -> List[str]:
@@ -596,10 +599,17 @@ def _beets_plugin_diagnostics(config_path: Path) -> Dict[str, Any]:
     combined = "\n".join([plugin_probe.get("stdout", ""), plugin_probe.get("stderr", "")])
     failures = _diagnostic_failure_lines(combined)
     version_text = (version_probe.get("stdout") or version_probe.get("stderr") or "").strip().splitlines()
+    diagnostic_error = (
+        _BEETS_DIAGNOSTIC_COMMAND_FAILED
+        if version_probe.get("stderr") == _BEETS_DIAGNOSTIC_COMMAND_FAILED
+        or plugin_probe.get("stderr") == _BEETS_DIAGNOSTIC_COMMAND_FAILED
+        else ""
+    )
     return {
         "available": bool(version_probe.get("available")),
         "path": version_probe.get("path", ""),
         "version": version_text[0] if version_text else "",
+        "diagnostic_error": diagnostic_error,
         "configured_plugins": config_summary["plugins"],
         "pluginpath": config_summary["pluginpath"],
         "plugin_failures": failures,

--- a/tests/test_import_review_manual_id_workflow.py
+++ b/tests/test_import_review_manual_id_workflow.py
@@ -25,6 +25,7 @@ RGID = "11111111-1111-1111-1111-111111111111"
 RELEASE_ID = "22222222-2222-2222-2222-222222222222"
 ALT_RELEASE_ID = "33333333-3333-3333-3333-333333333333"
 RECORDING_ID = "44444444-4444-4444-4444-444444444444"
+SENSITIVE_EXCEPTION_TEXT = '/database/internal/path token=super-secret-key Traceback... File "secret.py", line 7'
 
 
 
@@ -349,6 +350,45 @@ class ImportReviewManualIdBehaviorTests(unittest.TestCase):
         response = self._post(f"https://musicbrainz.org/recording/{RECORDING_ID}", target_kind="album")
         self.assertEqual(response.status_code, 400)
         self.assertIn("requires album Release or Release Group ID", response.get_json()["error"])
+
+    def assertNoSensitiveExceptionDetails(self, response):
+        text = response.get_data(as_text=True)
+        for forbidden in ("super-secret-key", "/database/internal/path", "Traceback", 'File "', "line 7"):
+            self.assertNotIn(forbidden, text)
+
+    def test_unexpected_manual_release_lookup_exception_is_sanitized(self):
+        with mock.patch.object(self.app_module, "_fetch_mb_release_tracklist", side_effect=RuntimeError(SENSITIVE_EXCEPTION_TEXT)):
+            response = self._post(f"https://musicbrainz.org/release/{RELEASE_ID}")
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.get_json()["error"], "MusicBrainz validation could not be completed.")
+        self.assertNoSensitiveExceptionDetails(response)
+
+    def test_manual_track_comparison_failure_does_not_leak_nested_error(self):
+        with mock.patch.object(self.app_module, "_fetch_mb_release_tracklist", return_value=_tracklist()), \
+             mock.patch.object(self.app_module, "_candidate_track_comparison_payload", return_value={"ok": False, "error": SENSITIVE_EXCEPTION_TEXT}):
+            response = self._post(f"https://musicbrainz.org/release/{RELEASE_ID}")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "Track comparison could not be completed.")
+        self.assertNoSensitiveExceptionDetails(response)
+
+    def test_candidate_track_endpoint_local_scan_exception_is_sanitized(self):
+        with mock.patch.object(self.app_module, "_candidate_track_local_candidates", side_effect=RuntimeError(SENSITIVE_EXCEPTION_TEXT)):
+            response = self.client.get(f"/api/candidates/{RELEASE_ID}/tracks?folder=/tmp/manual-album")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "Track comparison could not be completed.")
+        self.assertNoSensitiveExceptionDetails(response)
+
+    def test_candidate_track_endpoint_musicbrainz_error_is_sanitized(self):
+        with mock.patch.object(self.app_module, "_candidate_track_local_candidates", return_value=[]), \
+             mock.patch.object(self.app_module, "_fetch_mb_release_tracklist", return_value={"ok": False, "error": SENSITIVE_EXCEPTION_TEXT}):
+            response = self.client.get(f"/api/candidates/{RELEASE_ID}/tracks?folder=/tmp/manual-album")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "MusicBrainz lookup failed.")
+        self.assertNoSensitiveExceptionDetails(response)
 
     def test_manual_match_builder_keeps_target_preview_eligible_contract(self):
         selected = self.app_module._import_review_build_revalidated_match(

--- a/tests/test_routes_setup.py
+++ b/tests/test_routes_setup.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import types
 import unittest
+import unittest.mock as mock
 from pathlib import Path
 
 
@@ -77,6 +78,26 @@ class RoutesSetupStatusTests(unittest.TestCase):
         r = self.client.get("/api/setup/status")
         settings = r.get_json()["settings"]
         self.assertNotIn("verysecretvalue123", str(settings))
+
+    def test_status_sanitizes_beets_diagnostic_exceptions(self):
+        sensitive = "/database/internal/path token=super-secret-key Traceback... File \"secret.py\", line 7"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_dir = root / "config"
+            config_dir.mkdir()
+            config_file = config_dir / "config.yaml"
+            config_file.write_text("plugins: musicbrainz\n", encoding="utf-8")
+            with mock.patch.dict(os.environ, {"BEETSDIR": str(config_dir), "BEETS_CONFIG": str(config_file)}, clear=False), \
+                 mock.patch.object(self.module, "_beet_binary", return_value=(True, "beet")), \
+                 mock.patch.object(self.module.subprocess, "run", side_effect=RuntimeError(sensitive)):
+                response = self.client.get("/api/setup/status")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["beets"]["diagnostic_error"], "Beets diagnostic command failed.")
+        text = response.get_data(as_text=True)
+        for forbidden in ("super-secret-key", "/database/internal/path", "Traceback", 'File "', "line 7"):
+            self.assertNotIn(forbidden, text)
 
     def test_status_reports_demo_mode_flag(self):
         r = self.client.get("/api/setup/status")


### PR DESCRIPTION
## Problem

While PR #17 (\`fix/import-review-ux\`) was being split into narrower replacement PRs (#20, #21) and closed as superseded, a commit was pushed to that branch outside of this working session, and the PR was reopened and marked ready for review with a rewritten description. That commit (\`0b9d0e99\`, "fix: sanitize CodeQL exception responses") contains genuine security-hardening work not present in #20 or #21:

- \`app.py\`: manual MusicBrainz validation and candidate track-comparison failures now return stable public messages instead of nested helper exception text (unexpected manual validation exceptions return \`MusicBrainz validation could not be completed.\`, and logs record only the exception category).
- \`routes_setup.py\`: Beets diagnostic command exceptions now return \`Beets diagnostic command failed.\` in setup status; raw subprocess/exception text is no longer exposed in the public response.
- Regression tests using exception text containing a token, filesystem path, traceback marker, file name, and line number, asserting those fragments are absent from HTTP responses while expected public validation errors remain useful.

Since PR #17 is being re-closed as superseded (its other content already merged via #18, #20, #21), this commit needed a home so it isn't lost.

## Resolution

Cherry-picked commit \`0b9d0e99\` cleanly onto a fresh branch off current \`main\` (post #18/#20/#21 merges). No conflicts, no manual adjustment needed.

## Validation

- \`python -m py_compile app.py routes_setup.py\`: passed
- \`python -m unittest tests.test_import_review_manual_id_workflow tests.test_routes_setup\`: passed (46 tests, OK)
- \`python -m unittest discover -s tests -p "test_*.py"\`: passed (1128 tests, OK, 1 skip)

## Scope

Only touches CodeQL exception-message sanitization in \`app.py\` and \`routes_setup.py\`, plus their regression tests. Does not include any Import Review UX, manual MBID, optional-AI, or Beets packaging changes — those are already merged via #20 and #21.

Left as draft pending independent review.