### PR TITLE
docs: move screenshot tour to its own page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,7 @@ I made this because the beets web plugin just wasn't cutting it. Not only does t
 
 ## Screenshots
 
-| | |
-| --- | --- |
-| **Library** | ![Library](screenshots/library.jpg) |
-| **Import — Import Source** | ![Import Source](screenshots/import-source.jpg) |
-| **Import — Review Queue** | ![Review Queue](screenshots/import-review-queue.jpg) |
-| **Playlists** | ![Playlists](screenshots/playlists.jpg) |
-| **Jobs / Library Cleanup** | ![Jobs](screenshots/jobs.jpg) |
-| **Submissions** | ![Submissions](screenshots/submissions.jpg) |
-| **Settings** | ![Settings](screenshots/settings.jpg) |
-| **Library Changes** | ![Library Changes](screenshots/library-changes.jpg) |
+See [SCREENSHOTS.md](SCREENSHOTS.md) for a tour of the app (Library, Import, Playlists, Jobs, Submissions, Settings, Library Changes).
 
 ## Installation
 

--- a/SCREENSHOTS.md
+++ b/SCREENSHOTS.md
@@ -1,0 +1,14 @@
+# Screenshots
+
+A general tour of the running app.
+
+| | |
+| --- | --- |
+| **Library** | ![Library](screenshots/library.jpg) |
+| **Import — Import Source** | ![Import Source](screenshots/import-source.jpg) |
+| **Import — Review Queue** | ![Review Queue](screenshots/import-review-queue.jpg) |
+| **Playlists** | ![Playlists](screenshots/playlists.jpg) |
+| **Jobs / Library Cleanup** | ![Jobs](screenshots/jobs.jpg) |
+| **Submissions** | ![Submissions](screenshots/submissions.jpg) |
+| **Settings** | ![Settings](screenshots/settings.jpg) |
+| **Library Changes** | ![Library Changes](screenshots/library-changes.jpg) |


### PR DESCRIPTION
## Summary
- Adds `SCREENSHOTS.md` with the screenshot tour (moved out of the README).
- README's Screenshots section is now a one-line link to it, so Features/Installation stay front and center on the repo landing page.

No image files moved -- both pages reference the same `screenshots/` folder.