### PR TITLE
fix: auto-repair pre-Issue-#14 config.yaml on startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -2014,6 +2014,112 @@ def _bootstrap_auth_token_if_missing() -> None:
 _bootstrap_auth_token_if_missing()
 
 
+_LEGACY_BEETS_CONFIG_MIGRATION_MARKER = "# beets-web-manager: legacy-plugin-config-migrated"
+
+
+def _repair_legacy_beets_config(config_path: Optional[str] = None) -> None:
+    """First-run safety net for installs whose /config/config.yaml predates
+    the Issue #14 packaging fix: setup.sh/setup.ps1 only copy
+    config.yaml.example into place when config.yaml does not already exist,
+    so an install set up before that fix shipped stays stuck on the old
+    broken defaults across every later image update -- a raw `beet` CLI
+    invocation inside the container reads this file directly, with none of
+    the job-config overrides the web app's own operations already get
+    (_BEETS_PLUGINPATH_CONFIG, _JOB_PLUGIN_EXCLUDED).
+
+    Repairs exactly three known-legacy patterns and nothing else a user
+    configured:
+      1. drops the never-installed `plexsync` token from `plugins:`
+      2. adds `/app/beetsplug` to `pluginpath:` (where the bundled discpath
+         plugin now lives) if missing
+      3. switches an existing `replaygain:` section's backend to `ffmpeg`
+         (the one this image actually installs) when it's still pointed at
+         mp3gain -- explicitly or by omission, beets' own default -- and
+         mp3gain isn't actually available
+
+    Does not create a replaygain: section that isn't already present; that
+    narrower scope keeps this a config repair, not a config generator.
+    Idempotent: writes a marker comment on first repair and no-ops on every
+    later startup. Backs up the original once, to its own filename (not the
+    config editor's /api/config/revert backup), before ever touching it.
+    """
+    path = Path(config_path or os.environ.get("BEETS_CONFIG", "/config/config.yaml"))
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return
+    if _LEGACY_BEETS_CONFIG_MIGRATION_MARKER in text:
+        return
+
+    changed = False
+
+    def _fix_plugins_line(m: "re.Match") -> str:
+        nonlocal changed
+        tokens = m.group(1).split()
+        if "plexsync" not in tokens:
+            return m.group(0)
+        changed = True
+        return "plugins: " + " ".join(t for t in tokens if t != "plexsync")
+
+    text = re.sub(r"(?m)^plugins:[ \t]*(.*)$", _fix_plugins_line, text, count=1)
+
+    pluginpath_match = re.search(r"(?m)^pluginpath:[ \t]*(.*)$((?:\n[ \t]+-[ \t]*\S.*$)*)", text)
+    if pluginpath_match is None:
+        changed = True
+        block = "pluginpath:\n  - /config/beetsplug\n  - /app/beetsplug\n"
+        if re.search(r"(?m)^plugins:.*$", text):
+            text = re.sub(r"(?m)^plugins:.*$\n", lambda m: m.group(0) + block, text, count=1)
+        else:
+            text = block + text
+    else:
+        inline_value = pluginpath_match.group(1).strip()
+        list_block = pluginpath_match.group(2) or ""
+        entries = [inline_value] if inline_value else []
+        entries += [ln.split("-", 1)[1].strip() for ln in list_block.splitlines() if ln.strip().startswith("-")]
+        if "/app/beetsplug" not in entries:
+            changed = True
+            new_entries = (entries or ["/config/beetsplug"]) + ["/app/beetsplug"]
+            replacement = "pluginpath:\n" + "".join(f"  - {e}\n" for e in new_entries if e)
+            text = text[:pluginpath_match.start()] + replacement.rstrip("\n") + text[pluginpath_match.end():]
+
+    replaygain_match = re.search(r"(?m)^replaygain:[ \t]*$((?:\n[ \t]+\S.*$)*)", text)
+    if replaygain_match is not None:
+        block = replaygain_match.group(1) or ""
+        backend_match = re.search(r"(?m)^([ \t]+)backend:[ \t]*(\S+)[ \t]*$", block)
+        current_backend = backend_match.group(2) if backend_match else "mp3gain"
+        if current_backend != "ffmpeg" and not shutil.which("mp3gain") and shutil.which("ffmpeg"):
+            changed = True
+            if backend_match:
+                indent = backend_match.group(1)
+                new_block = block[:backend_match.start()] + f"{indent}backend: ffmpeg" + block[backend_match.end():]
+            else:
+                indent_search = re.search(r"(?m)^([ \t]+)\S", block)
+                indent = indent_search.group(1) if indent_search else "    "
+                new_block = block + f"\n{indent}backend: ffmpeg"
+            text = text[:replaygain_match.start(1)] + new_block + text[replaygain_match.end(1):]
+
+    if not changed:
+        return
+    try:
+        backup = path.with_name(path.name + ".bak-legacy-plugin-migration")
+        if not backup.exists():
+            shutil.copy2(str(path), str(backup))
+        if not text.endswith("\n"):
+            text += "\n"
+        text += f"{_LEGACY_BEETS_CONFIG_MIGRATION_MARKER}\n"
+        path.write_text(text, encoding="utf-8")
+        print(
+            "Repaired legacy config.yaml defaults from before the Issue #14 fix "
+            f"(backup saved to {backup}).",
+            flush=True,
+        )
+    except Exception:
+        pass
+
+
+_repair_legacy_beets_config()
+
+
 def _constant_time_equal(left: str, right: str) -> bool:
     return hmac.compare_digest((left or "").encode("utf-8"), (right or "").encode("utf-8"))
 

