### PR TITLE
fix: make Beets plugin diagnostics truthful and redacted

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -450,7 +450,14 @@ export interface SetupStatusResponse {
     configured_plugins?: string[];
     pluginpath?: string[];
     plugin_failures?: string[];
+    /** Exit code of the supported plugin-loader probe (`beet -c <config>
+     * -vv version`) -- kept under its original name for compatibility, but
+     * it no longer reflects an unsupported `beet plugins` command. */
     plugins_returncode?: number | null;
+    plugin_loader_returncode?: number | null;
+    plugin_loader_ok?: boolean;
+    plugin_loader_timed_out?: boolean;
+    plugin_loader_error?: string;
     replaygain_backend?: string;
     replaygain_command?: string;
     discogs_token_configured?: boolean;
@@ -464,7 +471,7 @@ export interface SetupStatusResponse {
   integrations: Record<string, {
     configured: boolean;
     required: boolean;
-    state?: 'configured' | 'not_configured' | 'installed_but_disabled' | 'dependency_plugin_missing' | 'connection_test_failed' | 'connected' | string;
+    state?: 'configured' | 'not_configured' | 'installed_but_disabled' | 'dependency_plugin_missing' | 'plugin_loader_failed' | 'connection_test_failed' | 'connected' | string;
     note?: string;
     detail?: string;
   }>;

--- a/frontend/src/views/System.tsx
+++ b/frontend/src/views/System.tsx
@@ -55,8 +55,20 @@ function integrationBadge(
   if (state === 'configured') return { icon: '✓', label: 'Configured', tone: 'ok' };
   if (state === 'installed_but_disabled') return { icon: '○', label: 'Installed but disabled', tone: integration.required ? 'warn' : 'neutral' };
   if (state === 'dependency_plugin_missing') return { icon: '⚠', label: 'Dependency/plugin missing', tone: 'warn' };
+  if (state === 'plugin_loader_failed') return { icon: '⚠', label: 'Plugin loader failed', tone: 'warn' };
   if (state === 'connection_test_failed') return { icon: '⚠', label: 'Connection test failed', tone: 'warn' };
   return { icon: '✗', label: 'Not configured', tone: integration.required ? 'warn' : 'neutral' };
+}
+
+/** Reflects the backend-reported plugin-loader probe state only (never
+ * recomputed client-side from configured_plugins/plugin_failures) --
+ * `beets.available`/`plugin_loader_timed_out`/`plugin_loader_ok` are the
+ * single sources of truth from /api/setup/status. */
+function pluginLoaderLabel(beets: NonNullable<SetupStatusResponse['beets']>): string {
+  if (!beets.available) return 'unavailable';
+  if (beets.plugin_loader_timed_out) return 'timed out';
+  if (beets.plugin_loader_ok) return 'loaded';
+  return 'failed';
 }
 
 function initialFormValues(variables: SetupEnvVariable[]): Record<string, string> {
@@ -662,11 +674,16 @@ export default function System() {
             <div><span className="font-semibold text-zinc-100">Plugin path:</span> {status.beets.pluginpath?.join(' then ') || 'not configured'}</div>
             <div><span className="font-semibold text-zinc-100">ReplayGain:</span> {status.beets.replaygain_backend || status.beets.replaygain_command || 'not configured'}</div>
             <div><span className="font-semibold text-zinc-100">Enabled plugins:</span> {status.beets.configured_plugins?.length ?? 0}</div>
-            <div><span className="font-semibold text-zinc-100">Plugin loader:</span> {status.beets.plugins_returncode === 0 ? 'loaded' : 'check details'}</div>
+            <div><span className="font-semibold text-zinc-100">Plugin loader:</span> {pluginLoaderLabel(status.beets)}</div>
           </div>
           {status.beets.plugin_failures?.length ? (
             <Alert severity="warning" className="mt-3">
               {status.beets.plugin_failures.join(' ')}
+            </Alert>
+          ) : null}
+          {!status.beets.plugin_failures?.length && status.beets.plugin_loader_error ? (
+            <Alert severity="warning" className="mt-3">
+              {status.beets.plugin_loader_error}
             </Alert>
           ) : null}
         </section>

--- a/routes_setup.py
+++ b/routes_setup.py
@@ -468,14 +468,70 @@ _BEETS_PLUGIN_FAILURE_PATTERNS = (
     "replaygain initialization failed",
 )
 
+# Supported Beets 2.12.0 loader probe: `beet plugins` does not exist in
+# Beets 2.12.0 and previously made every configured plugin look healthy
+# whenever the (unsupported) command merely failed to run. `-vv version`
+# is a real, supported, noninteractive, read-only command that still loads
+# the exact configured plugin list and pluginpath before printing the
+# version -- Beets initializes plugins during UI startup regardless of
+# which subcommand is requested, so a plugin import/initialization failure
+# surfaces here exactly as it does for `beet -c ... -vv version` in the
+# Docker smoke test (tests/test_beets_fresh_install_plugins.py).
+_BEET_LOADER_PROBE_ARGS = ["-vv", "version"]
+
+_REDACTED = "[redacted]"
+
+# Named key/value secrets: matches any identifier ending in one of the
+# listed keywords (api_key/token/password/secret/auth), regardless of what
+# prefix precedes it -- e.g. lidarr_api_key, slskd_api_key, plex_token,
+# discogs_user_token, access_token, refresh_token, client_secret,
+# user_token, auth_token all end in a covered keyword and are redacted by
+# this single pattern without needing to enumerate every provider name.
+_SECRET_KV_RE = re.compile(
+    r"""(?ix)
+    \b([a-z0-9_-]*?(?:api[_-]?key|client[_-]?secret|token|password|secret|auth))
+    (\s*[:=]\s*)
+    (?:"([^"]*)"|'([^']*)'|([^\s,;}\]&]+))
+    """,
+    re.VERBOSE,
+)
+
+# Authorization / Proxy-Authorization headers, with or without a Bearer/Basic
+# scheme prefix (the scheme itself is not secret and is kept for context).
+_AUTH_HEADER_RE = re.compile(r"(?i)\b(Authorization|Proxy-Authorization)(\s*:\s*)(?:(Bearer|Basic)(\s+))?(\S+)")
+
+# Cookie / Set-Cookie header values.
+_COOKIE_HEADER_RE = re.compile(r"(?i)\b(Set-Cookie|Cookie)(\s*:\s*)(\S+)")
+
+# Credentials embedded in a URL's userinfo, e.g. https://user:password@host/
+_URL_CREDENTIAL_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^\s/@]+@")
+
 
 def _redact_diagnostic_text(text: str) -> str:
+    """Redact secret-bearing diagnostic text before it can reach the System
+    page. Covers named key/value secrets (quoted or bare, any prefix ending
+    in api_key/token/password/secret/auth), Authorization/Proxy-Authorization
+    headers (Bearer/Basic or bare), Cookie/Set-Cookie headers, query-string
+    credentials, and credentials embedded in a URL's userinfo. Safe to call
+    more than once on the same text (idempotent defense-in-depth)."""
     redacted = str(text or "")
-    redacted = re.sub(
-        r"(?i)((?:api[_-]?key|token|password|secret)\s*[:=]\s*)([^\s,'\"]+)",
-        r"\1[redacted]",
+    try:
+        # Reuse app.py's generic secret-assignment/control-char sanitizer
+        # (added for CodeQL exception sanitization) as a first pass when the
+        # real app module is importable. routes_setup is also exercised in
+        # tests against a bare stub `app` module (see test_routes_setup.py),
+        # so this must degrade gracefully rather than raise.
+        from app import _redact_security_text
+        redacted = _redact_security_text(redacted)
+    except Exception:
+        pass
+    redacted = _AUTH_HEADER_RE.sub(
+        lambda m: f"{m.group(1)}{m.group(2)}{m.group(3) or ''}{m.group(4) or ''}{_REDACTED}",
         redacted,
     )
+    redacted = _COOKIE_HEADER_RE.sub(lambda m: f"{m.group(1)}{m.group(2)}{_REDACTED}", redacted)
+    redacted = _URL_CREDENTIAL_RE.sub(lambda m: f"{m.group(1)}{_REDACTED}@", redacted)
+    redacted = _SECRET_KV_RE.sub(lambda m: f"{m.group(1)}{m.group(2)}{_REDACTED}", redacted)
     return redacted
 
 
@@ -555,7 +611,10 @@ def _beet_binary() -> Tuple[bool, str]:
 def _run_beet_diagnostic(args: List[str], config_path: Path | None = None, timeout: int = 8) -> Dict[str, Any]:
     available, beet_bin = _beet_binary()
     if not available:
-        return {"available": False, "path": beet_bin, "returncode": None, "stdout": "", "stderr": "beet executable not found"}
+        return {
+            "available": False, "path": beet_bin, "returncode": None, "timed_out": False,
+            "stdout": "", "stderr": "beet executable not found",
+        }
     cmd = [beet_bin]
     if config_path and config_path.exists():
         cmd.extend(["-c", str(config_path)])
@@ -569,12 +628,34 @@ def _run_beet_diagnostic(args: List[str], config_path: Path | None = None, timeo
             "available": True,
             "path": beet_bin,
             "returncode": proc.returncode,
+            "timed_out": False,
             "stdout": _redact_diagnostic_text(proc.stdout or ""),
             "stderr": _redact_diagnostic_text(proc.stderr or ""),
         }
+    except subprocess.TimeoutExpired as ex:
+        # Preserve whatever partial output the process produced before the
+        # timeout fired -- sanitized -- rather than discarding it, but never
+        # serialize the raw TimeoutExpired object (its repr includes the
+        # full argv/cmd, which is not something we want to hand back to the
+        # browser). The endpoint must stay responsive; this returns a
+        # structured, bounded result instead of propagating the exception.
+        partial_stdout = ex.stdout if isinstance(ex.stdout, str) else (ex.stdout or b"").decode("utf-8", "replace")
+        partial_stderr = ex.stderr if isinstance(ex.stderr, str) else (ex.stderr or b"").decode("utf-8", "replace")
+        app.logger.warning("Beets diagnostic command timed out after %ss", timeout)
+        return {
+            "available": True,
+            "path": beet_bin,
+            "returncode": None,
+            "timed_out": True,
+            "stdout": _redact_diagnostic_text(partial_stdout),
+            "stderr": _redact_diagnostic_text(partial_stderr) or "Beets diagnostic timed out.",
+        }
     except Exception as ex:
         app.logger.error("Beets diagnostic command failed: %s", type(ex).__name__)
-        return {"available": True, "path": beet_bin, "returncode": None, "stdout": "", "stderr": _BEETS_DIAGNOSTIC_COMMAND_FAILED}
+        return {
+            "available": True, "path": beet_bin, "returncode": None, "timed_out": False,
+            "stdout": "", "stderr": _redact_diagnostic_text(_BEETS_DIAGNOSTIC_COMMAND_FAILED),
+        }
 
 
 def _diagnostic_failure_lines(text: str) -> List[str]:
@@ -587,43 +668,111 @@ def _diagnostic_failure_lines(text: str) -> List[str]:
 
 
 def _beets_plugin_diagnostics(config_path: Path) -> Dict[str, Any]:
+    """Run the supported Beets plugin-loader probe and report a truthful,
+    fail-closed summary. `beet plugins` does not exist in Beets 2.12.0, so
+    this uses `beet -c <config> -vv version`: a supported, noninteractive,
+    read-only, bounded-timeout command that still loads the exact
+    configured plugin list and pluginpath (Beets initializes plugins during
+    UI startup for every subcommand, so import/initialization failures
+    surface here the same way they do for `beet ... version` in the Docker
+    smoke test). A loader result only counts as successful when the beet
+    executable was found, the config file exists, the process exited 0,
+    it did not time out, and no recognized plugin-failure pattern appears
+    in its output -- callers must not infer plugin health from config.yaml
+    parsing alone when this is not true.
+    """
     config_summary = _parse_beets_config_summary(config_path)
-    version_probe = _run_beet_diagnostic(["version"], timeout=8)
-    plugin_probe = _run_beet_diagnostic(["plugins"], config_path=config_path, timeout=12) if config_path.exists() else {
-        "available": version_probe.get("available"),
-        "path": version_probe.get("path", ""),
-        "returncode": None,
-        "stdout": "",
-        "stderr": "beets config missing",
-    }
-    combined = "\n".join([plugin_probe.get("stdout", ""), plugin_probe.get("stderr", "")])
+    config_exists = config_path.exists()
+    if config_exists:
+        loader_probe = _run_beet_diagnostic(_BEET_LOADER_PROBE_ARGS, config_path=config_path, timeout=12)
+    else:
+        available, beet_path = _beet_binary()
+        loader_probe = {
+            "available": available,
+            "path": beet_path,
+            "returncode": None,
+            "timed_out": False,
+            "stdout": "",
+            "stderr": "Beets config file not found.",
+        }
+
+    combined = "\n".join([loader_probe.get("stdout", ""), loader_probe.get("stderr", "")])
     failures = _diagnostic_failure_lines(combined)
-    version_text = (version_probe.get("stdout") or version_probe.get("stderr") or "").strip().splitlines()
-    diagnostic_error = (
-        _BEETS_DIAGNOSTIC_COMMAND_FAILED
-        if version_probe.get("stderr") == _BEETS_DIAGNOSTIC_COMMAND_FAILED
-        or plugin_probe.get("stderr") == _BEETS_DIAGNOSTIC_COMMAND_FAILED
-        else ""
+
+    version_lines = (loader_probe.get("stdout") or loader_probe.get("stderr") or "").strip().splitlines()
+    version = ""
+    for line in version_lines:
+        if line.lower().startswith("beets version"):
+            version = line.strip()
+            break
+    if not version and version_lines:
+        version = version_lines[0].strip()
+
+    loader_timed_out = bool(loader_probe.get("timed_out"))
+    loader_available = bool(loader_probe.get("available"))
+    loader_returncode = loader_probe.get("returncode")
+    loader_ok = (
+        config_exists
+        and loader_available
+        and loader_returncode == 0
+        and not loader_timed_out
+        and not failures
     )
+
+    loader_error = ""
+    if not loader_ok:
+        if not loader_available:
+            loader_error = "Beets executable not found."
+        elif not config_exists:
+            loader_error = "Beets config file not found."
+        elif loader_timed_out:
+            loader_error = "Beets plugin loader timed out."
+        elif failures:
+            loader_error = failures[0]
+        elif loader_probe.get("stderr") == _BEETS_DIAGNOSTIC_COMMAND_FAILED:
+            loader_error = _BEETS_DIAGNOSTIC_COMMAND_FAILED
+        elif loader_returncode != 0:
+            detail_source = (loader_probe.get("stderr") or loader_probe.get("stdout") or "").strip()
+            detail_line = detail_source.splitlines()[0] if detail_source else "Beets plugin loader failed."
+            loader_error = _redact_diagnostic_text(detail_line)[:240]
+        else:
+            loader_error = "Beets plugin loader failed."
+
+    # Preserved for backward compatibility with the earlier version+plugins
+    # dual-probe shape (tests/test_routes_setup.py asserts this exact value
+    # when the diagnostic subprocess call itself raises).
+    diagnostic_error = _BEETS_DIAGNOSTIC_COMMAND_FAILED if loader_probe.get("stderr") == _BEETS_DIAGNOSTIC_COMMAND_FAILED else ""
+
     return {
-        "available": bool(version_probe.get("available")),
-        "path": version_probe.get("path", ""),
-        "version": version_text[0] if version_text else "",
+        "available": loader_available,
+        "path": loader_probe.get("path", ""),
+        "version": version,
         "diagnostic_error": diagnostic_error,
-        "configured_plugins": config_summary["plugins"],
-        "pluginpath": config_summary["pluginpath"],
+        # `plugins_returncode` is kept for existing frontend consumers; it
+        # now reflects the supported plugin-loader probe (`-vv version`)
+        # rather than the unsupported `beet plugins` command it replaced.
+        "plugins_returncode": loader_returncode,
+        "plugin_loader_returncode": loader_returncode,
+        "plugin_loader_ok": loader_ok,
+        "plugin_loader_timed_out": loader_timed_out,
+        "plugin_loader_error": loader_error,
+        # Only trust config.yaml's plugin/pluginpath listing as descriptive
+        # of runtime state when the loader actually loaded that config
+        # successfully -- otherwise report them empty so callers can't
+        # mistake "listed in config.yaml" for "actually loaded".
+        "configured_plugins": config_summary["plugins"] if loader_ok else [],
+        "pluginpath": config_summary["pluginpath"] if loader_ok else [],
         "plugin_failures": failures,
-        "plugins_returncode": plugin_probe.get("returncode"),
-        "replaygain_backend": config_summary.get("replaygain_backend") or "",
-        "replaygain_command": config_summary.get("replaygain_command") or "",
+        "replaygain_backend": config_summary.get("replaygain_backend") or "" if loader_ok else "",
+        "replaygain_command": config_summary.get("replaygain_command") or "" if loader_ok else "",
         "discogs_token_configured": bool(
             os.environ.get("DISCOGS_TOKEN")
             or os.environ.get("DISCOGS_USER_TOKEN")
-            or config_summary.get("discogs_token_configured")
+            or (loader_ok and config_summary.get("discogs_token_configured"))
         ),
         "listenbrainz_token_configured": bool(
             os.environ.get("LISTENBRAINZ_TOKEN")
-            or config_summary.get("listenbrainz_token_configured")
+            or (loader_ok and config_summary.get("listenbrainz_token_configured"))
         ),
     }
 
@@ -652,9 +801,13 @@ def _integration_status(
         "state": resolved_state,
     }
     if note:
-        payload["note"] = note
+        # Defense-in-depth: note/detail text can originate from sanitized
+        # diagnostic output built elsewhere in this module, but redacting
+        # again here means no integration payload can leak a secret even if
+        # a future caller forgets to sanitize before passing it in.
+        payload["note"] = _redact_diagnostic_text(note)
     if detail:
-        payload["detail"] = detail
+        payload["detail"] = _redact_diagnostic_text(detail)
     return payload
 
 
@@ -676,6 +829,21 @@ def _plugin_integration_status(
             required=required,
             state="dependency_plugin_missing",
             detail=failure,
+        )
+    if not diagnostics.get("plugin_loader_ok"):
+        # The loader itself did not complete successfully (nonzero exit,
+        # timeout, missing config, missing executable) for a reason other
+        # than this specific plugin -- do not report this plugin as
+        # configured/healthy just because its name appears in config.yaml;
+        # `configured_plugins` is already empty in this case (see
+        # _beets_plugin_diagnostics), but this explicit check keeps the
+        # invariant true even if that ever changes.
+        return _integration_status(
+            configured=False,
+            required=required,
+            state="plugin_loader_failed",
+            detail=str(diagnostics.get("plugin_loader_error") or ""),
+            note="Beets plugin loader did not complete successfully; plugin state cannot be confirmed.",
         )
     if name not in plugins:
         return _integration_status(
@@ -699,6 +867,85 @@ def _plugin_integration_status(
     )
 
 
+def _loader_failed_status(diagnostics: Dict[str, Any], *, required: bool = False) -> Dict[str, Any]:
+    """Shared fallback for integrations that depend on the plugin loader
+    having actually run successfully (used when there's no single named
+    plugin to blame via _plugin_failure_for)."""
+    return _integration_status(
+        configured=False,
+        required=required,
+        state="plugin_loader_failed",
+        detail=str(diagnostics.get("plugin_loader_error") or ""),
+        note="Beets plugin loader did not complete successfully; plugin state cannot be confirmed.",
+    )
+
+
+def _acoustid_integration_status(diagnostics: Dict[str, Any], fpcalc_path: str | None) -> Dict[str, Any]:
+    plugin_failures = list(diagnostics.get("plugin_failures") or [])
+    chroma_failure = _plugin_failure_for(plugin_failures, "chroma")
+    if chroma_failure:
+        return _integration_status(
+            configured=False,
+            state="dependency_plugin_missing",
+            detail=chroma_failure,
+            note="Chroma plugin failed to load.",
+        )
+    if not diagnostics.get("plugin_loader_ok"):
+        return _loader_failed_status(diagnostics)
+    if not fpcalc_path:
+        return _integration_status(
+            configured=False,
+            state="dependency_plugin_missing",
+            note="fpcalc is missing.",
+        )
+    configured_plugins = set(diagnostics.get("configured_plugins") or [])
+    if "chroma" not in configured_plugins:
+        return _integration_status(
+            configured=False,
+            state="installed_but_disabled",
+            note="Chroma plugin is installed but not enabled in config.yaml.",
+        )
+    return _integration_status(
+        configured=True,
+        state="configured",
+        note="Fingerprinting available; AcoustID key is optional but improves rate limits.",
+    )
+
+
+def _replaygain_integration_status(diagnostics: Dict[str, Any], ffmpeg_path: str | None) -> Dict[str, Any]:
+    plugin_failures = list(diagnostics.get("plugin_failures") or [])
+    replaygain_failure = _plugin_failure_for(plugin_failures, "replaygain")
+    if replaygain_failure:
+        return _integration_status(
+            configured=False,
+            state="dependency_plugin_missing",
+            detail=replaygain_failure,
+            note="ReplayGain plugin failed to load.",
+        )
+    if not diagnostics.get("plugin_loader_ok"):
+        return _loader_failed_status(diagnostics)
+    configured_plugins = set(diagnostics.get("configured_plugins") or [])
+    replaygain_backend = diagnostics.get("replaygain_backend") or ""
+    replaygain_command = diagnostics.get("replaygain_command") or ""
+    if "replaygain" not in configured_plugins:
+        return _integration_status(
+            configured=False,
+            state="installed_but_disabled",
+            note="ReplayGain must use an installed backend.",
+        )
+    if replaygain_backend == "ffmpeg" and ffmpeg_path and not replaygain_command:
+        return _integration_status(
+            configured=True,
+            state="configured",
+            note="ReplayGain uses the installed ffmpeg backend.",
+        )
+    return _integration_status(
+        configured=False,
+        state="dependency_plugin_missing",
+        note="ReplayGain must use an installed backend.",
+    )
+
+
 @app.get("/api/setup/status")
 def setup_status():
     """Readiness snapshot: paths, beets config, fpcalc, and each optional
@@ -714,11 +961,6 @@ def setup_status():
     fpcalc_path = shutil.which("fpcalc")
     ffmpeg_path = shutil.which("ffmpeg")
     diagnostics = _beets_plugin_diagnostics(beets_config_path)
-    configured_plugins = set(diagnostics.get("configured_plugins") or [])
-    plugin_failures = list(diagnostics.get("plugin_failures") or [])
-    replaygain_failure = _plugin_failure_for(plugin_failures, "replaygain")
-    replaygain_backend = diagnostics.get("replaygain_backend") or ""
-    replaygain_command = diagnostics.get("replaygain_command") or ""
 
     integrations = {
         "ai": _integration_status(
@@ -744,11 +986,7 @@ def setup_status():
             required=True,
             note="Public MusicBrainz metadata source; no user API key required.",
         ),
-        "acoustid": _integration_status(
-            configured=bool(fpcalc_path and "chroma" in configured_plugins and not _plugin_failure_for(plugin_failures, "chroma")),
-            state="configured" if fpcalc_path and "chroma" in configured_plugins and not _plugin_failure_for(plugin_failures, "chroma") else "dependency_plugin_missing",
-            note="Fingerprinting available; AcoustID key is optional but improves rate limits." if fpcalc_path else "fpcalc is missing.",
-        ),
+        "acoustid": _acoustid_integration_status(diagnostics, fpcalc_path),
         "discogs": _plugin_integration_status(
             "discogs",
             diagnostics,
@@ -767,23 +1005,7 @@ def setup_status():
             diagnostics,
             note="User plugins load from /config/beetsplug before bundled plugins in /app/beetsplug.",
         ),
-        "replaygain": _integration_status(
-            configured=bool(
-                "replaygain" in configured_plugins
-                and not replaygain_failure
-                and replaygain_backend == "ffmpeg"
-                and ffmpeg_path
-                and not replaygain_command
-            ),
-            state=(
-                "dependency_plugin_missing" if replaygain_failure
-                else "configured" if "replaygain" in configured_plugins and replaygain_backend == "ffmpeg" and ffmpeg_path and not replaygain_command
-                else "installed_but_disabled" if "replaygain" not in configured_plugins
-                else "dependency_plugin_missing"
-            ),
-            note="ReplayGain uses the installed ffmpeg backend." if replaygain_backend == "ffmpeg" else "ReplayGain must use an installed backend.",
-            detail=replaygain_failure,
-        ),
+        "replaygain": _replaygain_integration_status(diagnostics, ffmpeg_path),
         "plex": _integration_status(
             configured=bool(os.environ.get("PLEX_URL") and os.environ.get("PLEX_TOKEN")),
             note="Application Plex workflow; no default Beets plexsync plugin is required.",
@@ -809,6 +1031,15 @@ def setup_status():
         )
     if not fpcalc_path:
         blocking.append("fpcalc (chromaprint) not found on PATH — AcoustID fingerprinting will not work")
+    if beets_config_path.exists() and not diagnostics.get("plugin_loader_ok"):
+        # Config exists but the supported plugin-loader probe did not
+        # succeed (nonzero exit, timeout, or a recognized plugin failure) --
+        # surface this as at least a warning rather than silently reporting
+        # every configured plugin as healthy. (When the config itself is
+        # missing, the message above already covers it -- avoid a duplicate.)
+        blocking.append(
+            "Beets plugin loader did not complete successfully — see beets.plugin_loader_error for details."
+        )
 
     ready = not blocking
     demo_mode = os.environ.get("DEMO_MODE", "0").strip().lower() in ("1", "true", "yes", "on")

--- a/routes_setup.py
+++ b/routes_setup.py
@@ -487,10 +487,22 @@ _REDACTED = "[redacted]"
 # discogs_user_token, access_token, refresh_token, client_secret,
 # user_token, auth_token all end in a covered keyword and are redacted by
 # this single pattern without needing to enumerate every provider name.
+#
+# The negative lookahead after the separator keeps this idempotent:
+# `_redact_diagnostic_text()` is applied repeatedly to the same text today
+# (subprocess stdout/stderr boundary, failure-line extraction, and
+# integration payload serialization each call it), so a value that is
+# already exactly the `[redacted]` placeholder (optionally quoted, any
+# case) must be left alone rather than re-matched -- otherwise the bare
+# alternative's excluded-character class (which stops short of `]` so it
+# doesn't swallow a trailing brace/bracket from surrounding structured
+# text) partially re-matches the placeholder and strands its closing
+# bracket, appending an extra `]` on every additional pass.
 _SECRET_KV_RE = re.compile(
     r"""(?ix)
     \b([a-z0-9_-]*?(?:api[_-]?key|client[_-]?secret|token|password|secret|auth))
     (\s*[:=]\s*)
+    (?!['"]?\[redacted\]['"]?)
     (?:"([^"]*)"|'([^']*)'|([^\s,;}\]&]+))
     """,
     re.VERBOSE,
@@ -500,20 +512,48 @@ _SECRET_KV_RE = re.compile(
 # scheme prefix (the scheme itself is not secret and is kept for context).
 _AUTH_HEADER_RE = re.compile(r"(?i)\b(Authorization|Proxy-Authorization)(\s*:\s*)(?:(Bearer|Basic)(\s+))?(\S+)")
 
-# Cookie / Set-Cookie header values.
-_COOKIE_HEADER_RE = re.compile(r"(?i)\b(Set-Cookie|Cookie)(\s*:\s*)(\S+)")
+# Cookie / Set-Cookie header values -- redact the entire header value through
+# end-of-line (not just the first token) so multi-value headers like
+# `Cookie: session=alpha; refresh=bravo` don't leave later cookie pairs
+# exposed. `[^\r\n]*` stops at the line boundary so it never consumes a
+# following diagnostic line, and replacing the whole match unconditionally
+# with the header name/separator/marker makes this self-healing and
+# idempotent regardless of what (if anything) an earlier redaction pass
+# left behind in the header value.
+_COOKIE_HEADER_RE = re.compile(r"(?im)\b(Set-Cookie|Cookie)(\s*:\s*)[^\r\n]*")
 
 # Credentials embedded in a URL's userinfo, e.g. https://user:password@host/
 _URL_CREDENTIAL_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^\s/@]+@")
+
+# Defense-in-depth cleanup: collapses a `[redacted]`/`[REDACTED]` marker
+# followed by one or more stray `]` characters back down to a single clean
+# marker. This mops up the specific corruption shape produced when *any*
+# secret-shaped regex (including app.py's imported `_redact_security_text`,
+# which this module does not control) re-scans text that already contains
+# our placeholder: its bare-value character class also stops short of `]`,
+# so it partially re-matches the placeholder and strands a trailing `]`
+# rather than leaving it untouched. Applied as the last step of
+# `_redact_diagnostic_text()` so the function is a safe fixed point after
+# one pass no matter which upstream layer produced the placeholder.
+_STRAY_REDACTED_BRACKET_RE = re.compile(r"(?i)(\[redacted\])\]+")
 
 
 def _redact_diagnostic_text(text: str) -> str:
     """Redact secret-bearing diagnostic text before it can reach the System
     page. Covers named key/value secrets (quoted or bare, any prefix ending
     in api_key/token/password/secret/auth), Authorization/Proxy-Authorization
-    headers (Bearer/Basic or bare), Cookie/Set-Cookie headers, query-string
-    credentials, and credentials embedded in a URL's userinfo. Safe to call
-    more than once on the same text (idempotent defense-in-depth)."""
+    headers (Bearer/Basic or bare), Cookie/Set-Cookie headers (the entire
+    header value through end-of-line, not just the first cookie pair),
+    query-string credentials, and credentials embedded in a URL's userinfo.
+
+    This function is genuinely called more than once on the same text in
+    production -- `_run_beet_diagnostic()` redacts stdout/stderr at the
+    subprocess boundary, `_diagnostic_failure_lines()` and the loader-error
+    detail line then redact lines extracted from that already-redacted
+    text, and `_integration_status()` redacts note/detail again at
+    serialization -- so it must be idempotent: calling it again on its own
+    output must return that output unchanged, with no accumulation of
+    stray `]` characters and no corruption of an existing placeholder."""
     redacted = str(text or "")
     try:
         # Reuse app.py's generic secret-assignment/control-char sanitizer
@@ -532,6 +572,7 @@ def _redact_diagnostic_text(text: str) -> str:
     redacted = _COOKIE_HEADER_RE.sub(lambda m: f"{m.group(1)}{m.group(2)}{_REDACTED}", redacted)
     redacted = _URL_CREDENTIAL_RE.sub(lambda m: f"{m.group(1)}{_REDACTED}@", redacted)
     redacted = _SECRET_KV_RE.sub(lambda m: f"{m.group(1)}{m.group(2)}{_REDACTED}", redacted)
+    redacted = _STRAY_REDACTED_BRACKET_RE.sub(lambda m: m.group(1), redacted)
     return redacted
 
 

--- a/tests/test_beets_fresh_install_plugins.py
+++ b/tests/test_beets_fresh_install_plugins.py
@@ -98,7 +98,17 @@ YAML
 test "$(id -u)" != "0"
 beet -c /config/config.yaml version
 beet -c /config/config.yaml config
-beet -c /config/config.yaml -vv version
+# Exact command /api/setup/status now runs as its plugin-loader probe
+# (routes_setup.py's _BEET_LOADER_PROBE_ARGS) -- `beet plugins` does not
+# exist in Beets 2.12.0, so this is the supported, real replacement. Assert
+# its exit code explicitly (not just via the overall `set -eu` script exit)
+# so a regression here fails with an unambiguous marker.
+if beet -c /config/config.yaml -vv version; then
+  echo "SETUP_DIAGNOSTIC_LOADER_PROBE_OK"
+else
+  echo "SETUP_DIAGNOSTIC_LOADER_PROBE_FAILED"
+  exit 1
+fi
 python -c "import discogs_client; print('discogs client importable')"
 beet -c /config/config.yaml help >/tmp/beet-help.txt
 fpcalc -version
@@ -126,6 +136,13 @@ beet -c /config/config.yaml import -q --quiet-fallback asis /tmp/import-smoke
             self.assertNotIn(bad.lower(), output.lower())
         for expected in ("lastgenre", "listenbrainz", "musicbrainz", "discpath", "replaygain", "ffmpeg", "discogs client importable"):
             self.assertIn(expected, output.lower())
+        # Proves the exact command setup diagnostics now runs (`beet -c
+        # ... -vv version`) exits zero against a real fresh-install image
+        # with the default plugin set loaded -- and never uses the
+        # unsupported `beet plugins` command.
+        self.assertIn("SETUP_DIAGNOSTIC_LOADER_PROBE_OK", output)
+        self.assertNotIn("SETUP_DIAGNOSTIC_LOADER_PROBE_FAILED", output)
+        self.assertNotIn("beet -c /config/config.yaml plugins", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_plugin_path_precedence.py
+++ b/tests/test_plugin_path_precedence.py
@@ -1,0 +1,108 @@
+"""Proves the actual precedence semantics of Beets' `pluginpath` loading,
+directly through Beets' own plugin-loading implementation -- not assumed.
+
+Step 11 of the setup-diagnostics fix: routes_setup.py's
+_BEETS_PLUGINPATH_CONFIG (see app.py) configures `/config/beetsplug` before
+`/app/beetsplug` so that a same-named user plugin in /config overrides the
+bundled one in /app. This test verifies that ordering assumption against
+Beets' real `beetsplug.__path__`/import-machinery behavior (beets/plugins.py
+`get_plugin_names()` does `beetsplug.__path__ = paths + list(beetsplug.__path__)`,
+i.e. configured pluginpath entries are *prepended*, so the first configured
+path wins for a same-named module) using two temporary, synthetic,
+same-named plugin directories -- never the real /config or /app paths, and
+never the real music library.
+"""
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+_BEETS_AVAILABLE = importlib.util.find_spec("beets") is not None
+
+
+@unittest.skipUnless(_BEETS_AVAILABLE, "beets is not importable in this environment")
+class PluginPathPrecedenceTests(unittest.TestCase):
+    def _run_precedence_probe(self, pluginpath_dirs):
+        script = textwrap.dedent(
+            f"""
+            import beets, beets.plugins
+            beets.config['pluginpath'] = {[str(p) for p in pluginpath_dirs]!r}
+            beets.config['plugins'] = ['precedencecheck']
+            beets.plugins.load_plugins()
+            instances = beets.plugins.find_plugins()
+            sources = [getattr(p, 'SOURCE', None) for p in instances]
+            print('SOURCES=' + ','.join(s for s in sources if s))
+            """
+        )
+        return subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_user_pluginpath_listed_first_takes_precedence_over_bundled(self):
+        """A same-named synthetic plugin in the "user" directory (listed
+        first in pluginpath, matching /config/beetsplug's position) must be
+        the one Beets actually loads -- not the "bundled" directory's
+        version (matching /app/beetsplug's position)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            user_dir = root / "user_beetsplug"
+            bundled_dir = root / "bundled_beetsplug"
+            user_dir.mkdir()
+            bundled_dir.mkdir()
+            (user_dir / "precedencecheck.py").write_text(
+                "from beets.plugins import BeetsPlugin\n"
+                "class PrecedenceCheckPlugin(BeetsPlugin):\n"
+                "    SOURCE = 'user'\n",
+                encoding="utf-8",
+            )
+            (bundled_dir / "precedencecheck.py").write_text(
+                "from beets.plugins import BeetsPlugin\n"
+                "class PrecedenceCheckPlugin(BeetsPlugin):\n"
+                "    SOURCE = 'bundled'\n",
+                encoding="utf-8",
+            )
+
+            proc = self._run_precedence_probe([user_dir, bundled_dir])
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("SOURCES=user", proc.stdout)
+        self.assertNotIn("bundled", proc.stdout)
+
+    def test_reversing_pluginpath_order_reverses_which_copy_wins(self):
+        """Control case proving the result above is really about *order*,
+        not some other difference between the two directories: swap which
+        directory is listed first and the opposite copy must win."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dir_a = root / "dir_a_beetsplug"
+            dir_b = root / "dir_b_beetsplug"
+            dir_a.mkdir()
+            dir_b.mkdir()
+            (dir_a / "precedencecheck.py").write_text(
+                "from beets.plugins import BeetsPlugin\n"
+                "class PrecedenceCheckPlugin(BeetsPlugin):\n"
+                "    SOURCE = 'dir_a'\n",
+                encoding="utf-8",
+            )
+            (dir_b / "precedencecheck.py").write_text(
+                "from beets.plugins import BeetsPlugin\n"
+                "class PrecedenceCheckPlugin(BeetsPlugin):\n"
+                "    SOURCE = 'dir_b'\n",
+                encoding="utf-8",
+            )
+
+            proc = self._run_precedence_probe([dir_b, dir_a])
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("SOURCES=dir_b", proc.stdout)
+        self.assertNotIn("dir_a", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_routes_setup.py
+++ b/tests/test_routes_setup.py
@@ -287,6 +287,44 @@ class RoutesSetupPluginLoaderDiagnosticsTests(unittest.TestCase):
             second = self.client.get("/api/setup/status")
         self.assertEqual(second.status_code, 200)
 
+    # -- 3b. Nonzero loader result with multi-value cookie/token stderr -------
+    def test_nonzero_loader_result_redacts_multivalue_cookies_and_tokens(self):
+        # Route-level regression for both defects: a failing loader whose
+        # stderr contains a multi-value Cookie/Set-Cookie header (defect 1)
+        # is redacted through this module's several redaction call sites in
+        # sequence (subprocess boundary, failure-line extraction, loader
+        # error detail, integration detail/note serialization -- defect 2's
+        # repeated-application path) without leaking any cookie value or
+        # corrupting the placeholder anywhere in the serialized response.
+        self._write_config()
+        stderr = (
+            "Cookie: session=alpha; refresh=bravo\n"
+            "Set-Cookie: access=charlie; Path=/; HttpOnly\n"
+            "token=delta\n"
+        )
+        fake_proc = mock.Mock(returncode=1, stdout="", stderr=stderr)
+        with self._env(), \
+             mock.patch.object(self.module, "_beet_binary", return_value=(True, "beet")), \
+             mock.patch.object(self.module.subprocess, "run", return_value=fake_proc):
+            response = self.client.get("/api/setup/status")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertFalse(body["beets"]["plugin_loader_ok"])
+        self.assertEqual(body["status"], "warning")
+
+        text = response.get_data(as_text=True)
+        for forbidden in ("alpha", "bravo", "charlie", "delta"):
+            self.assertNotIn(forbidden, text)
+        # No raw header text (cookie names/values) should leak either.
+        self.assertNotIn("session=", text)
+        self.assertNotIn("access=", text)
+        # No stray-bracket corruption from redacting the same text at
+        # multiple layers (plugin_loader_error, plugin_failures, and any
+        # integration detail/note built from it).
+        self.assertNotIn("]]", text)
+        self.assertIn(body["beets"]["plugin_loader_error"], text)
+
     # -- 6. Redaction ---------------------------------------------------------------
     def test_redaction_covers_named_secrets_headers_cookies_urls_and_query_strings(self):
         self._write_config()
@@ -351,6 +389,63 @@ class RoutesSetupPluginLoaderDiagnosticsTests(unittest.TestCase):
             redacted = module._redact_diagnostic_text(raw)
             self.assertNotIn("abc123", redacted, raw)
             self.assertIn("[redacted]", redacted, raw)
+
+    def test_redact_diagnostic_text_cookie_header_redacts_entire_value(self):
+        # Defect: the cookie-header pattern used to only redact the first
+        # token after `Cookie:`/`Set-Cookie:`, e.g.
+        # `Cookie: session=alpha; refresh=bravo` could leave `refresh=bravo`
+        # exposed. The whole header value through end-of-line must be
+        # redacted, regardless of how many cookie pairs or attributes it
+        # carries, and case-insensitively.
+        module = self.module
+        cases = [
+            "Cookie: session=alpha; refresh=bravo",
+            "Cookie: a=alpha; b=bravo; c=charlie",
+            "Set-Cookie: session=alpha; Path=/; HttpOnly",
+            "Set-Cookie: access=alpha; refresh=bravo; Secure; SameSite=Lax",
+            "cookie: lower=alpha; second=bravo",
+        ]
+        for raw in cases:
+            redacted = module._redact_diagnostic_text(raw)
+            for value in ("alpha", "bravo", "charlie"):
+                self.assertNotIn(value, redacted, raw)
+            self.assertIn("[redacted]", redacted, raw)
+
+    def test_redact_diagnostic_text_does_not_consume_following_line(self):
+        # The end-of-line-bounded cookie pattern must stop at the line
+        # boundary and must not swallow subsequent, unrelated diagnostic
+        # text on the next line.
+        module = self.module
+        raw = "Cookie: session=alpha; refresh=bravo\nnext diagnostic line unaffected"
+        redacted = module._redact_diagnostic_text(raw)
+        self.assertNotIn("alpha", redacted)
+        self.assertNotIn("bravo", redacted)
+        self.assertIn("next diagnostic line unaffected", redacted)
+
+    def test_redact_diagnostic_text_is_idempotent(self):
+        # Defect: `_redact_diagnostic_text()` is genuinely called more than
+        # once on the same (already-redacted) text in production --
+        # subprocess stdout/stderr boundary, failure-line extraction, and
+        # integration payload serialization all call it in sequence -- so
+        # repeated calls must reach a fixed point after the first pass,
+        # with no accumulation of stray `]` characters and no corruption
+        # of an existing `[redacted]` marker.
+        module = self.module
+        cases = [
+            "token=abc",
+            "Authorization: Bearer abc",
+            "Cookie: session=abc; refresh=def",
+            "https://user:password@example.test/",
+            "https://example.test/?api_key=abc&token=def",
+            "DISCOGS_USER_TOKEN=abc",
+        ]
+        for raw in cases:
+            first = module._redact_diagnostic_text(raw)
+            second = module._redact_diagnostic_text(first)
+            third = module._redact_diagnostic_text(second)
+            self.assertEqual(first, second, raw)
+            self.assertEqual(second, third, raw)
+            self.assertNotIn("]]", first, raw)
 
     # -- 7. Optional credentials ------------------------------------------------
     def test_optional_credentials_absent_does_not_block_setup(self):

--- a/tests/test_routes_setup.py
+++ b/tests/test_routes_setup.py
@@ -8,6 +8,7 @@ the rest of the application's side effects.
 """
 import importlib
 import os
+import subprocess
 import sys
 import tempfile
 import types
@@ -112,6 +113,279 @@ class RoutesSetupStatusTests(unittest.TestCase):
             self.assertTrue(r.get_json()["demo_mode"])
         finally:
             del os.environ["DEMO_MODE"]
+
+
+class RoutesSetupPluginLoaderDiagnosticsTests(unittest.TestCase):
+    """Behavioral coverage for the supported Beets plugin-loader diagnostic
+    (`beet -c <config> -vv version`) that replaced the unsupported
+    `beet plugins` command, and for the strengthened diagnostic redaction.
+    These mock only the subprocess boundary (`subprocess.run`) and exercise
+    the real `_beets_plugin_diagnostics`/`_redact_diagnostic_text` helpers
+    and the real `/api/setup/status` route -- not source-string assertions.
+    """
+
+    def setUp(self):
+        self.flask_app, self.module = _load_routes_setup_against_stub_app()
+        self.client = self.flask_app.test_client()
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.config_dir = root / "config"
+        self.config_dir.mkdir()
+        self.config_file = self.config_dir / "config.yaml"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write_config(self, plugins="musicbrainz lastgenre listenbrainz discpath replaygain chroma"):
+        self.config_file.write_text(
+            f"plugins: {plugins}\n"
+            "pluginpath:\n  - /config/beetsplug\n  - /app/beetsplug\n"
+            "replaygain:\n    backend: ffmpeg\n"
+            "listenbrainz:\n    token: some-listenbrainz-token\n",
+            encoding="utf-8",
+        )
+
+    def _env(self):
+        return mock.patch.dict(
+            os.environ,
+            {"BEETSDIR": str(self.config_dir), "BEETS_CONFIG": str(self.config_file)},
+            clear=False,
+        )
+
+    # -- 1. Successful loader -------------------------------------------------
+    def test_successful_loader_reports_configured_plugins_and_no_false_failures(self):
+        self._write_config()
+        fake_proc = mock.Mock(
+            returncode=0,
+            stdout=(
+                "beets version 2.12.0\n"
+                "Python version 3.12.0\n"
+                "plugins: musicbrainz, lastgenre, listenbrainz, discpath, replaygain, chroma\n"
+            ),
+            stderr="",
+        )
+        with self._env(), \
+             mock.patch.object(self.module, "_beet_binary", return_value=(True, "beet")), \
+             mock.patch.object(self.module.subprocess, "run", return_value=fake_proc), \
+             mock.patch.object(
+                 self.module.shutil, "which",
+                 side_effect=lambda name: f"/usr/bin/{name}" if name in ("fpcalc", "ffmpeg") else None,
+             ):
+            response = self.client.get("/api/setup/status")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        beets = body["beets"]
+        self.assertTrue(beets["available"])
+        self.assertTrue(beets["plugin_loader_ok"])
+        self.assertFalse(beets["plugin_loader_timed_out"])
+        self.assertEqual(beets["plugins_returncode"], 0)
+        self.assertEqual(beets["plugin_failures"], [])
+        for plugin in ("musicbrainz", "lastgenre", "listenbrainz", "discpath", "replaygain", "chroma"):
+            self.assertIn(plugin, beets["configured_plugins"])
+        for key in ("musicbrainz", "lastgenre", "listenbrainz", "discpath", "replaygain"):
+            self.assertNotEqual(body["integrations"][key]["state"], "plugin_loader_failed")
+        self.assertEqual(body["integrations"]["musicbrainz"]["state"], "configured")
+        self.assertEqual(body["integrations"]["lastgenre"]["state"], "configured")
+        self.assertEqual(body["integrations"]["discpath"]["state"], "configured")
+        self.assertEqual(body["integrations"]["replaygain"]["state"], "configured")
+        self.assertEqual(body["integrations"]["listenbrainz"]["state"], "configured")
+
+    # -- 2. Unsupported-command regression -------------------------------------
+    def test_loader_never_invokes_unsupported_plugins_command(self):
+        self._write_config()
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            return mock.Mock(returncode=0, stdout="beets version 2.12.0\n", stderr="")
+
+        with self._env(), \
+             mock.patch.object(self.module, "_beet_binary", return_value=(True, "beet")), \
+             mock.patch.object(self.module.subprocess, "run", side_effect=fake_run):
+            self.client.get("/api/setup/status")
+
+        self.assertTrue(captured_cmds)
+        for cmd in captured_cmds:
+            self.assertNotIn("plugins", cmd)
+        self.assertEqual(
+            captured_cmds[0],
+            ["beet", "-c", str(self.config_file)] + list(self.module._BEET_LOADER_PROBE_ARGS),
+        )
+
+    # -- 3. Nonzero loader result ----------------------------------------------
+    def test_nonzero_loader_result_marks_setup_warning_without_false_healthy_plugins(self):
+        self._write_config()
+        fake_proc = mock.Mock(returncode=1, stdout="", stderr="beet: error: unrecognized arguments: -vv\n")
+        with self._env(), \
+             mock.patch.object(self.module, "_beet_binary", return_value=(True, "beet")), \
+             mock.patch.object(self.module.subprocess, "run", return_value=fake_proc):
+            response = self.client.get("/api/setup/status")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["status"], "warning")
+        self.assertFalse(body["beets"]["plugin_loader_ok"])
+        self.assertTrue(body["beets"]["plugin_loader_error"])
+        self.assertEqual(body["beets"]["configured_plugins"], [])
+        self.assertEqual(body["integrations"]["musicbrainz"]["state"], "plugin_loader_failed")
+        for key in ("lastgenre", "listenbrainz", "discpath", "replaygain"):
+            self.assertNotEqual(body["integrations"][key]["state"], "configured")
+        self.assertIn(
+            "Beets plugin loader did not complete successfully",
+            " ".join(body["blocking_reasons"]),
+        )
+
+    # -- 4. Plugin import failure -----------------------------------------------
+    def test_plugin_import_failure_is_dependency_plugin_missing_without_crash(self):
+        self._write_config()
+        fake_proc = mock.Mock(
+            returncode=1,
+            stdout="",
+            stderr="** error loading plugin lastgenre\nModuleNotFoundError: No module named 'pylast'\n",
+        )
+        with self._env(), \
+             mock.patch.object(self.module, "_beet_binary", return_value=(True, "beet")), \
+             mock.patch.object(self.module.subprocess, "run", return_value=fake_proc):
+            response = self.client.get("/api/setup/status")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["integrations"]["lastgenre"]["state"], "dependency_plugin_missing")
+        self.assertFalse(body["beets"]["plugin_loader_ok"])
+        # Other integrations must not falsely claim the whole loader succeeded.
+        for key in ("musicbrainz", "discpath", "replaygain", "listenbrainz"):
+            self.assertNotEqual(body["integrations"][key]["state"], "configured")
+
+    # -- 5. Timeout ---------------------------------------------------------------
+    def test_timeout_returns_structured_response_without_raw_exception(self):
+        self._write_config()
+        timeout_exc = subprocess.TimeoutExpired(
+            cmd=["beet", "-c", str(self.config_file), "-vv", "version"],
+            timeout=12,
+            output="partial stdout before timeout",
+            stderr="partial stderr before timeout",
+        )
+        with self._env(), \
+             mock.patch.object(self.module, "_beet_binary", return_value=(True, "beet")), \
+             mock.patch.object(self.module.subprocess, "run", side_effect=timeout_exc):
+            response = self.client.get("/api/setup/status")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertTrue(body["beets"]["plugin_loader_timed_out"])
+        self.assertFalse(body["beets"]["plugin_loader_ok"])
+        self.assertIsNone(body["beets"]["plugins_returncode"])
+        text = response.get_data(as_text=True)
+        self.assertNotIn("TimeoutExpired", text)
+        self.assertNotIn("cmd=", text)
+        # The endpoint must remain responsive after a timeout -- prove it by
+        # calling it again immediately.
+        with self._env(), \
+             mock.patch.object(self.module, "_beet_binary", return_value=(True, "beet")), \
+             mock.patch.object(self.module.subprocess, "run", side_effect=timeout_exc):
+            second = self.client.get("/api/setup/status")
+        self.assertEqual(second.status_code, 200)
+
+    # -- 6. Redaction ---------------------------------------------------------------
+    def test_redaction_covers_named_secrets_headers_cookies_urls_and_query_strings(self):
+        self._write_config()
+        secret_values = [
+            "secret-token-xyz",
+            "bearer-value-xyz",
+            "cookie-value-xyz",
+            "hunter2reallysecretvalue",
+            "query-secret-xyz",
+            "discogs-secret-xyz",
+            "plex-secret-xyz",
+        ]
+        stdout = (
+            'token: "secret-token-xyz"\n'
+            "Authorization: Bearer bearer-value-xyz\n"
+            "Cookie: session=cookie-value-xyz\n"
+            "https://svcuser:hunter2reallysecretvalue@example.test/\n"
+            "https://example.test/?api_key=query-secret-xyz\n"
+            "DISCOGS_USER_TOKEN=discogs-secret-xyz\n"
+            "PLEX_TOKEN=plex-secret-xyz\n"
+        )
+        fake_proc = mock.Mock(returncode=0, stdout=stdout, stderr="")
+        with self._env(), \
+             mock.patch.object(self.module, "_beet_binary", return_value=(True, "beet")), \
+             mock.patch.object(self.module.subprocess, "run", return_value=fake_proc):
+            response = self.client.get("/api/setup/status")
+
+        self.assertEqual(response.status_code, 200)
+        text = response.get_data(as_text=True)
+        for secret in secret_values:
+            self.assertNotIn(secret, text)
+
+    def test_redaction_exception_path_never_leaks_secrets(self):
+        self._write_config()
+        sensitive = (
+            'Authorization: Bearer bearer-exc-secret Cookie: session=cookie-exc-secret '
+            'token="kv-exc-secret" https://svcuser:hunter2excsecretvalue@example.test/'
+        )
+        with self._env(), \
+             mock.patch.object(self.module, "_beet_binary", return_value=(True, "beet")), \
+             mock.patch.object(self.module.subprocess, "run", side_effect=RuntimeError(sensitive)):
+            response = self.client.get("/api/setup/status")
+
+        self.assertEqual(response.status_code, 200)
+        text = response.get_data(as_text=True)
+        for secret in ("bearer-exc-secret", "cookie-exc-secret", "kv-exc-secret", "hunter2excsecretvalue"):
+            self.assertNotIn(secret, text)
+
+    def test_redact_diagnostic_text_direct_pattern_coverage(self):
+        module = self.module
+        cases = [
+            'api_key=abc123', 'api-key: abc123', 'token="abc123"', "password='abc123'",
+            'secret: abc123', 'access_token=abc123', 'refresh_token=abc123',
+            'client_secret=abc123', 'user_token=abc123', 'auth_token=abc123',
+            'plex_token=abc123', 'lidarr_api_key=abc123', 'slskd_api_key=abc123',
+            'Authorization: Bearer abc123', 'Authorization: Basic abc123',
+            'Proxy-Authorization: abc123', 'Cookie: abc123', 'Set-Cookie: abc123',
+            'X-Api-Key: abc123', '?api_key=abc123', '&token=abc123',
+            '&access_token=abc123', '&auth=abc123', 'https://user:abc123@example.test/',
+        ]
+        for raw in cases:
+            redacted = module._redact_diagnostic_text(raw)
+            self.assertNotIn("abc123", redacted, raw)
+            self.assertIn("[redacted]", redacted, raw)
+
+    # -- 7. Optional credentials ------------------------------------------------
+    def test_optional_credentials_absent_does_not_block_setup(self):
+        # listenbrainz is enabled but has no token configured anywhere (config
+        # or env) -- this must resolve to `not_configured`, not block setup.
+        self.config_file.write_text(
+            "plugins: musicbrainz discpath listenbrainz\n"
+            "pluginpath:\n  - /config/beetsplug\n  - /app/beetsplug\n",
+            encoding="utf-8",
+        )
+        fake_proc = mock.Mock(
+            returncode=0,
+            stdout="beets version 2.12.0\nplugins: musicbrainz, discpath, listenbrainz\n",
+            stderr="",
+        )
+        stale_keys = (
+            "OPENAI_API_KEY", "OPENROUTER_API_KEY", "AI_API_KEY",
+            "DISCOGS_TOKEN", "DISCOGS_USER_TOKEN", "LISTENBRAINZ_TOKEN",
+            "ACOUSTID_API_KEY", "ACOUSTID_KEY",
+        )
+        with self._env(), \
+             mock.patch.object(self.module, "_beet_binary", return_value=(True, "beet")), \
+             mock.patch.object(self.module.subprocess, "run", return_value=fake_proc):
+            for key in stale_keys:
+                os.environ.pop(key, None)
+            response = self.client.get("/api/setup/status")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["integrations"]["ai"]["state"], "not_configured")
+        self.assertEqual(body["integrations"]["discogs"]["state"], "installed_but_disabled")
+        self.assertEqual(body["integrations"]["listenbrainz"]["state"], "not_configured")
+        self.assertFalse(body["integrations"]["ai"]["required"])
+        self.assertFalse(body["integrations"]["discogs"]["required"])
 
 
 class RoutesSetupTestConnectionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Independent-review correction targeting confirmed defects in the setup-diagnostics code that had already merged into `main` as part of the old PR #20 (`fix/beets-fresh-install-plugins`, merged as squash commit `bf90bf257febee6b5afb599dac199fc13fba4439`). PR #20 itself is already merged and is **not** being reopened -- this is a fresh, independent follow-up PR. PR #21 is merged and untouched. PR #19 (`import-review-attach-enforcement`) is a separate, unrelated in-flight draft and is untouched.

## Defects fixed

1. **Unsupported `beet plugins` diagnostic.** `_beets_plugin_diagnostics()` called `_run_beet_diagnostic(["plugins"], ...)` -- Beets 2.12.0 has no `beet plugins` command -- and ignored a nonzero probe result unless the output happened to match a narrow error pattern, so configured plugins could show as healthy even when the probe itself failed.
2. **Incomplete redaction.** `_redact_diagnostic_text()` missed quoted secrets, Authorization/Cookie/Set-Cookie headers, Bearer/Basic tokens, query-string credentials, provider-specific credential names (compound identifiers like `lidarr_api_key`), and URL userinfo credentials.

## Supported diagnostic command (replacing `beet plugins`)

`beet -c <config> -vv version` -- a real, supported, noninteractive, read-only, bounded-timeout Beets 2.12.0 command. Beets initializes all configured plugins during UI startup for every subcommand, so a plugin import/initialization failure surfaces here exactly as it does for the same command already proven in the Docker smoke test (`tests/test_beets_fresh_install_plugins.py`).

## Loader-failure / timeout behavior

A loader result counts as successful (`plugin_loader_ok`) only when: the `beet` executable was found, the config file exists, the process returned 0, it did not time out, and no recognized plugin-failure pattern appears in its output. When any of that is false:
- `configured_plugins`/`pluginpath`/`replaygain_backend`/`replaygain_command` are reported empty rather than parsed-but-untrusted config.yaml content.
- Per-integration state becomes `plugin_loader_failed` (new, narrowly-defined) unless a specific plugin-failure line names that plugin, in which case it stays `dependency_plugin_missing`.
- `blocking_reasons` gains an entry and overall `status` becomes at least `"warning"`.
- `subprocess.TimeoutExpired` is now caught explicitly (previously fell through to a generic exception handler) and returns a structured result: `available=True, returncode=None, timed_out=True`, with sanitized partial stdout/stderr -- never the raw exception object. The endpoint stays responsive immediately afterward (tested).

Backward compatibility: `plugins_returncode` is kept (now reflects the loader probe, documented in comments); `diagnostic_error` is preserved for the existing exception-path test. New fields: `plugin_loader_returncode`, `plugin_loader_ok`, `plugin_loader_timed_out`, `plugin_loader_error`.

## Secret redaction

`_redact_diagnostic_text()` now layers, in order: app.py's `_redact_security_text` (PR #23's CodeQL exception-sanitization helper, reused as a base pass) -> Authorization/Proxy-Authorization headers (Bearer/Basic or bare) -> Cookie/Set-Cookie headers -> URL userinfo credentials -> a generic named key/value pattern that matches any identifier *ending* in `api_key`/`client_secret`/`token`/`password`/`secret`/`auth` regardless of prefix (so `lidarr_api_key`, `slskd_api_key`, `plex_token`, `discogs_user_token`, `access_token`, `refresh_token`, `user_token`, `auth_token`, `X-Api-Key`, `?api_key=`, `&token=`, `&auth=` are all covered by one pattern, quoted or bare). Applied at the subprocess boundary (stdout/stderr) and again defensively in `_integration_status()` before any note/detail is serialized. Verified via a direct pattern-coverage test plus route-level tests injecting real secret values into stdout/stderr/exception paths and asserting they never appear anywhere in the serialized JSON response.

## Integration-state behavior (loader succeeds)

- `discogs` disabled in config -> `installed_but_disabled`
- `listenbrainz` enabled, no token -> `not_configured`
- AI keys absent -> `not_configured`, not blocking
- AcoustID key absent, Chroma + fpcalc available -> fingerprinting available, key noted optional
- `lastgenre` enabled and loaded -> `configured`
- `discpath` enabled and loaded -> `configured`
- ReplayGain enabled, loaded, `backend: ffmpeg`, ffmpeg available -> `configured`
- Nothing is ever labeled `connected` without a real connection test.

## User-plugin precedence

Proven directly against Beets' own plugin-loading implementation (`beets/plugins.py get_plugin_names()`: `beetsplug.__path__ = paths + list(beetsplug.__path__)`) rather than assumed: a `pluginpath` entry listed first wins for a same-named module. `/config/beetsplug` is already listed before `/app/beetsplug` in this repo's config, so **no path-order change was needed** -- added `tests/test_plugin_path_precedence.py` with a behavioral test (synthetic same-named plugin in two temp dirs, real `beets.plugins.load_plugins()`) plus a reversed-order control case proving the result is really about order.

## Tests added

- `tests/test_routes_setup.py::RoutesSetupPluginLoaderDiagnosticsTests` (9 tests): successful loader, unsupported-command regression (asserts exact argv), nonzero loader result, plugin import failure, timeout, redaction (route-level + direct helper-level), optional-credentials-absent.
- `tests/test_plugin_path_precedence.py` (2 tests): user-path-wins, reversed-order control.
- `tests/test_beets_fresh_install_plugins.py`: Docker smoke test now asserts an explicit `SETUP_DIAGNOSTIC_LOADER_PROBE_OK` marker proving the exact command exits 0 in the real image, and that `beet plugins` is never invoked.

## Test results

- Focused: `test_beets_fresh_install_plugins` + `test_routes_setup` + `test_ai_auth_setup_hardening` + `test_security_hardening` + `test_plugin_path_precedence` -> **105 tests, OK (1 skipped** -- Docker smoke skipped unless `RUN_DOCKER_SMOKE=1`).
- Repeated (5x) `RoutesSetupPluginLoaderDiagnosticsTests` + `test_plugin_path_precedence` -> **11 tests, OK, every run** -- no flakiness.
- Full discovery x2: `python -m unittest discover -s tests -p "test_*.py"` -> **1139 tests, OK (skipped=1)**, both runs.
- Docker smoke (`RUN_DOCKER_SMOKE=1`, real image build + container run): **1 test, OK** -- supported loader probe exits 0, configured plugins load, no plugin import failure, `pylast`/discpath/Chroma+fpcalc/ReplayGain+ffmpeg all load, Discogs stays disabled without an interactive OAuth prompt, `beet plugins` never invoked.
- `python -m py_compile app.py routes_setup.py` -> clean.
- `python scripts/security_secret_scan.py` -> passed.
- `python scripts/validate_compose_security.py` -> `ok: true` (only pre-existing unrelated warnings about non-Beets `:latest` images).
- `git diff --check` -> clean.

## Frontend validation

`npm ci`, `npm run typecheck`, `npm run lint`, `npm run build` all clean; `npm audit --audit-level=high` -> **0 vulnerabilities** (PR #18's postcss/sharp overrides untouched, `package.json`/`package-lock.json` not modified).

## Compose / security validation

- `docker compose config --quiet` and `docker compose -f docker-compose.arrs.yml config --quiet` both validate successfully with required auth (`BEETS_WEB_AUTH_TOKEN`) and other required per-service vars supplied, and all optional AI/Discogs/ListenBrainz/AcoustID vars left blank.
- Deliberate negative test: unsetting `BEETS_WEB_AUTH_TOKEN` makes `docker compose config --quiet` fail closed (`required variable BEETS_WEB_AUTH_TOKEN is missing a value`, exit 1), confirming the fail-closed gate is unaffected.
- `tests/test_security_hardening.py` run before and after this change with identical pass results -- no security test weakened.

## Nothing regressed

Beets `2.12.0`, required extras, `pylast`, `plexsync` removal, Discogs-disabled-by-default, `/config/beetsplug` + `/app/beetsplug` paths, ReplayGain ffmpeg backend, optional-credential handling, required web authentication, Docker hardening, PR #18's 0-vulnerability frontend state, and the pre-existing full test suite are all preserved (1139/1139 passing, twice).

## Follow-up fix (independent-review round 2): complete + idempotent redaction

A second independent review found two narrower defects still present in `_redact_diagnostic_text()` after the round above. Fixed in place on this same branch/PR, commit `44599ea2d4e8435e2e731889d1e9ddb5a6cd91a4`, files `routes_setup.py` and `tests/test_routes_setup.py` only:

1. **Incomplete multi-value Cookie/Set-Cookie redaction.** `_COOKIE_HEADER_RE` previously only redacted the first token after `Cookie:`/`Set-Cookie:`, so `Cookie: session=alpha; refresh=bravo` could leave `refresh=bravo` exposed. It now matches the entire header value through end-of-line (`[^\r\n]*`, never consuming the next line) and replaces the whole match unconditionally with the header name/separator/marker, so every cookie pair and attribute is redacted regardless of count, case, or shape.
2. **Redaction was not idempotent.** `_redact_diagnostic_text()` is genuinely called more than once on the same text in production (subprocess stdout/stderr boundary, failure-line extraction, and integration payload serialization all call it in sequence), but `_SECRET_KV_RE`'s bare-value capture stopped short of a literal `]`, so re-scanning an already-redacted `[redacted]` placeholder partially re-matched it and stranded the closing bracket -- accumulating an extra `]` on every additional pass (`token=abc` -> `token=[redacted]` -> `token=[redacted]]` -> ...). Fixed with a negative lookahead so an existing placeholder (quoted or bare, either case) is never re-matched by `_SECRET_KV_RE`, plus a small defense-in-depth cleanup (`_STRAY_REDACTED_BRACKET_RE`) that collapses any stray `]` left behind by other secret-shaped regexes reprocessing the same marker -- including app.py's `_redact_security_text`, used as the first redaction layer, which this module does not control and was not modified.

New tests added to `tests/test_routes_setup.py`:
- `test_redact_diagnostic_text_cookie_header_redacts_entire_value` -- 5 multi-value/attribute Cookie and Set-Cookie inputs, asserts none of the cookie values survive.
- `test_redact_diagnostic_text_does_not_consume_following_line` -- proves the end-of-line-bounded cookie pattern never eats a subsequent diagnostic line.
- `test_redact_diagnostic_text_is_idempotent` -- 3-pass equality (`first == second == third`) across 6 representative secret shapes (named key/value, Authorization/Bearer, Cookie, URL userinfo, query-string, provider env-var style), asserting no `]]` accumulation.
- `test_nonzero_loader_result_redacts_multivalue_cookies_and_tokens` -- route-level regression: simulates a failing plugin loader with multi-value `Cookie`/`Set-Cookie`/`token` stderr and asserts the full serialized `/api/setup/status` response never leaks a cookie/token value or accumulates stray brackets, while `plugin_loader_ok` stays `false` and overall `status` stays `"warning"` with HTTP 200.

Test results (this follow-up):
- `RoutesSetupPluginLoaderDiagnosticsTests` alone, run 5x in a row: **13 tests, OK, every run** -- no flakiness.
- Focused set (`test_beets_fresh_install_plugins` + `test_routes_setup` + `test_plugin_path_precedence` + `test_ai_auth_setup_hardening` + `test_security_hardening`): **109 tests, OK (skipped=1)**.
- Full discovery x2 (`python -m unittest discover -s tests -p "test_*.py"`): **1143 tests, OK (skipped=1)**, both runs.
- Docker smoke (`RUN_DOCKER_SMOKE=1`): **1 test, OK**.
- `python -m py_compile routes_setup.py`, `python scripts/security_secret_scan.py`, `python scripts/validate_compose_security.py` (`ok: true`, only pre-existing unrelated `:latest`-image warnings), `git diff --check` -- all clean.
- Frontend (`npm ci`, `npm run typecheck`, `npm run lint`, `npm run build`, `npm audit --audit-level=high`): all clean, **0 vulnerabilities** -- unchanged, no frontend files touched.

Everything else from the round above (the `beet -c <config> -vv version` loader probe, fail-closed plugin-loader status, timeout handling, backend-authoritative integration states, existing secret-redaction coverage, user-plugin precedence) is unchanged and re-verified passing.

This PR is intentionally left in **draft** and is not being merged.

