### PR TITLE
fix: redact Bearer/Basic auth values in shared security-text helper

### DIFF
--- a/app.py
+++ b/app.py
@@ -1713,7 +1713,7 @@ _AUTH_PUBLIC_ENDPOINTS = {
 }
 _SECRET_ASSIGNMENT_RE = re.compile(
     r"(?i)\b(api[_-]?key|token|password|secret|authorization|cookie|client[_-]?secret)"
-    r"(\s*[:=]\s*)([^\s,;}\]\"]+)"
+    r"(\s*[:=]\s*)(?:(?:Bearer|Basic)\s+)?(\[REDACTED\]|[^\s,;}\]\"]+)"
 )
 _CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
 _REDACTED_SECRET = "[REDACTED]"
@@ -2194,10 +2194,16 @@ def _json_security_error(status: int, message: str):
     return response
 
 
+def _redact_secret_assignment_match(match: "re.Match[str]") -> str:
+    if match.group(3) == _REDACTED_SECRET:
+        return match.group(0)
+    return f"{match.group(1)}{match.group(2)}{_REDACTED_SECRET}"
+
+
 def _redact_security_text(value: Any) -> str:
     text = _s(value)
     text = _CONTROL_CHAR_RE.sub("?", text)
-    return _SECRET_ASSIGNMENT_RE.sub(lambda m: f"{m.group(1)}{m.group(2)}{_REDACTED_SECRET}", text)
+    return _SECRET_ASSIGNMENT_RE.sub(_redact_secret_assignment_match, text)
 
 
 def _is_public_endpoint() -> bool:

--- a/tests/test_import_review_manual_id_workflow.py
+++ b/tests/test_import_review_manual_id_workflow.py
@@ -390,6 +390,34 @@ class ImportReviewManualIdBehaviorTests(unittest.TestCase):
         self.assertEqual(response.get_json()["error"], "MusicBrainz lookup failed.")
         self.assertNoSensitiveExceptionDetails(response)
 
+    def test_redact_security_text_fully_redacts_bearer_and_basic_auth_values(self):
+        redact = self.app_module._redact_security_text
+        cases = [
+            "Authorization: Bearer abc123xyzSECRETTOKEN",
+            "Authorization=Bearer abc123xyzSECRETTOKEN",
+            "Authorization: Basic dXNlcjpwYXNzd29yZA==",
+        ]
+        for text in cases:
+            result = redact(text)
+            self.assertNotIn("abc123xyzSECRETTOKEN", result)
+            self.assertNotIn("dXNlcjpwYXNzd29yZA==", result)
+            self.assertIn("[REDACTED]", result)
+
+    def test_redact_security_text_is_idempotent(self):
+        redact = self.app_module._redact_security_text
+        cases = [
+            "token=supersecretvalue",
+            "Authorization: Bearer abc123xyzSECRETTOKEN",
+            "api_key: my-secret-key-123",
+        ]
+        for text in cases:
+            first = redact(text)
+            second = redact(first)
+            third = redact(second)
+            self.assertEqual(first, second)
+            self.assertEqual(second, third)
+            self.assertNotIn("]]", third)
+
     def test_manual_match_builder_keeps_target_preview_eligible_contract(self):
         selected = self.app_module._import_review_build_revalidated_match(
             {"suggestion": {"confidence": "high"}},


### PR DESCRIPTION
## Problem

Found during independent review of PR #24's redaction fixes (unrelated to that PR's own scope, but discovered while verifying its redaction logic). \`app.py\`'s \`_redact_security_text()\` — the shared base redaction layer, added in PR #23 for CodeQL exception sanitization — fails to fully redact HTTP Authorization values:

\`\`\`
Authorization: Bearer abc123xyzSECRETTOKEN
\`\`\`
redacted to:
\`\`\`
Authorization: [REDACTED] abc123xyzSECRETTOKEN
\`\`\`

The regex's value-capture group only matched the scheme word (\`Bearer\`/\`Basic\`) and stopped at the following whitespace, leaving the actual credential exposed. This function is used both for exception/traceback logging (\`_handle_unexpected_error\`) and for the ytdlp cookie-rejection reason surfaced via \`_redacted_ytdlp_rejection\` (which flows into an API response field on the System page), so the leak could reach both server logs and, in the cookie-rejection path, an HTTP response.

A related idempotence bug was also present: the value pattern's character class excluded \`]\`, so it could never fully match an already-redacted \`[REDACTED]\` marker. Since this helper runs at multiple call sites/layers, repeated redaction of the same text accumulated trailing \`]\` characters (e.g. \`token=[REDACTED]\` → \`token=[REDACTED]]\` → \`token=[REDACTED]]]\`).

## Resolution

- \`_SECRET_ASSIGNMENT_RE\` now optionally consumes a \`Bearer \`/\`Basic \` prefix as part of the matched value, so the entire credential is captured and replaced, not just the scheme word.
- The replacement callback now special-cases an already-\`[REDACTED]\` value and returns the match unchanged, making repeated redaction a true no-op (fixes the idempotence bug for the same underlying pattern).
- Two new direct unit tests in \`tests/test_import_review_manual_id_workflow.py\` call the real \`_redact_security_text()\` function (not mocked) to verify: (1) Bearer and Basic auth values are fully redacted with no residual token/credential text, and (2) three successive redaction passes produce identical output with no \`]\` accumulation.

## Validation

- \`python -m py_compile app.py\`: passed
- \`python -m unittest tests.test_import_review_manual_id_workflow tests.test_security_hardening\`: passed (34 tests, OK)
- \`python -m unittest discover -s tests -p "test_*.py"\`: passed (1130 tests, OK, 1 skip)
- \`python scripts/security_secret_scan.py\`: passed
- \`python scripts/validate_compose_security.py\`: ok: true (only pre-existing unrelated \`:latest\`-image warnings)
- \`git diff --check origin/main...HEAD\`: clean
- Frontend (\`npm ci\`/\`typecheck\`/\`lint\`/\`audit\`): all clean, 0 vulnerabilities — no frontend files touched

## Scope

Only touches \`app.py\` (the shared \`_redact_security_text\` helper) and its new regression tests. Does not touch Import Review, matching logic, attach-enforcement, jobs, dependency files, or anything in PR #19/#20/#21/#23/#24.

Left as draft pending independent review.