--- a/tests/test_legacy_beets_config_migration.py
+++ b/tests/test_legacy_beets_config_migration.py
@@ -1,0 +1,201 @@
+"""Tests for _repair_legacy_beets_config() -- the startup safety net for
+installs whose /config/config.yaml predates the Issue #14 packaging fix
+(https://github.com/Iranman/beets-web-manager/issues/14). setup.sh/setup.ps1
+only copy config.yaml.example into place when config.yaml does not already
+exist, so an install set up before that fix shipped stays stuck on the old
+plexsync/pluginpath/mp3gain defaults across every later image update -- a
+raw `beet` CLI invocation inside the container reads this file directly.
+These tests import the real app.py (same isolated-temp-environment pattern
+as tests/test_ai_batch_retry_race.py) and call the actual function against
+synthetic config.yaml fixtures on disk.
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_TMP_ROOT = Path(tempfile.mkdtemp(prefix="beets_legacy_config_migration_"))
+unittest.addModuleCleanup(shutil.rmtree, str(_TMP_ROOT), ignore_errors=True)
+
+_ENV_OVERRIDES = {
+    "BEETSDIR": str(_TMP_ROOT / "config"),
+    "LIB_PATH": str(_TMP_ROOT / "config" / "musiclibrary.blb"),
+    "AI_BATCH_STATE_DIR": str(_TMP_ROOT / "ai_batch_jobs"),
+    "METADATA_CACHE_DIR": str(_TMP_ROOT / "cache"),
+    "BEETS_TRANSACTION_DIR": str(_TMP_ROOT / "transactions"),
+    "BEETS_WEB_AUTH_DISABLED": "1",
+}
+(_TMP_ROOT / "config").mkdir(parents=True, exist_ok=True)
+_env_patcher = mock.patch.dict(os.environ, _ENV_OVERRIDES, clear=False)
+_env_patcher.start()
+unittest.addModuleCleanup(_env_patcher.stop)
+
+
+def setUpModule():
+    os.environ.update(_ENV_OVERRIDES)
+
+
+def _import_app():
+    sys.path.insert(0, str(ROOT))
+    import app as app_module
+    return app_module
+
+
+try:
+    APP = _import_app()
+    _APP_IMPORT_ERROR = None
+except Exception as exc:  # pragma: no cover - environment-dependent
+    APP = None
+    _APP_IMPORT_ERROR = exc
+
+
+OLD_BROKEN_CONFIG = """plugins: fetchart embedart convert scrub replaygain lastgenre chroma lyrics mbsync musicbrainz deezer listenbrainz ftintitle fromfilename duplicates missing smartplaylist mbsubmit unimported discpath plexsync
+pluginpath: /config/beetsplug
+directory: /data/media/music
+library: /config/musiclibrary.blb
+
+replaygain:
+    auto: no
+
+scrub:
+    auto: yes
+"""
+
+ALREADY_CURRENT_CONFIG = """plugins: fetchart embedart replaygain discpath
+pluginpath:
+  - /config/beetsplug
+  - /app/beetsplug
+directory: /data/media/music
+
+replaygain:
+    auto: no
+    backend: ffmpeg
+"""
+
+
+@unittest.skipIf(APP is None, f"app.py could not be imported: {_APP_IMPORT_ERROR}")
+class LegacyBeetsConfigMigrationTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="legacy_config_case_"))
+        self.addCleanup(shutil.rmtree, str(self.tmp), ignore_errors=True)
+        self.config_path = self.tmp / "config.yaml"
+
+    def _write(self, text: str) -> None:
+        self.config_path.write_text(text, encoding="utf-8")
+
+    def _repair(self, mp3gain_present=False, ffmpeg_present=True):
+        def fake_which(name):
+            if name == "mp3gain":
+                return "/usr/bin/mp3gain" if mp3gain_present else None
+            if name == "ffmpeg":
+                return "/usr/bin/ffmpeg" if ffmpeg_present else None
+            return None
+        with mock.patch.object(APP.shutil, "which", side_effect=fake_which):
+            APP._repair_legacy_beets_config(str(self.config_path))
+
+    def test_drops_plexsync_from_plugins_line(self):
+        self._write(OLD_BROKEN_CONFIG)
+        self._repair()
+        result = self.config_path.read_text(encoding="utf-8")
+        first_line = result.splitlines()[0]
+        self.assertNotIn("plexsync", first_line)
+        self.assertIn("discpath", first_line)
+        self.assertIn("fetchart", first_line)
+
+    def test_upgrades_single_string_pluginpath_to_list_with_app_beetsplug(self):
+        self._write(OLD_BROKEN_CONFIG)
+        self._repair()
+        result = self.config_path.read_text(encoding="utf-8")
+        self.assertIn("pluginpath:\n  - /config/beetsplug\n  - /app/beetsplug\n", result)
+
+    def test_inserts_missing_pluginpath_after_plugins_line(self):
+        text = "plugins: fetchart discpath\ndirectory: /data/media/music\n"
+        self._write(text)
+        self._repair()
+        result = self.config_path.read_text(encoding="utf-8")
+        self.assertIn("pluginpath:\n  - /config/beetsplug\n  - /app/beetsplug\n", result)
+        self.assertLess(result.index("pluginpath:"), result.index("directory:"))
+
+    def test_appends_missing_app_beetsplug_to_existing_pluginpath_list(self):
+        text = "plugins: fetchart discpath\npluginpath:\n  - /config/beetsplug\n  - /config/custom-plugins\ndirectory: /x\n"
+        self._write(text)
+        self._repair()
+        result = self.config_path.read_text(encoding="utf-8")
+        self.assertIn("/config/custom-plugins", result)
+        self.assertIn("/app/beetsplug", result)
+
+    def test_switches_mp3gain_backend_to_ffmpeg_when_mp3gain_unavailable(self):
+        self._write(OLD_BROKEN_CONFIG)
+        self._repair(mp3gain_present=False, ffmpeg_present=True)
+        result = self.config_path.read_text(encoding="utf-8")
+        self.assertIn("backend: ffmpeg", result)
+
+    def test_inserts_backend_line_when_replaygain_section_has_none(self):
+        self._write(OLD_BROKEN_CONFIG)
+        self._repair()
+        result = self.config_path.read_text(encoding="utf-8")
+        self.assertIn("replaygain:\n    auto: no\n    backend: ffmpeg\n", result)
+
+    def test_replaces_explicit_mp3gain_backend_value(self):
+        text = "plugins: fetchart\nreplaygain:\n    auto: no\n    backend: mp3gain\n"
+        self._write(text)
+        self._repair(mp3gain_present=False, ffmpeg_present=True)
+        result = self.config_path.read_text(encoding="utf-8")
+        self.assertIn("backend: ffmpeg", result)
+        self.assertNotIn("backend: mp3gain", result)
+
+    def test_does_not_touch_working_mp3gain_setup(self):
+        text = "plugins: fetchart\nreplaygain:\n    auto: no\n    backend: mp3gain\n"
+        self._write(text)
+        self._repair(mp3gain_present=True, ffmpeg_present=True)
+        result = self.config_path.read_text(encoding="utf-8")
+        self.assertIn("backend: mp3gain", result)
+
+    def test_already_current_config_is_left_untouched(self):
+        self._write(ALREADY_CURRENT_CONFIG)
+        self._repair()
+        result = self.config_path.read_text(encoding="utf-8")
+        self.assertEqual(result, ALREADY_CURRENT_CONFIG)
+        backup = self.tmp / "config.yaml.bak-legacy-plugin-migration"
+        self.assertFalse(backup.exists())
+
+    def test_creates_backup_before_first_repair(self):
+        self._write(OLD_BROKEN_CONFIG)
+        self._repair()
+        backup = self.tmp / "config.yaml.bak-legacy-plugin-migration"
+        self.assertTrue(backup.exists())
+        self.assertEqual(backup.read_text(encoding="utf-8"), OLD_BROKEN_CONFIG)
+
+    def test_idempotent_second_run_is_a_no_op(self):
+        self._write(OLD_BROKEN_CONFIG)
+        self._repair()
+        once = self.config_path.read_text(encoding="utf-8")
+        backup = self.tmp / "config.yaml.bak-legacy-plugin-migration"
+        backup_mtime = backup.stat().st_mtime
+        self._repair()
+        twice = self.config_path.read_text(encoding="utf-8")
+        self.assertEqual(once, twice)
+        self.assertEqual(backup.stat().st_mtime, backup_mtime)
+
+    def test_missing_config_file_does_not_raise(self):
+        # No config.yaml written at all -- must not crash startup.
+        APP._repair_legacy_beets_config(str(self.tmp / "does-not-exist.yaml"))
+
+    def test_full_reporter_scenario_ends_up_fully_repaired(self):
+        self._write(OLD_BROKEN_CONFIG)
+        self._repair(mp3gain_present=False, ffmpeg_present=True)
+        result = self.config_path.read_text(encoding="utf-8")
+        first_line = result.splitlines()[0]
+        self.assertNotIn("plexsync", first_line)
+        self.assertIn("pluginpath:\n  - /config/beetsplug\n  - /app/beetsplug\n", result)
+        self.assertIn("backend: ffmpeg", result)
+        self.assertNotIn("backend: mp3gain", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Follow-up to #14. The original fix (coherent plugin deps, bundled `pluginpath`, `ffmpeg` replaygain backend) only applies to config.yaml.example -- setup.sh/setup.ps1 never overwrite an existing config.yaml, so anyone who set up before that fix shipped is permanently stuck on the old broken defaults (confirmed by the reporter's follow-up comment: https://github.com/Iranman/beets-web-manager/issues/14#issuecomment-5056096064, still showing `plexsync`/`discpath`/`mp3gain` failures from a raw `beet` CLI invocation after updating).

Adds `_repair_legacy_beets_config()`, run once at startup (same pattern as `_bootstrap_auth_token_if_missing`), which narrowly repairs exactly three known-legacy patterns in an existing `/config/config.yaml` and nothing else a user configured:

1. Drops the never-installed `plexsync` token from `plugins:`.
2. Adds `/app/beetsplug` to `pluginpath:` if missing (where the bundled `discpath` plugin now lives).
3. Switches an existing `replaygain:` section's backend to `ffmpeg` when it's still pointed at mp3gain (explicit or by omission) and mp3gain isn't actually available.

Backs up the original to `config.yaml.bak-legacy-plugin-migration` before the first repair (separate from the config editor's own `/api/config/revert` backup). Idempotent via a marker comment -- a no-op on every later startup, and a no-op entirely for a config that's already current.

Does **not** create a `replaygain:` section that isn't already present -- kept narrow (a repair, not a generator).

## Test plan
- [x] New `tests/test_legacy_beets_config_migration.py` (13 tests): plexsync removal, pluginpath upgrade from single-string/missing/incomplete-list, replaygain backend switch (with mp3gain-present guard), idempotency, backup creation, already-current no-op, missing-file no-crash, and the reporter's full scenario end-to-end.
- [x] `tests.test_beets_fresh_install_plugins`, `tests.test_beets_config` unaffected (20 tests total)
- [x] `python -m py_compile app.py`
- [x] `security_secret_scan.py`, `validate_compose_security.py` clean
- [x] Full `unittest discover` run