### PR TITLE
fix: validate outbound URL at the OpenGraph fetch sink

### DIFF
--- a/routes_submissions.py
+++ b/routes_submissions.py
@@ -1237,6 +1237,10 @@ def _fetch_discogs_release(entity_type: str, entity_id: str) -> Dict[str, Any]:
 
 
 def _fetch_open_graph_metadata(url: str) -> Dict[str, Any]:
+    # Re-validated here, not just by the route's _validate_reference_url()
+    # call before this is reached -- this is the actual network sink, so it
+    # must not depend on every future caller remembering to check first.
+    validate_outbound_url(url)
     req = urllib.request.Request(url, headers={"User-Agent": "beets-web-manager reference-url fetcher"})
     with urllib.request.urlopen(req, timeout=_REFERENCE_URL_TIMEOUT) as resp:
         raw = resp.read(_REFERENCE_MAX_BYTES)


### PR DESCRIPTION
## Summary
Fixes CodeQL alert #18 (`py/full-ssrf`, critical): https://github.com/Iranman/beets-web-manager/security/code-scanning/18

`_fetch_open_graph_metadata(url)` (`routes_submissions.py`) makes an outbound `urllib.request` call with a user-supplied URL and had no validation of its own. Its one call site (`/api/submissions/reference-url`) does validate first via `_validate_reference_url()` -> `validate_outbound_url()`, so this wasn't currently exploitable, but CodeQL's static analysis doesn't credit a separate caller-side check as a sanitizer for this sink, and depending solely on every future caller remembering to validate first is fragile. Added a direct `validate_outbound_url(url)` call at the top of the function, right before the network request it guards.

## Test plan
- [x] `python -m py_compile app.py routes_submissions.py backend/security.py`
- [x] `tests.test_submissions_page`, `tests.test_discogs_fallback`, `tests.test_outbound_security`, `tests.test_submission_folder_resolution` (49 tests) pass
- [x] `python scripts/security_secret_scan.py`, `python scripts/validate_compose_security.py` clean
- [x] Full `unittest discover` run