### PR TITLE
feat: enforce matching decisions for playlist suggestions

### DIFF
--- a/app.py
+++ b/app.py
@@ -47377,129 +47377,261 @@ def _playlist_apply_manifest_replacements(clean_name: str,
     }
 
 
-def _playlist_suggestion_key(artist: str, title: str, source: str) -> tuple:
-    return (_norm(artist), _norm(title), _s(source).strip().lower())
-
-
-def _playlist_add_suggestion(out: List[Dict[str, Any]],
-                             seen: set,
-                             *,
-                             artist: str,
-                             title: str,
-                             source: str,
-                             confidence: float,
-                             safe: bool,
-                             reason: str,
-                             extra: Optional[Dict[str, Any]] = None) -> None:
-    artist = _playlist_clean_video_text(artist)
-    title = _playlist_clean_video_text(title)
-    if not title:
-        return
-    key = _playlist_suggestion_key(artist, title, source)
-    if key in seen:
-        return
-    seen.add(key)
-    row = {
-        "artist": artist,
-        "title": title,
-        "source": source,
-        "confidence": round(max(0.0, min(1.0, float(confidence or 0))), 3),
-        "safe": bool(safe),
-        "reason": reason,
-    }
-    if extra:
-        row.update(extra)
-    out.append(row)
-
-
-def _playlist_suggestions_for_track(track: Dict[str, Any],
-                                    index: Dict[str, Any],
-                                    *,
-                                    include_musicbrainz: bool = True,
-                                    limit: int = 5) -> List[Dict[str, Any]]:
-    row = _playlist_track_manifest_payload(track)
-    artist = _s(row.get("artist") or "").strip()
-    title = _s(row.get("title") or "").strip()
-    suggestions: List[Dict[str, Any]] = []
-    seen: set = set()
-
-    match = _match_track(artist, title)
-    if match:
-        item, score = match
-        cand_artist = _s(getattr(item, "artist", "")).strip()
-        cand_title = _s(getattr(item, "title", "")).strip()
-        title_score = _playlist_title_score(title, cand_title)
-        artist_score = _playlist_artist_name_score(artist, cand_artist) if artist else 1.0
-        confidence = min(1.0, float(score or 0))
-        _playlist_add_suggestion(
-            suggestions,
-            seen,
-            artist=cand_artist,
-            title=cand_title,
-            source="beets",
-            confidence=confidence,
-            safe=confidence >= 0.94 and title_score >= 0.92 and artist_score >= 0.82,
-            reason=f"Beets library match ({round(confidence * 100)}%)",
-            extra={
-                "item_id": int(getattr(item, "id", 0) or 0),
-                "album": _s(getattr(item, "album", "")).strip(),
-                "title_score": round(title_score, 3),
-                "artist_score": round(artist_score, 3),
-            },
+def _run_playlist_track_restore(playlist_name: str, fields: Dict[str, Any], log: List[str], cancel_event=None) -> bool:
+    """Undo executor for apply-safe-suggestions: restores one playlist's
+    desired-track manifest entry to its pre-apply artist/title. This never
+    touches a Beets item's own tags -- only this playlist's own manifest --
+    so, unlike attach-recording's rollback, there is no beet subprocess
+    sequence here, only a manifest read/write/verify. Returns True only
+    when the previous identity is confirmed present in the manifest after
+    the restore; never claim a restore that didn't verify."""
+    previous = (fields or {}).get("previous") or {}
+    applied = (fields or {}).get("applied") or {}
+    prev_artist = _s(previous.get("artist") or "").strip()
+    prev_title = _s(previous.get("title") or "").strip()
+    if not prev_title:
+        log.append(f"  [playlist-rollback] Missing previous title for {playlist_name!r}; skipped.")
+        return False
+    clean_name = _clean_playlist_name(playlist_name)
+    try:
+        result = _playlist_apply_manifest_replacements(
+            clean_name,
+            [{"track": applied, "replacement": {"artist": prev_artist, "title": prev_title}}],
+            source_label="rollback",
         )
+    except Exception as ex:
+        log.append(f"  [playlist-rollback] Restore failed for {clean_name}: {_redact_security_text(str(ex))[:200]}")
+        return False
+    if not result.get("resolved_count"):
+        log.append(f"  [playlist-rollback] Could not locate the resolved track to restore in {clean_name}.")
+        return False
+    reread_tracks = _playlist_clean_track_list(_playlist_read_manifest(clean_name).get("desired_tracks") or [])
+    want_artist = _norm(prev_artist)
+    want_title = _norm(prev_title)
+    if not any(_norm(t.get("artist") or "") == want_artist and _norm(t.get("title") or "") == want_title
+               for t in reread_tracks):
+        log.append(f"  [playlist-rollback] Previous identity did not verify after restore in {clean_name}.")
+        return False
+    log.append(f"  [playlist-rollback] Restored previous desired-track identity in {clean_name}.")
+    return True
 
-    title_key = _norm(title)
-    if title_key:
-        for cand in (index.get("by_title") or {}).get(title_key, [])[:8]:
-            cand_artist = _s(cand.get("artist") or cand.get("albumartist") or "").strip()
-            cand_title = _s(cand.get("title") or "").strip()
-            artist_score = _playlist_artist_name_score(artist, cand_artist) if artist else _playlist_payload_rank(cand)
-            confidence = min(1.0, max(0.0, artist_score))
-            _playlist_add_suggestion(
-                suggestions,
-                seen,
-                artist=cand_artist,
-                title=cand_title,
-                source="beets-title",
-                confidence=confidence,
-                safe=confidence >= 0.9,
-                reason=f"Same title in Beets ({round(confidence * 100)}% artist)",
-                extra={
-                    "item_id": int(cand.get("id") or 0),
-                    "album": _s(cand.get("album") or "").strip(),
-                    "artist_score": round(artist_score, 3),
-                },
-            )
+
+PLAYLIST_APPLY_RESERVATIONS_LOCK = threading.Lock()
+_PLAYLIST_APPLY_RESERVED_NAMES: set = set()
+
+
+def _reserve_playlist_apply(clean_name: str) -> bool:
+    with PLAYLIST_APPLY_RESERVATIONS_LOCK:
+        if clean_name in _PLAYLIST_APPLY_RESERVED_NAMES:
+            return False
+        _PLAYLIST_APPLY_RESERVED_NAMES.add(clean_name)
+        return True
+
+
+def _release_playlist_apply(clean_name: str) -> None:
+    with PLAYLIST_APPLY_RESERVATIONS_LOCK:
+        _PLAYLIST_APPLY_RESERVED_NAMES.discard(clean_name)
+
+
+def _playlist_track_key(clean_name: str, artist: str, title: str, occurrence: int) -> str:
+    """Stable, opaque identity for one missing-track slot in a playlist.
+
+    Derived from the playlist's own stable id, the normalized artist/title,
+    and this row's occurrence index among other rows sharing that same
+    identity -- never raw list position, candidate display order, or a
+    timestamp -- so intentional duplicate entries of the same song each get
+    their own distinguishable, reproducible key across requests as long as
+    the missing set itself hasn't changed shape.
+    """
+    stable_id = _playlist_stable_id(clean_name)
+    raw = f"{stable_id}\x1f{_norm(artist)}\x1f{_norm(title)}\x1f{int(occurrence)}"
+    return "ptk_" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def _playlist_missing_rows_with_keys(clean_name: str,
+                                     missing_tracks: List[Dict[str, Any]]) -> List[Tuple[str, Dict[str, Any]]]:
+    occurrence_counts: Dict[tuple, int] = {}
+    out: List[Tuple[str, Dict[str, Any]]] = []
+    for track in missing_tracks or []:
+        artist = _s(track.get("artist") or "").strip()
+        title = _s(track.get("title") or "").strip()
+        ident = (_norm(artist), _norm(title))
+        occurrence = occurrence_counts.get(ident, 0)
+        occurrence_counts[ident] = occurrence + 1
+        out.append((_playlist_track_key(clean_name, artist, title, occurrence), track))
+    return out
+
+
+def _playlist_top_library_matches(artist: str, title: str,
+                                  limit: int = 3) -> List[Tuple[Dict[str, Any], float]]:
+    """Best-scoring distinct Beets items for artist/title, most confident first."""
+    candidates = _playlist_library_match_candidates()
+    rows = list((candidates.get("by_title") or {}).get(_norm(title), []) or [])
+    if not rows:
+        rows = list(candidates.get("all") or [])
+    best_by_item: Dict[int, Tuple[Dict[str, Any], float]] = {}
+    for row in rows:
+        score = _playlist_candidate_match_score(
+            artist, title, row.get("artist", ""), row.get("title", ""), row.get("quality") or {})
+        if score is None:
+            continue
+        payload = row.get("payload") or {}
+        item_id = int(payload.get("id") or 0)
+        if not item_id:
+            continue
+        prev = best_by_item.get(item_id)
+        if prev is None or score > prev[1]:
+            best_by_item[item_id] = (payload, score)
+    ranked = sorted(best_by_item.values(), key=lambda pair: pair[1], reverse=True)
+    return ranked[:max(1, limit)]
+
+
+def _playlist_raw_candidates_for_track(artist: str, title: str, *,
+                                       include_musicbrainz: bool,
+                                       limit: int) -> Tuple[List[Dict[str, Any]], bool]:
+    """Untrusted candidate inputs for build_recording_matching_decision().
+
+    Returns (candidates, ambiguous_tie). `ambiguous_tie` is True when two or
+    more distinct Beets library items score within 0.03 of each other for
+    this artist/title -- a genuine top-candidate tie must never be silently
+    resolved by picking whichever happens to sort first.
+    """
+    out: List[Dict[str, Any]] = []
+    seen_recording_ids: set = set()
+
+    top_matches = _playlist_top_library_matches(artist, title, limit=3)
+    ambiguous_tie = bool(
+        len(top_matches) >= 2 and (top_matches[0][1] - top_matches[1][1]) < 0.03
+    )
+
+    if top_matches:
+        payload, _score = top_matches[0]
+        item_path = _s(payload.get("path") or "").strip()
+        item_mbid = _s(payload.get("mb_trackid") or "").strip().lower()
+        fingerprint_attempted = False
+        fingerprint_matched = False
+        fingerprint_status = "not_attempted"
+        mapped_recording_id = ""
+        if item_path:
+            fingerprint_attempted = True
+            try:
+                mapped_ids = _acoustid_fingerprint_ids(item_path)
+            except Exception:
+                mapped_ids = []
+            if mapped_ids:
+                mapped_recording_id = mapped_ids[0]
+                fingerprint_matched = bool(item_mbid) and item_mbid in mapped_ids
+                fingerprint_status = "matched" if fingerprint_matched else ("mismatch" if item_mbid else "no_result")
+            else:
+                fingerprint_status = "no_result"
+        out.append({
+            "artist": _s(payload.get("artist") or "").strip(),
+            "title": _s(payload.get("title") or "").strip(),
+            "source": "beets",
+            "item_id": int(payload.get("id") or 0),
+            "mb_trackid": item_mbid,
+            "mb_albumid": _s(payload.get("mb_albumid") or ""),
+            "mb_releasegroupid": _s(payload.get("mb_releasegroupid") or ""),
+            "album": _s(payload.get("album") or ""),
+            "fingerprint_attempted": fingerprint_attempted,
+            "fingerprint_matched": fingerprint_matched,
+            "fingerprint_status": fingerprint_status,
+            "mapped_recording_id": mapped_recording_id,
+            "candidate_index": len(out),
+        })
+        if item_mbid:
+            seen_recording_ids.add(item_mbid)
 
     if include_musicbrainz:
-        for cand in _playlist_recording_search_candidates(title, artist)[:8]:
-            cand_artist = _playlist_primary_artist_name(cand.get("artist") or "")
-            cand_title = _s(cand.get("title") or "").strip()
-            mb_score = max(0.0, min(1.0, float(cand.get("score") or 0) / 100.0))
-            title_score = _playlist_title_score(title, cand_title)
-            artist_score = _playlist_artist_name_score(artist, cand_artist) if artist else 1.0
-            confidence = (mb_score * 0.45) + (title_score * 0.35) + (artist_score * 0.20)
-            _playlist_add_suggestion(
-                suggestions,
-                seen,
-                artist=cand_artist,
-                title=cand_title,
-                source="musicbrainz",
-                confidence=confidence,
-                safe=mb_score >= 0.95 and title_score >= 0.95 and artist_score >= 0.82,
-                reason=f"MusicBrainz recording ({round(confidence * 100)}%)",
-                extra={
-                    "mb_trackid": _s(cand.get("mb_trackid") or "").strip(),
-                    "mb_url": _s(cand.get("mb_url") or "").strip(),
-                    "album": _s(cand.get("album") or "").strip(),
-                    "year": _s(cand.get("year") or "").strip(),
-                    "title_score": round(title_score, 3),
-                    "artist_score": round(artist_score, 3),
-                },
-            )
+        for cand in _playlist_recording_search_candidates(title, artist)[:limit]:
+            mbid = _s(cand.get("mb_trackid") or "").strip().lower()
+            if not mbid or mbid in seen_recording_ids:
+                continue
+            seen_recording_ids.add(mbid)
+            out.append({
+                "artist": _playlist_primary_artist_name(cand.get("artist") or ""),
+                "title": _s(cand.get("title") or "").strip(),
+                "source": "musicbrainz",
+                "mb_trackid": mbid,
+                "album": _s(cand.get("album") or "").strip(),
+                "year": _s(cand.get("year") or "").strip(),
+                "fingerprint_attempted": False,
+                "fingerprint_matched": False,
+                "fingerprint_status": "not_attempted",
+                "mapped_recording_id": "",
+                "candidate_index": len(out),
+            })
 
-    suggestions.sort(key=lambda s: (not bool(s.get("safe")), -float(s.get("confidence") or 0), s.get("source", "")))
-    return suggestions[:max(1, min(int(limit or 5), 10))]
+    return out, ambiguous_tie
+
+
+def _playlist_decision_row(track_key: str, artist: str, title: str,
+                          candidate: Dict[str, Any], *,
+                          extra_conflicts: Tuple[str, ...] = ()) -> Dict[str, Any]:
+    current = {"title": title, "artist": artist}
+    library_identity_verified = candidate.get("source") == "beets"
+    matching_result = build_recording_matching_decision(
+        current=current,
+        candidate=candidate,
+        library_identity_verified=library_identity_verified,
+        extra_conflicts=extra_conflicts,
+    )
+    row = matching_result.to_review_recording_candidate()
+    row["decision_version"] = compute_decision_version(track_key, matching_result)
+    row["source"] = candidate.get("source")
+    if candidate.get("item_id"):
+        row["item_id"] = int(candidate["item_id"])
+    evidence = matching_result.evidence if isinstance(matching_result.evidence, dict) else {}
+    row["evidence"] = {
+        "acoustid": evidence.get("acoustid", {}),
+        "musicbrainz": evidence.get("musicbrainz", {}),
+        "library": {
+            "item_id": candidate.get("item_id"),
+            "verified": library_identity_verified and not extra_conflicts,
+        },
+    }
+    # Deprecated legacy fields (see _playlist_legacy_suggestion_fields):
+    # overwrites to_review_recording_candidate()'s tier-string "confidence"
+    # and match-explanation "reason" with the playlist-specific meanings
+    # documented on PlaylistSuggestionCandidate in the frontend types --
+    # this row is never shared with Import Review's own use of that helper.
+    row.update(_playlist_legacy_suggestion_fields(row))
+    return row
+
+
+def _playlist_decisions_for_track(clean_name: str, track_key: str, artist: str, title: str, *,
+                                  include_musicbrainz: bool = True,
+                                  limit: int = 5) -> List[Dict[str, Any]]:
+    raw_candidates, ambiguous_tie = _playlist_raw_candidates_for_track(
+        artist, title, include_musicbrainz=include_musicbrainz, limit=limit)
+    extra_conflicts = ("competing_candidates_tie",) if ambiguous_tie else ()
+    decisions = [
+        _playlist_decision_row(track_key, artist, title, cand, extra_conflicts=extra_conflicts)
+        for cand in raw_candidates
+    ]
+    decisions.sort(key=lambda d: (
+        not bool((d.get("decision") or {}).get("action_eligibility", {}).get("playlist_resolve_without_review")),
+        -float((d.get("decision") or {}).get("confidence_score") or 0),
+    ))
+    return decisions[:max(1, min(int(limit or 5), 10))]
+
+
+def _playlist_legacy_suggestion_fields(decision_row: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Deprecated top-level fields kept temporarily for frontend compatibility.
+
+    Derived only from the authoritative decision -- never assigned or
+    overridden independently -- so a stale client that still reads these
+    cannot see a safety signal the backend didn't compute.
+    """
+    if not decision_row:
+        return {"confidence": 0.0, "safe": False, "reason": ""}
+    decision = decision_row.get("decision") or {}
+    action_eligibility = decision.get("action_eligibility") or {}
+    return {
+        "confidence": round(float(decision.get("confidence_score") or 0), 3),
+        "safe": bool(action_eligibility.get("playlist_resolve_without_review")),
+        "reason": _s(decision.get("eligibility_reason") or ""),
+    }
 
 
 @app.post("/api/playlists/<path:name>/resolve-track")
@@ -47528,7 +47660,7 @@ def playlist_resolve_track(name):
 def playlist_suggestions(name):
     clean_name = _clean_playlist_name(_s(name))
     if not _playlist_saved_playlist_exists(clean_name):
-        return jsonify({"ok": False, "error": f"Playlist not found: {clean_name}"}), 404
+        return jsonify({"ok": False, "error": f"Playlist not found: {clean_name}", "code": "playlist_not_found"}), 404
     include_mb = request.args.get("musicbrainz", "1").strip().lower() not in {"0", "false", "no", "off"}
     try:
         limit = int(request.args.get("limit") or 5)
@@ -47536,23 +47668,27 @@ def playlist_suggestions(name):
         limit = 5
     index = _playlist_library_index()
     detail = _playlist_detail_payload(clean_name, index)
+    missing = detail.get("missing") or []
     rows = []
     safe_count = 0
-    for track in detail.get("missing") or []:
-        suggestions = _playlist_suggestions_for_track(
-            track, index, include_musicbrainz=include_mb, limit=limit)
-        best = suggestions[0] if suggestions else None
-        if best and best.get("safe"):
+    for track_key, track in _playlist_missing_rows_with_keys(clean_name, missing):
+        artist = _s(track.get("artist") or "").strip()
+        title = _s(track.get("title") or "").strip()
+        candidates = _playlist_decisions_for_track(
+            clean_name, track_key, artist, title, include_musicbrainz=include_mb, limit=limit)
+        best = candidates[0] if candidates else None
+        if best and bool((best.get("decision") or {}).get("action_eligibility", {}).get("playlist_resolve_without_review")):
             safe_count += 1
         rows.append({
             "track": track,
-            "suggestions": suggestions,
+            "track_key": track_key,
+            "suggestions": candidates,
             "best": best,
         })
     return jsonify({
         "ok": True,
         "name": clean_name,
-        "total_missing": len(detail.get("missing") or []),
+        "total_missing": len(missing),
         "safe_count": safe_count,
         "rows": rows,
     })
@@ -47562,37 +47698,247 @@ def playlist_suggestions(name):
 def playlist_apply_safe_suggestions(name):
     clean_name = _clean_playlist_name(_s(name))
     if not _playlist_saved_playlist_exists(clean_name):
-        return jsonify({"ok": False, "error": f"Playlist not found: {clean_name}"}), 404
+        return jsonify({"ok": False, "error": f"Playlist not found: {clean_name}", "code": "playlist_not_found"}), 404
+
     payload = request.get_json(silent=True) or {}
-    include_mb = bool(payload.get("musicbrainz", True))
-    index = _playlist_library_index()
-    detail = _playlist_detail_payload(clean_name, index)
-    replacements: List[Dict[str, Any]] = []
-    suggestion_rows = []
-    for track in detail.get("missing") or []:
-        suggestions = _playlist_suggestions_for_track(
-            track, index, include_musicbrainz=include_mb, limit=5)
-        best = suggestions[0] if suggestions else None
-        suggestion_rows.append({"track": track, "best": best})
-        if best and best.get("safe"):
-            replacements.append({
-                "track": track,
-                "replacement": {
-                    "artist": best.get("artist") or "",
-                    "title": best.get("title") or "",
-                },
+    submitted = payload.get("suggestions")
+    submitted = submitted if isinstance(submitted, list) else []
+
+    if not _reserve_playlist_apply(clean_name):
+        return jsonify({
+            "ok": False,
+            "error": "A suggestion application is already running for this playlist.",
+            "code": "playlist_update_in_progress",
+        }), 409
+
+    try:
+        index = _playlist_library_index()
+        detail = _playlist_detail_payload(clean_name, index)
+        missing = detail.get("missing") or []
+        by_key = dict(_playlist_missing_rows_with_keys(clean_name, missing))
+
+        applied: List[Dict[str, Any]] = []
+        unchanged: List[Dict[str, Any]] = []
+        skipped_review: List[Dict[str, Any]] = []
+        conflict_rows: List[Dict[str, Any]] = []
+        stale_rows: List[Dict[str, Any]] = []
+        replacements: List[Dict[str, Any]] = []
+        change_entries: List[Dict[str, Any]] = []
+
+        for entry in submitted:
+            if not isinstance(entry, dict):
+                continue
+            track_key = _s(entry.get("track_key") or "").strip()
+            submitted_mbid = _s(entry.get("mb_trackid") or "").strip().lower()
+            try:
+                submitted_item_id = int(entry.get("item_id") or 0)
+            except Exception:
+                submitted_item_id = 0
+            submitted_version = _s(entry.get("decision_version") or "").strip()
+
+            track = by_key.get(track_key)
+            if track is None:
+                stale_rows.append({
+                    "track_key": track_key,
+                    "code": "playlist_track_not_found",
+                    "error": "This track is no longer in the current missing-track set; refresh suggestions.",
+                })
+                continue
+
+            artist = _s(track.get("artist") or "").strip()
+            title = _s(track.get("title") or "").strip()
+            candidates = _playlist_decisions_for_track(
+                clean_name, track_key, artist, title, include_musicbrainz=True, limit=5)
+
+            candidate = None
+            for cand in candidates:
+                cand_mbid = _s(cand.get("mb_trackid") or "").strip().lower()
+                cand_item_id = int(cand.get("item_id") or 0)
+                if submitted_mbid and cand_mbid and cand_mbid == submitted_mbid:
+                    candidate = cand
+                    break
+                if not submitted_mbid and submitted_item_id and cand_item_id == submitted_item_id:
+                    candidate = cand
+                    break
+            if candidate is None:
+                conflict_rows.append({
+                    "track_key": track_key,
+                    "code": "candidate_not_in_trusted_set",
+                    "error": "This candidate is not part of the current trusted candidate set.",
+                })
+                continue
+
+            computed_version = _s(candidate.get("decision_version") or "")
+            if submitted_version and submitted_version != computed_version:
+                stale_rows.append({
+                    "track_key": track_key,
+                    "code": "playlist_suggestions_stale",
+                    "error": "The matching decision has changed since it was displayed; refresh suggestions.",
+                    "candidate": candidate,
+                })
+                continue
+
+            decision = candidate.get("decision") or {}
+            action_eligibility = decision.get("action_eligibility") or {}
+            if decision.get("review_required") or not action_eligibility.get("playlist_resolve_without_review"):
+                skipped_review.append({
+                    "track_key": track_key,
+                    "code": "playlist_review_required",
+                    "reason": _s(decision.get("eligibility_reason") or ""),
+                    "candidate": candidate,
+                })
+                continue
+            if decision.get("conflicts"):
+                conflict_rows.append({
+                    "track_key": track_key,
+                    "code": "playlist_conflict",
+                    "conflicts": list(decision.get("conflicts") or []),
+                    "candidate": candidate,
+                })
+                continue
+
+            resolved_artist = _s(candidate.get("artist") or "").strip()
+            resolved_title = _s(candidate.get("title") or "").strip()
+            if not resolved_title:
+                conflict_rows.append({
+                    "track_key": track_key,
+                    "code": "playlist_candidate_required",
+                    "error": "Candidate has no title.",
+                })
+                continue
+
+            if _norm(artist) == _norm(resolved_artist) and _norm(title) == _norm(resolved_title):
+                unchanged.append({"track_key": track_key, "ok": True, "changed": False, "reason": "already_resolved"})
+                continue
+
+            current_metadata = {
+                "artist": artist, "title": title,
+                "mb_trackid": "", "mb_releasegroupid": "",
+            }
+            candidate_identity = {
+                "artist": resolved_artist, "title": resolved_title,
+                "mb_trackid": _s(candidate.get("mb_trackid") or ""),
+                "mb_releasegroupid": _s(candidate.get("mb_releasegroupid") or ""),
+                "item_id": candidate.get("item_id"),
+            }
+            replacements.append({"track": track, "replacement": {"artist": resolved_artist, "title": resolved_title}})
+            change_entries.append({
+                "track_key": track_key,
+                "current_metadata": current_metadata,
+                "candidate_identity": candidate_identity,
+                "decision_version": computed_version,
+                "confidence": {"overall": decision.get("confidence_score")},
+                "reason": _s(decision.get("eligibility_reason") or ""),
+                "warnings": list(decision.get("warnings") or []),
+                "source": candidate.get("source"),
             })
-    result = _playlist_apply_manifest_replacements(
-        clean_name,
-        replacements,
-        index=index,
-        source_label="suggestion",
-    ) if replacements else _playlist_detail_payload(clean_name, index)
-    return jsonify({
-        **result,
-        "suggested": suggestion_rows,
-        "safe_count": len(replacements),
-    })
+
+        audit_id = None
+        if change_entries:
+            tx = transactions.create(
+                operation_type="Playlist Match",
+                initiating_user=_transaction_user_label(),
+                status="Running",
+                dry_run=False,
+                summary=f"Apply {len(change_entries)} safe playlist suggestion(s) for {clean_name}",
+                reason="Backend-verified safe playlist suggestion application",
+                source="Playlist suggestions apply-safe-suggestions",
+                confidence={"overall": None},
+                changes=[{
+                    "id": entry["track_key"],
+                    "operation": "Playlist Match",
+                    "track": entry["candidate_identity"]["title"],
+                    "artist": entry["candidate_identity"]["artist"],
+                    "current_metadata": entry["current_metadata"],
+                    "new_metadata": entry["candidate_identity"],
+                    "metadata_diff": metadata_diff(entry["current_metadata"], entry["candidate_identity"]),
+                    "candidate_identity": entry["candidate_identity"],
+                    "persisted_identity": {},
+                    "decision_version": entry["decision_version"],
+                    "confidence": entry["confidence"],
+                    "reason": entry["reason"],
+                    "warnings": entry["warnings"],
+                } for entry in change_entries],
+                rollback_available=True,
+                rollback_reason="Restores the previous desired-track artist/title for each resolved row.",
+                metadata={"playlist": clean_name, "rows": len(change_entries)},
+            )
+            audit_id = tx["id"]
+            transactions.update(audit_id, rollback={
+                "available": True,
+                "reason": "Restores the previous desired-track artist/title for each resolved row.",
+                "operations": [{
+                    "type": "playlist_track_restore",
+                    "playlist": clean_name,
+                    "track_key": entry["track_key"],
+                    "fields": {
+                        "previous": entry["current_metadata"],
+                        "applied": {
+                            "artist": entry["candidate_identity"]["artist"],
+                            "title": entry["candidate_identity"]["title"],
+                        },
+                    },
+                    "reason": "Restore desired-track identity captured before suggestion apply.",
+                } for entry in change_entries],
+            }, counts={"items": len(change_entries), "changes": len(change_entries)})
+
+            _playlist_apply_manifest_replacements(
+                clean_name, replacements, index=index, source_label="suggestion")
+
+            # Truthfulness: re-read the manifest after writing and verify
+            # every intended row actually landed before claiming success --
+            # never mark Completed on the strength of the in-memory return
+            # value from _playlist_apply_manifest_replacements alone.
+            reread_tracks = _playlist_clean_track_list(
+                _playlist_read_manifest(clean_name).get("desired_tracks") or [])
+            verified_keys = set()
+            for entry in change_entries:
+                want_artist = _norm(entry["candidate_identity"]["artist"])
+                want_title = _norm(entry["candidate_identity"]["title"])
+                if any(_norm(t.get("artist") or "") == want_artist and _norm(t.get("title") or "") == want_title
+                       for t in reread_tracks):
+                    verified_keys.add(entry["track_key"])
+                    applied.append({
+                        "track_key": entry["track_key"],
+                        "artist": entry["candidate_identity"]["artist"],
+                        "title": entry["candidate_identity"]["title"],
+                    })
+
+            if len(verified_keys) == len(change_entries):
+                transactions.update(audit_id, status="Completed")
+            else:
+                transactions.update(audit_id, status="Failed")
+                transactions.append_log(
+                    audit_id, "ERROR: one or more resolved rows did not verify after the manifest write.")
+                for entry in change_entries:
+                    if entry["track_key"] not in verified_keys:
+                        conflict_rows.append({
+                            "track_key": entry["track_key"],
+                            "code": "playlist_persistence_failed",
+                            "error": "Resolved identity did not verify after persistence.",
+                        })
+
+        if not applied and not unchanged and not skipped_review and not conflict_rows and stale_rows:
+            return jsonify({
+                "ok": False,
+                "error": "The missing-track set has changed since suggestions were displayed; refresh suggestions.",
+                "code": "playlist_suggestions_stale",
+                "stale": stale_rows,
+            }), 409
+
+        return jsonify({
+            "ok": True,
+            "name": clean_name,
+            "changed": bool(applied),
+            "applied": applied,
+            "unchanged": unchanged,
+            "skipped_review": skipped_review,
+            "conflicts": conflict_rows,
+            "stale": stale_rows,
+            "audit_id": audit_id,
+        })
+    finally:
+        _release_playlist_apply(clean_name)
 
 
 @app.get("/api/playlists/<path:name>/tracks")
@@ -49246,10 +49592,8 @@ def api_transaction_rollback(transaction_id):
             "rollback_available": False,
         }), 409
 
-    unsupported = [
-        op for op in operations
-        if op.get("type") != "metadata_restore" and op.get("type") != "recording_id_restore"
-    ]
+    _ROLLBACK_OP_TYPES = {"metadata_restore", "recording_id_restore", "playlist_track_restore"}
+    unsupported = [op for op in operations if op.get("type") not in _ROLLBACK_OP_TYPES]
     if unsupported:
         return jsonify({
             "ok": False,
@@ -49267,12 +49611,25 @@ def api_transaction_rollback(transaction_id):
                     log.append("  [rollback] Cancel requested.")
                     break
                 fields = op.get("fields") or {}
+                op_type = op.get("type")
+                if op_type == "playlist_track_restore":
+                    playlist_name = _s(op.get("playlist") or "").strip()
+                    if not playlist_name:
+                        failed_count += 1
+                        log.append("  [rollback] Missing playlist name; skipped operation.")
+                        continue
+                    restored = _run_playlist_track_restore(playlist_name, fields, log, cancel_event=cancel_event)
+                    if restored:
+                        ok_count += 1
+                    else:
+                        failed_count += 1
+                    continue
                 item_id = int(op.get("item_id") or 0)
                 if not item_id:
                     failed_count += 1
                     log.append("  [rollback] Missing item id; skipped operation.")
                     continue
-                if op.get("type") == "recording_id_restore":
+                if op_type == "recording_id_restore":
                     restored = _run_item_recording_id_restore(item_id, fields, log, cancel_event=cancel_event)
                 else:
                     restored = _run_item_metadata_restore(item_id, fields, log, cancel_event=cancel_event)

--- a/app.py
+++ b/app.py
@@ -41325,6 +41325,9 @@ def _playlist_track_manifest_payload(track: Dict[str, Any]) -> Dict[str, Any]:
         "artist": artist,
         "title": title,
     }
+    row_id = _s(track.get("row_id") or "").strip()
+    if row_id:
+        row["row_id"] = row_id
     if canonicalized:
         row["source_artist"] = source_artist
         row["source_title"] = source_title or title
@@ -41411,15 +41414,48 @@ def _playlist_apply_tombstones(name: str,
 
 
 def _playlist_merge_desired_tracks(*groups: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Dedup + mint/preserve each desired-track row's stable `row_id`.
+
+    A track that already carries a `row_id` (read back from a previously
+    persisted manifest) is only deduplicated against another literal copy
+    of that *same* id -- never merged with a different row sharing the
+    same artist/title -- so intentionally duplicated songs in a playlist
+    (e.g. the same track appearing twice in a source M3U) stay independent
+    rows across suggestion display, apply, and rollback.
+
+    A track with no `row_id` yet (fresh from m3u/external input) is
+    assigned one the first time it's merged -- self-healing migration for
+    manifests written before row ids existed. Identity-based dedup for
+    these fresh tracks only ever looks at *earlier* groups, never at
+    siblings within the same group: two same-identity fresh tracks passed
+    together (the normal shape of an M3U's own duplicate entries) are both
+    kept as distinct rows, while a later group's entry (e.g. an externally
+    "added" track) that duplicates something already accepted from an
+    earlier group is dropped, matching this function's original intent of
+    not re-adding what's already present.
+    """
     merged: List[Dict[str, Any]] = []
-    seen = set()
+    seen_ids: set = set()
+    seen_identity_prior_groups: set = set()
     for group in groups:
+        seen_identity_this_group: set = set()
         for track in _playlist_clean_track_list(group or []):
-            key = _playlist_manifest_identity(track)
-            if key in seen:
-                continue
-            seen.add(key)
+            row_id = _s(track.get("row_id") or "").strip()
+            identity = _playlist_manifest_identity(track)
+            if row_id:
+                if row_id in seen_ids:
+                    continue
+                seen_ids.add(row_id)
+            else:
+                if identity in seen_identity_prior_groups:
+                    continue
+                track = dict(track)
+                row_id = f"ptr_{uuid.uuid4().hex[:20]}"
+                track["row_id"] = row_id
+                seen_ids.add(row_id)
+            seen_identity_this_group.add(identity)
             merged.append(track)
+        seen_identity_prior_groups |= seen_identity_this_group
     return merged
 
 
@@ -46309,7 +46345,7 @@ def _playlist_match_reference_track(track: Dict[str, Any],
     }
     if path:
         payload["path"] = path
-    for key in ("source_artist", "source_title", "canonicalized", "canonical_source"):
+    for key in ("row_id", "source_artist", "source_title", "canonicalized", "canonical_source"):
         if key in track:
             payload[key] = track.get(key)
     if verify_acoustid and item:
@@ -47377,42 +47413,96 @@ def _playlist_apply_manifest_replacements(clean_name: str,
     }
 
 
+def _playlist_replace_rows_by_id(clean_name: str,
+                                 resolutions: List[Dict[str, Any]],
+                                 *, index: Optional[Dict[str, Any]] = None) -> Dict[str, set]:
+    """Exact-row replacement for apply-safe-suggestions and its rollback.
+
+    Locates each row by its stable manifest `row_id` -- never by fuzzy
+    artist/title matching, and never "any row with this text" -- and
+    writes the whole batch in a single manifest update. Returns exactly
+    which row_ids were found and replaced so the caller can verify each
+    intended change precisely, rather than merely "some row changed."
+    """
+    index = index or _playlist_library_index()
+    desired_tracks, desired_source = _playlist_desired_or_m3u_tracks(clean_name, index)
+    manifest = _playlist_read_manifest(clean_name)
+    next_tracks = list(desired_tracks)
+    by_id = {t.get("row_id"): idx for idx, t in enumerate(next_tracks) if t.get("row_id")}
+    resolved_ids: set = set()
+    not_found_ids: set = set()
+    for res in resolutions:
+        row_id = _s(res.get("row_id") or "").strip()
+        idx = by_id.get(row_id)
+        if idx is None:
+            not_found_ids.add(row_id)
+            continue
+        original = next_tracks[idx]
+        updated = dict(original)
+        updated["artist"] = _s(res.get("artist") or "")
+        updated["title"] = _s(res.get("title") or "")
+        updated["canonicalized"] = True
+        updated["canonical_source"] = _s(res.get("canonical_source") or "suggestion")
+        next_tracks[idx] = updated
+        resolved_ids.add(row_id)
+    if resolved_ids:
+        next_tracks = _playlist_merge_desired_tracks(next_tracks)
+        _playlist_write_manifest(
+            clean_name, next_tracks,
+            source=f"{desired_source}:suggestion",
+            content=_s(manifest.get("content") or ""),
+        )
+    return {"resolved_ids": resolved_ids, "not_found_ids": not_found_ids}
+
+
 def _run_playlist_track_restore(playlist_name: str, fields: Dict[str, Any], log: List[str], cancel_event=None) -> bool:
     """Undo executor for apply-safe-suggestions: restores one playlist's
-    desired-track manifest entry to its pre-apply artist/title. This never
+    desired-track manifest row -- located by its exact stable `row_id`,
+    never by artist/title text -- to its pre-apply identity. This never
     touches a Beets item's own tags -- only this playlist's own manifest --
     so, unlike attach-recording's rollback, there is no beet subprocess
     sequence here, only a manifest read/write/verify. Returns True only
-    when the previous identity is confirmed present in the manifest after
-    the restore; never claim a restore that didn't verify."""
+    when the exact row is confirmed restored after the write; a row that
+    no longer exists, no longer matches the recorded applied state, or
+    doesn't verify after the write is never reported as a successful
+    restore."""
     previous = (fields or {}).get("previous") or {}
     applied = (fields or {}).get("applied") or {}
+    row_id = _s((fields or {}).get("row_id") or "").strip()
     prev_artist = _s(previous.get("artist") or "").strip()
     prev_title = _s(previous.get("title") or "").strip()
-    if not prev_title:
-        log.append(f"  [playlist-rollback] Missing previous title for {playlist_name!r}; skipped.")
+    if not row_id or not prev_title:
+        log.append(f"  [playlist-rollback] playlist_rollback_row_missing: missing row_id/previous title for {playlist_name!r}.")
         return False
     clean_name = _clean_playlist_name(playlist_name)
+    manifest = _playlist_read_manifest(clean_name)
+    tracks = _playlist_clean_track_list(manifest.get("desired_tracks") or [])
+    current = next((t for t in tracks if t.get("row_id") == row_id), None)
+    if current is None:
+        log.append(f"  [playlist-rollback] playlist_rollback_row_missing: row {row_id} no longer exists in {clean_name}.")
+        return False
+    applied_artist = _norm(applied.get("artist") or "")
+    applied_title = _norm(applied.get("title") or "")
+    if _norm(current.get("artist") or "") != applied_artist or _norm(current.get("title") or "") != applied_title:
+        log.append(f"  [playlist-rollback] playlist_rollback_state_changed: row {row_id} in {clean_name} no longer matches the applied state; refusing to overwrite blindly.")
+        return False
     try:
-        result = _playlist_apply_manifest_replacements(
-            clean_name,
-            [{"track": applied, "replacement": {"artist": prev_artist, "title": prev_title}}],
-            source_label="rollback",
-        )
+        result = _playlist_replace_rows_by_id(
+            clean_name, [{"row_id": row_id, "artist": prev_artist, "title": prev_title, "canonical_source": "rollback"}])
     except Exception as ex:
-        log.append(f"  [playlist-rollback] Restore failed for {clean_name}: {_redact_security_text(str(ex))[:200]}")
+        log.append(f"  [playlist-rollback] playlist_rollback_persistence_failed: {_redact_security_text(str(ex))[:200]}")
         return False
-    if not result.get("resolved_count"):
-        log.append(f"  [playlist-rollback] Could not locate the resolved track to restore in {clean_name}.")
+    if row_id not in result.get("resolved_ids", set()):
+        log.append(f"  [playlist-rollback] playlist_rollback_row_missing: row {row_id} could not be located for restore in {clean_name}.")
         return False
-    reread_tracks = _playlist_clean_track_list(_playlist_read_manifest(clean_name).get("desired_tracks") or [])
-    want_artist = _norm(prev_artist)
-    want_title = _norm(prev_title)
-    if not any(_norm(t.get("artist") or "") == want_artist and _norm(t.get("title") or "") == want_title
-               for t in reread_tracks):
-        log.append(f"  [playlist-rollback] Previous identity did not verify after restore in {clean_name}.")
+    reread = _playlist_clean_track_list(_playlist_read_manifest(clean_name).get("desired_tracks") or [])
+    restored_row = next((t for t in reread if t.get("row_id") == row_id), None)
+    if (restored_row is None
+            or _norm(restored_row.get("artist") or "") != _norm(prev_artist)
+            or _norm(restored_row.get("title") or "") != _norm(prev_title)):
+        log.append(f"  [playlist-rollback] playlist_rollback_persistence_failed: row {row_id} did not verify after restore in {clean_name}.")
         return False
-    log.append(f"  [playlist-rollback] Restored previous desired-track identity in {clean_name}.")
+    log.append(f"  [playlist-rollback] Restored previous desired-track identity for row {row_id} in {clean_name}.")
     return True
 
 
@@ -47433,32 +47523,22 @@ def _release_playlist_apply(clean_name: str) -> None:
         _PLAYLIST_APPLY_RESERVED_NAMES.discard(clean_name)
 
 
-def _playlist_track_key(clean_name: str, artist: str, title: str, occurrence: int) -> str:
-    """Stable, opaque identity for one missing-track slot in a playlist.
-
-    Derived from the playlist's own stable id, the normalized artist/title,
-    and this row's occurrence index among other rows sharing that same
-    identity -- never raw list position, candidate display order, or a
-    timestamp -- so intentional duplicate entries of the same song each get
-    their own distinguishable, reproducible key across requests as long as
-    the missing set itself hasn't changed shape.
-    """
-    stable_id = _playlist_stable_id(clean_name)
-    raw = f"{stable_id}\x1f{_norm(artist)}\x1f{_norm(title)}\x1f{int(occurrence)}"
-    return "ptk_" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
-
-
 def _playlist_missing_rows_with_keys(clean_name: str,
                                      missing_tracks: List[Dict[str, Any]]) -> List[Tuple[str, Dict[str, Any]]]:
-    occurrence_counts: Dict[tuple, int] = {}
+    """Pairs each missing-track row with its stable manifest `row_id`,
+    used directly as the public `track_key` -- no occurrence counting or
+    re-hashing needed, since `row_id` is already a unique, stable,
+    per-row identity assigned once by _playlist_merge_desired_tracks and
+    persisted from then on (including across duplicate songs, which get
+    independent ids). A row that somehow still lacks a row_id (should not
+    happen once the manifest has been through a merge/write) is skipped
+    rather than given an unstable ad hoc key.
+    """
     out: List[Tuple[str, Dict[str, Any]]] = []
     for track in missing_tracks or []:
-        artist = _s(track.get("artist") or "").strip()
-        title = _s(track.get("title") or "").strip()
-        ident = (_norm(artist), _norm(title))
-        occurrence = occurrence_counts.get(ident, 0)
-        occurrence_counts[ident] = occurrence + 1
-        out.append((_playlist_track_key(clean_name, artist, title, occurrence), track))
+        row_id = _s(track.get("row_id") or "").strip()
+        if row_id:
+            out.append((row_id, track))
     return out
 
 
@@ -47486,6 +47566,42 @@ def _playlist_top_library_matches(artist: str, title: str,
     return ranked[:max(1, limit)]
 
 
+def _playlist_acoustid_evidence(item_path: str, item_mbid: str) -> Dict[str, Any]:
+    """Truthful, non-contradictory AcoustID fingerprint evidence for one
+    Beets library candidate.
+
+    States:
+      not_attempted     -- no usable local/staged audio file.
+      lookup_failed     -- fpcalc/network exception; never silently
+                           downgraded to "no evidence" (masks a real tool
+                           failure as an absence of a match).
+      no_match          -- lookup succeeded, AcoustID returned no candidate
+                           recording ids at all.
+      matched           -- a returned id equals the item's own Recording ID.
+      conflict          -- returned ids exist and disagree with the item's
+                           Recording ID; blocks automatic resolution.
+      mapped_unverified -- returned ids exist but the item has no Recording
+                           ID to compare against -- neither positive nor
+                           negative evidence.
+    `mapped_recording_id` is only ever populated from a real lookup result,
+    never fabricated, and is left empty for not_attempted/lookup_failed/
+    no_match so a caller can't mistake "no evidence" for a real mapping.
+    """
+    if not item_path:
+        return {"attempted": False, "matched": False, "status": "not_attempted", "mapped_recording_id": ""}
+    try:
+        mapped_ids = _acoustid_fingerprint_ids(item_path)
+    except Exception:
+        return {"attempted": True, "matched": False, "status": "lookup_failed", "mapped_recording_id": ""}
+    if not mapped_ids:
+        return {"attempted": True, "matched": False, "status": "no_match", "mapped_recording_id": ""}
+    if item_mbid and item_mbid in mapped_ids:
+        return {"attempted": True, "matched": True, "status": "matched", "mapped_recording_id": item_mbid}
+    if item_mbid:
+        return {"attempted": True, "matched": False, "status": "conflict", "mapped_recording_id": mapped_ids[0]}
+    return {"attempted": True, "matched": False, "status": "mapped_unverified", "mapped_recording_id": mapped_ids[0]}
+
+
 def _playlist_raw_candidates_for_track(artist: str, title: str, *,
                                        include_musicbrainz: bool,
                                        limit: int) -> Tuple[List[Dict[str, Any]], bool]:
@@ -47494,7 +47610,11 @@ def _playlist_raw_candidates_for_track(artist: str, title: str, *,
     Returns (candidates, ambiguous_tie). `ambiguous_tie` is True when two or
     more distinct Beets library items score within 0.03 of each other for
     this artist/title -- a genuine top-candidate tie must never be silently
-    resolved by picking whichever happens to sort first.
+    resolved by picking whichever happens to sort first. `_playlist_top_
+    library_matches` already dedupes candidates by item id even though a
+    single item can surface under several path/filename-derived text
+    variants, so those variants can never independently inflate ranking or
+    manufacture a tie on their own.
     """
     out: List[Dict[str, Any]] = []
     seen_recording_ids: set = set()
@@ -47506,41 +47626,39 @@ def _playlist_raw_candidates_for_track(artist: str, title: str, *,
 
     if top_matches:
         payload, _score = top_matches[0]
-        item_path = _s(payload.get("path") or "").strip()
-        item_mbid = _s(payload.get("mb_trackid") or "").strip().lower()
-        fingerprint_attempted = False
-        fingerprint_matched = False
-        fingerprint_status = "not_attempted"
-        mapped_recording_id = ""
-        if item_path:
-            fingerprint_attempted = True
-            try:
-                mapped_ids = _acoustid_fingerprint_ids(item_path)
-            except Exception:
-                mapped_ids = []
-            if mapped_ids:
-                mapped_recording_id = mapped_ids[0]
-                fingerprint_matched = bool(item_mbid) and item_mbid in mapped_ids
-                fingerprint_status = "matched" if fingerprint_matched else ("mismatch" if item_mbid else "no_result")
-            else:
-                fingerprint_status = "no_result"
-        out.append({
-            "artist": _s(payload.get("artist") or "").strip(),
-            "title": _s(payload.get("title") or "").strip(),
-            "source": "beets",
-            "item_id": int(payload.get("id") or 0),
-            "mb_trackid": item_mbid,
-            "mb_albumid": _s(payload.get("mb_albumid") or ""),
-            "mb_releasegroupid": _s(payload.get("mb_releasegroupid") or ""),
-            "album": _s(payload.get("album") or ""),
-            "fingerprint_attempted": fingerprint_attempted,
-            "fingerprint_matched": fingerprint_matched,
-            "fingerprint_status": fingerprint_status,
-            "mapped_recording_id": mapped_recording_id,
-            "candidate_index": len(out),
-        })
-        if item_mbid:
-            seen_recording_ids.add(item_mbid)
+        item_id = int(payload.get("id") or 0)
+        # Re-read the exact item by id rather than trusting the (possibly
+        # stale-cached) index payload -- library-identity verification
+        # must reflect the item's *current* existence and tags, not a
+        # snapshot from whenever the index was last built.
+        live_item = lib.get_item(item_id) if item_id else None
+        if live_item is not None:
+            live_artist = _s(getattr(live_item, "artist", "") or "").strip()
+            live_title = _s(getattr(live_item, "title", "") or "").strip()
+            live_mbid = _s(getattr(live_item, "mb_trackid", "") or "").strip().lower()
+            live_path = _s(getattr(live_item, "path", "") or "").strip()
+            acoustid = _playlist_acoustid_evidence(live_path, live_mbid)
+            out.append({
+                "artist": live_artist,
+                "title": live_title,
+                "source": "beets",
+                "item_id": item_id,
+                "mb_trackid": live_mbid,
+                "mb_albumid": _s(getattr(live_item, "mb_albumid", "") or ""),
+                "mb_releasegroupid": _s(getattr(live_item, "mb_releasegroupid", "") or ""),
+                "album": _s(getattr(live_item, "album", "") or ""),
+                "fingerprint_attempted": acoustid["attempted"],
+                "fingerprint_matched": acoustid["matched"],
+                "fingerprint_status": acoustid["status"],
+                "mapped_recording_id": acoustid["mapped_recording_id"],
+                "verified_existing_library_item": True,
+                "candidate_index": len(out),
+            })
+            if live_mbid:
+                seen_recording_ids.add(live_mbid)
+        # else: the indexed item no longer exists (deleted/moved since the
+        # index was built) -- drop it rather than offering a stale/deleted
+        # item as a "safe" suggestion.
 
     if include_musicbrainz:
         for cand in _playlist_recording_search_candidates(title, artist)[:limit]:
@@ -47569,7 +47687,10 @@ def _playlist_decision_row(track_key: str, artist: str, title: str,
                           candidate: Dict[str, Any], *,
                           extra_conflicts: Tuple[str, ...] = ()) -> Dict[str, Any]:
     current = {"title": title, "artist": artist}
-    library_identity_verified = candidate.get("source") == "beets"
+    # Only ever True when _playlist_raw_candidates_for_track freshly
+    # re-read this exact item by id and confirmed it still exists -- never
+    # inferred merely from candidate["source"] == "beets".
+    library_identity_verified = bool(candidate.get("verified_existing_library_item"))
     matching_result = build_recording_matching_decision(
         current=current,
         candidate=candidate,
@@ -47694,8 +47815,20 @@ def playlist_suggestions(name):
     })
 
 
+def _playlist_submission_signature(entry: Dict[str, Any]) -> tuple:
+    return (
+        _s(entry.get("mb_trackid") or "").strip().lower(),
+        _s(entry.get("item_id") if entry.get("item_id") is not None else ""),
+        _s(entry.get("decision_version") or "").strip(),
+    )
+
+
 @app.post("/api/playlists/<path:name>/apply-safe-suggestions")
 def playlist_apply_safe_suggestions(name):
+    # Atomic batch: validated structurally, then against freshly rebuilt
+    # candidates/decisions, before anything is written. Any malformed,
+    # stale, untrusted, review-required, or conflicted row rejects the
+    # *entire* batch with zero mutation.
     clean_name = _clean_playlist_name(_s(name))
     if not _playlist_saved_playlist_exists(clean_name):
         return jsonify({"ok": False, "error": f"Playlist not found: {clean_name}", "code": "playlist_not_found"}), 404
@@ -47712,23 +47845,77 @@ def playlist_apply_safe_suggestions(name):
         }), 409
 
     try:
-        index = _playlist_library_index()
-        detail = _playlist_detail_payload(clean_name, index)
-        missing = detail.get("missing") or []
-        by_key = dict(_playlist_missing_rows_with_keys(clean_name, missing))
-
-        applied: List[Dict[str, Any]] = []
-        unchanged: List[Dict[str, Any]] = []
-        skipped_review: List[Dict[str, Any]] = []
+        # ---- Phase 1: structural validation + duplicate submissions ----
+        invalid: List[Dict[str, Any]] = []
         conflict_rows: List[Dict[str, Any]] = []
-        stale_rows: List[Dict[str, Any]] = []
-        replacements: List[Dict[str, Any]] = []
-        change_entries: List[Dict[str, Any]] = []
-
+        by_track_key: Dict[str, List[Dict[str, Any]]] = {}
+        order: List[str] = []
         for entry in submitted:
             if not isinstance(entry, dict):
+                invalid.append({
+                    "track_key": "", "code": "playlist_candidate_required",
+                    "error": "Each submitted suggestion must be an object.",
+                })
                 continue
             track_key = _s(entry.get("track_key") or "").strip()
+            if not track_key:
+                invalid.append({
+                    "track_key": "", "code": "playlist_track_not_found",
+                    "error": "track_key is required.",
+                })
+                continue
+            if not _s(entry.get("decision_version") or "").strip():
+                invalid.append({
+                    "track_key": track_key, "code": "decision_version_required",
+                    "error": "decision_version is required for every submitted row.",
+                })
+                continue
+            if track_key not in by_track_key:
+                order.append(track_key)
+            by_track_key.setdefault(track_key, []).append(entry)
+
+        if invalid:
+            codes = {row["code"] for row in invalid}
+            top_code = next(iter(codes)) if len(codes) == 1 else "playlist_batch_rejected"
+            return jsonify({
+                "ok": False, "changed": False, "code": top_code,
+                "invalid": invalid, "stale": [], "conflicts": [], "skipped_review": [],
+            }), 400
+
+        deduped: List[Dict[str, Any]] = []
+        for track_key in order:
+            entries = by_track_key[track_key]
+            signatures = {_playlist_submission_signature(e) for e in entries}
+            if len(signatures) > 1:
+                conflict_rows.append({
+                    "track_key": track_key, "code": "playlist_duplicate_submission",
+                    "error": "This track_key was submitted more than once with different candidates or versions.",
+                })
+                continue
+            deduped.append(entries[0])
+
+        if not deduped and not conflict_rows:
+            return jsonify({
+                "ok": True, "name": clean_name, "changed": False,
+                "applied": [], "unchanged": [], "skipped_review": [], "conflicts": [], "stale": [],
+                "audit_id": None,
+            })
+
+        # ---- Phase 2: business validation against fresh candidates -----
+        # _playlist_desired_tracks_for_name (not a raw manifest read) so a
+        # manifest written before row ids existed self-heals/persists them
+        # here too, not only on a prior GET suggestions call.
+        manifest_tracks, _desired_source = _playlist_desired_tracks_for_name(clean_name, min_tracks=0)
+        by_row_id = {t.get("row_id"): t for t in manifest_tracks if t.get("row_id")}
+
+        unchanged: List[Dict[str, Any]] = []
+        skipped_review: List[Dict[str, Any]] = []
+        stale_rows: List[Dict[str, Any]] = []
+        to_apply: List[Dict[str, Any]] = []
+
+        for entry in deduped:
+            track_key = _s(entry.get("track_key") or "").strip()
+            row_id = track_key
             submitted_mbid = _s(entry.get("mb_trackid") or "").strip().lower()
             try:
                 submitted_item_id = int(entry.get("item_id") or 0)
@@ -47736,19 +47923,18 @@ def playlist_apply_safe_suggestions(name):
                 submitted_item_id = 0
             submitted_version = _s(entry.get("decision_version") or "").strip()
 
-            track = by_key.get(track_key)
+            track = by_row_id.get(row_id)
             if track is None:
                 stale_rows.append({
-                    "track_key": track_key,
-                    "code": "playlist_track_not_found",
-                    "error": "This track is no longer in the current missing-track set; refresh suggestions.",
+                    "track_key": track_key, "code": "playlist_track_not_found",
+                    "error": "This track no longer exists in the playlist manifest; refresh suggestions.",
                 })
                 continue
 
             artist = _s(track.get("artist") or "").strip()
             title = _s(track.get("title") or "").strip()
             candidates = _playlist_decisions_for_track(
-                clean_name, track_key, artist, title, include_musicbrainz=True, limit=5)
+                clean_name, row_id, artist, title, include_musicbrainz=True, limit=5)
 
             candidate = None
             for cand in candidates:
@@ -47762,17 +47948,26 @@ def playlist_apply_safe_suggestions(name):
                     break
             if candidate is None:
                 conflict_rows.append({
-                    "track_key": track_key,
-                    "code": "candidate_not_in_trusted_set",
+                    "track_key": track_key, "code": "candidate_not_in_trusted_set",
                     "error": "This candidate is not part of the current trusted candidate set.",
                 })
                 continue
 
+            resolved_artist = _s(candidate.get("artist") or "").strip()
+            resolved_title = _s(candidate.get("title") or "").strip()
+
+            # Idempotency check first: if this row's *current* persisted
+            # identity already equals what this submission would resolve
+            # to, there is nothing to mutate -- a safe no-op regardless of
+            # whether the underlying decision has since drifted.
+            if resolved_title and _norm(artist) == _norm(resolved_artist) and _norm(title) == _norm(resolved_title):
+                unchanged.append({"track_key": track_key, "ok": True, "changed": False, "reason": "already_resolved"})
+                continue
+
             computed_version = _s(candidate.get("decision_version") or "")
-            if submitted_version and submitted_version != computed_version:
+            if submitted_version != computed_version:
                 stale_rows.append({
-                    "track_key": track_key,
-                    "code": "playlist_suggestions_stale",
+                    "track_key": track_key, "code": "playlist_suggestions_stale",
                     "error": "The matching decision has changed since it was displayed; refresh suggestions.",
                     "candidate": candidate,
                 })
@@ -47782,70 +47977,69 @@ def playlist_apply_safe_suggestions(name):
             action_eligibility = decision.get("action_eligibility") or {}
             if decision.get("review_required") or not action_eligibility.get("playlist_resolve_without_review"):
                 skipped_review.append({
-                    "track_key": track_key,
-                    "code": "playlist_review_required",
+                    "track_key": track_key, "code": "playlist_review_required",
                     "reason": _s(decision.get("eligibility_reason") or ""),
                     "candidate": candidate,
                 })
                 continue
             if decision.get("conflicts"):
                 conflict_rows.append({
-                    "track_key": track_key,
-                    "code": "playlist_conflict",
+                    "track_key": track_key, "code": "playlist_conflict",
                     "conflicts": list(decision.get("conflicts") or []),
                     "candidate": candidate,
                 })
                 continue
-
-            resolved_artist = _s(candidate.get("artist") or "").strip()
-            resolved_title = _s(candidate.get("title") or "").strip()
             if not resolved_title:
                 conflict_rows.append({
-                    "track_key": track_key,
-                    "code": "playlist_candidate_required",
+                    "track_key": track_key, "code": "playlist_candidate_required",
                     "error": "Candidate has no title.",
                 })
                 continue
 
-            if _norm(artist) == _norm(resolved_artist) and _norm(title) == _norm(resolved_title):
-                unchanged.append({"track_key": track_key, "ok": True, "changed": False, "reason": "already_resolved"})
-                continue
-
-            current_metadata = {
-                "artist": artist, "title": title,
-                "mb_trackid": "", "mb_releasegroupid": "",
-            }
-            candidate_identity = {
-                "artist": resolved_artist, "title": resolved_title,
-                "mb_trackid": _s(candidate.get("mb_trackid") or ""),
-                "mb_releasegroupid": _s(candidate.get("mb_releasegroupid") or ""),
-                "item_id": candidate.get("item_id"),
-            }
-            replacements.append({"track": track, "replacement": {"artist": resolved_artist, "title": resolved_title}})
-            change_entries.append({
+            to_apply.append({
                 "track_key": track_key,
-                "current_metadata": current_metadata,
-                "candidate_identity": candidate_identity,
+                "row_id": row_id,
+                "current_metadata": {"artist": artist, "title": title, "mb_trackid": "", "mb_releasegroupid": ""},
+                "candidate_identity": {
+                    "artist": resolved_artist, "title": resolved_title,
+                    "mb_trackid": _s(candidate.get("mb_trackid") or ""),
+                    "mb_releasegroupid": _s(candidate.get("mb_releasegroupid") or ""),
+                    "item_id": candidate.get("item_id"),
+                },
                 "decision_version": computed_version,
                 "confidence": {"overall": decision.get("confidence_score")},
                 "reason": _s(decision.get("eligibility_reason") or ""),
                 "warnings": list(decision.get("warnings") or []),
                 "source": candidate.get("source"),
+                "evidence": candidate.get("evidence") or {},
             })
 
+        # ---- All-or-nothing: any blocker rejects the whole batch --------
+        if stale_rows or conflict_rows or skipped_review:
+            blocking_codes = {
+                row["code"] for row in (*stale_rows, *conflict_rows, *skipped_review) if row.get("code")
+            }
+            top_code = next(iter(blocking_codes)) if len(blocking_codes) == 1 else "playlist_batch_rejected"
+            return jsonify({
+                "ok": False, "changed": False, "code": top_code,
+                "invalid": [], "stale": stale_rows, "conflicts": conflict_rows, "skipped_review": skipped_review,
+            }), 409
+
+        # ---- Apply: exactly one manifest write for the whole batch -----
+        applied: List[Dict[str, Any]] = []
         audit_id = None
-        if change_entries:
+        if to_apply:
             tx = transactions.create(
                 operation_type="Playlist Match",
                 initiating_user=_transaction_user_label(),
                 status="Running",
                 dry_run=False,
-                summary=f"Apply {len(change_entries)} safe playlist suggestion(s) for {clean_name}",
+                summary=f"Apply {len(to_apply)} safe playlist suggestion(s) for {clean_name}",
                 reason="Backend-verified safe playlist suggestion application",
                 source="Playlist suggestions apply-safe-suggestions",
                 confidence={"overall": None},
                 changes=[{
-                    "id": entry["track_key"],
+                    "id": entry["row_id"], "row_id": entry["row_id"], "track_key": entry["track_key"],
                     "operation": "Playlist Match",
                     "track": entry["candidate_identity"]["title"],
                     "artist": entry["candidate_identity"]["artist"],
@@ -47858,20 +48052,22 @@ def playlist_apply_safe_suggestions(name):
                     "confidence": entry["confidence"],
                     "reason": entry["reason"],
                     "warnings": entry["warnings"],
-                } for entry in change_entries],
+                    "evidence": entry["evidence"],
+                } for entry in to_apply],
                 rollback_available=True,
-                rollback_reason="Restores the previous desired-track artist/title for each resolved row.",
-                metadata={"playlist": clean_name, "rows": len(change_entries)},
+                rollback_reason="Restores the previous desired-track identity for each resolved row.",
+                metadata={"playlist": clean_name, "rows": len(to_apply)},
             )
             audit_id = tx["id"]
             transactions.update(audit_id, rollback={
                 "available": True,
-                "reason": "Restores the previous desired-track artist/title for each resolved row.",
+                "reason": "Restores the previous desired-track identity for each resolved row.",
                 "operations": [{
                     "type": "playlist_track_restore",
                     "playlist": clean_name,
-                    "track_key": entry["track_key"],
+                    "row_id": entry["row_id"],
                     "fields": {
+                        "row_id": entry["row_id"],
                         "previous": entry["current_metadata"],
                         "applied": {
                             "artist": entry["candidate_identity"]["artist"],
@@ -47879,52 +48075,89 @@ def playlist_apply_safe_suggestions(name):
                         },
                     },
                     "reason": "Restore desired-track identity captured before suggestion apply.",
-                } for entry in change_entries],
-            }, counts={"items": len(change_entries), "changes": len(change_entries)})
+                } for entry in to_apply],
+            }, counts={"items": len(to_apply), "changes": len(to_apply)})
 
-            _playlist_apply_manifest_replacements(
-                clean_name, replacements, index=index, source_label="suggestion")
+            try:
+                _playlist_replace_rows_by_id(
+                    clean_name,
+                    [{"row_id": e["row_id"], "artist": e["candidate_identity"]["artist"],
+                      "title": e["candidate_identity"]["title"]} for e in to_apply],
+                )
 
-            # Truthfulness: re-read the manifest after writing and verify
-            # every intended row actually landed before claiming success --
-            # never mark Completed on the strength of the in-memory return
-            # value from _playlist_apply_manifest_replacements alone.
-            reread_tracks = _playlist_clean_track_list(
-                _playlist_read_manifest(clean_name).get("desired_tracks") or [])
-            verified_keys = set()
-            for entry in change_entries:
-                want_artist = _norm(entry["candidate_identity"]["artist"])
-                want_title = _norm(entry["candidate_identity"]["title"])
-                if any(_norm(t.get("artist") or "") == want_artist and _norm(t.get("title") or "") == want_title
-                       for t in reread_tracks):
-                    verified_keys.add(entry["track_key"])
+                # Truthfulness: re-read and verify each exact row_id landed
+                # on its exact intended identity -- never "any row with
+                # this text," which could double-count one persisted row
+                # as proof of two different changes.
+                reread_by_id = {
+                    t.get("row_id"): t
+                    for t in _playlist_clean_track_list(
+                        _playlist_read_manifest(clean_name).get("desired_tracks") or [])
+                    if t.get("row_id")
+                }
+                unverified = [
+                    entry for entry in to_apply
+                    if not (
+                        reread_by_id.get(entry["row_id"]) is not None
+                        and _norm(reread_by_id[entry["row_id"]].get("artist") or "") == _norm(entry["candidate_identity"]["artist"])
+                        and _norm(reread_by_id[entry["row_id"]].get("title") or "") == _norm(entry["candidate_identity"]["title"])
+                    )
+                ]
+                if unverified:
+                    transactions.update(audit_id, status="Failed")
+                    transactions.append_log(
+                        audit_id,
+                        f"ERROR: {len(unverified)} of {len(to_apply)} resolved row(s) "
+                        "did not verify by exact row_id after the manifest write.",
+                    )
+                    return jsonify({
+                        "ok": False, "changed": False, "code": "playlist_persistence_failed",
+                        "invalid": [], "stale": [], "skipped_review": [],
+                        "conflicts": [{
+                            "track_key": e["track_key"], "code": "playlist_persistence_failed",
+                            "error": "Resolved identity did not verify after persistence.",
+                        } for e in unverified],
+                        "audit_id": audit_id,
+                    }), 500
+
+                updated_changes = []
+                for entry in to_apply:
+                    persisted = reread_by_id[entry["row_id"]]
+                    persisted_identity = {
+                        "artist": persisted.get("artist"), "title": persisted.get("title"),
+                        "row_id": entry["row_id"],
+                    }
                     applied.append({
                         "track_key": entry["track_key"],
                         "artist": entry["candidate_identity"]["artist"],
                         "title": entry["candidate_identity"]["title"],
                     })
-
-            if len(verified_keys) == len(change_entries):
-                transactions.update(audit_id, status="Completed")
-            else:
+                    updated_changes.append({
+                        "id": entry["row_id"], "row_id": entry["row_id"], "track_key": entry["track_key"],
+                        "operation": "Playlist Match",
+                        "track": entry["candidate_identity"]["title"],
+                        "artist": entry["candidate_identity"]["artist"],
+                        "current_metadata": entry["current_metadata"],
+                        "new_metadata": entry["candidate_identity"],
+                        "metadata_diff": metadata_diff(entry["current_metadata"], entry["candidate_identity"]),
+                        "candidate_identity": entry["candidate_identity"],
+                        "persisted_identity": persisted_identity,
+                        "decision_version": entry["decision_version"],
+                        "confidence": entry["confidence"],
+                        "reason": entry["reason"],
+                        "warnings": entry["warnings"],
+                        "evidence": entry["evidence"],
+                    })
+                transactions.update(audit_id, status="Completed", changes=updated_changes)
+            except Exception as ex:
                 transactions.update(audit_id, status="Failed")
-                transactions.append_log(
-                    audit_id, "ERROR: one or more resolved rows did not verify after the manifest write.")
-                for entry in change_entries:
-                    if entry["track_key"] not in verified_keys:
-                        conflict_rows.append({
-                            "track_key": entry["track_key"],
-                            "code": "playlist_persistence_failed",
-                            "error": "Resolved identity did not verify after persistence.",
-                        })
-
-        if not applied and not unchanged and not skipped_review and not conflict_rows and stale_rows:
-            return jsonify({
-                "ok": False,
-                "error": "The missing-track set has changed since suggestions were displayed; refresh suggestions.",
-                "code": "playlist_suggestions_stale",
-                "stale": stale_rows,
-            }), 409
+                transactions.append_log(audit_id, f"ERROR: {_redact_security_text(str(ex))[:300]}")
+                return jsonify({
+                    "ok": False,
+                    "error": "Applying playlist suggestions failed.",
+                    "code": "playlist_persistence_failed",
+                    "audit_id": audit_id,
+                }), 500
 
         return jsonify({
             "ok": True,
@@ -47932,10 +48165,20 @@ def playlist_apply_safe_suggestions(name):
             "changed": bool(applied),
             "applied": applied,
             "unchanged": unchanged,
-            "skipped_review": skipped_review,
-            "conflicts": conflict_rows,
-            "stale": stale_rows,
+            "skipped_review": [],
+            "conflicts": [],
+            "stale": [],
             "audit_id": audit_id,
+            # Truthful derived-state accounting: this operation only ever
+            # rewrites the desired-track manifest (same as the pre-existing
+            # resolve-track action) -- it never regenerates the playlist's
+            # M3U file or pipeline checkpoint. `sync_required` tells the
+            # frontend a manifest change occurred that a later pipeline/
+            # sync run should pick up; it is never claimed to already be
+            # reflected in the M3U.
+            "manifest_updated": bool(applied),
+            "m3u_updated": False,
+            "sync_required": bool(applied),
         })
     finally:
         _release_playlist_apply(clean_name)

--- a/backend/matching_contract.py
+++ b/backend/matching_contract.py
@@ -542,6 +542,8 @@ def build_recording_matching_decision(
     linked_releases: Optional[Sequence[Mapping[str, Any]]] = None,
     ai_state: Optional[AiState] = None,
     similarity_fn: Optional[SimilarityFn] = None,
+    library_identity_verified: bool = False,
+    extra_conflicts: Sequence[str] = (),
 ) -> MatchingDecision:
     """Build the authoritative recording-candidate decision for Import Review.
 
@@ -806,6 +808,15 @@ def build_recording_matching_decision(
         conflicts.append("release_group_id_source_conflict")
     if selected_release_not_linked:
         conflicts.append("selected_release_not_linked")
+    # Caller-supplied conflicts (e.g. a playlist adapter's own competing-
+    # candidate-tie check) fold into the same conflicts list the rest of
+    # this function reasons about, so they participate in the safety-key
+    # ladder and the decision-version hash identically to every built-in
+    # conflict -- never bypassed or applied after the fact.
+    for name in extra_conflicts:
+        name = _s(name).strip()
+        if name and name not in conflicts:
+            conflicts.append(name)
     if fingerprint_state == "incomplete" and fingerprint_attempted and fingerprint_matched and not acoustid_mapped_recording_id:
         warnings.append("acoustid_mapped_recording_id_missing")
     if title_only_strong:
@@ -833,8 +844,23 @@ def build_recording_matching_decision(
         and not selected_release_not_linked
         and ((title_score >= 0.82 and artist_score >= 0.72) or title_only_strong)
     )
+    # Playlist-only bypass: an existing Beets library item can be safely
+    # bound to a playlist slot purely on a deterministic artist+title match
+    # -- it never mutates the item's own tags, so it doesn't need a
+    # MusicBrainz Recording ID or release-group evidence the way attaching
+    # one does. `library_identity_verified` is only ever True when the
+    # caller (the playlist adapter) has already confirmed the candidate
+    # item still exists in the library; it defaults False and is never set
+    # by Import Review, so `attach_eligible`/`attach_without_review` below
+    # are computed exactly as before for every existing caller.
+    library_eligible = bool(
+        library_identity_verified
+        and not conflicts
+        and title_score >= 0.94
+        and artist_score >= 0.90
+    )
 
-    if not resolved_recording_id:
+    if not resolved_recording_id and not library_eligible:
         safety_result = "No verified match"
         safety_key = "none"
         confidence_tier = "low"
@@ -856,18 +882,23 @@ def build_recording_matching_decision(
         confidence_tier = "medium"
         recommended_action = "Confirm conflicts, then attach Recording ID"
         eligibility_reason = "Candidate has review-only conflicts: " + ", ".join(conflicts)
-    elif not release_group_id:
+    elif resolved_recording_id and not release_group_id and not library_eligible:
         safety_result = "Needs review"
         safety_key = "review"
         confidence_tier = "medium"
         recommended_action = "Attach Recording ID only after review"
         eligibility_reason = "Only recording identity is supported; release-group identity is missing."
-    elif attach_eligible:
-        safety_result = "Safe to attach"
+    elif attach_eligible or library_eligible:
+        safety_result = "Safe to attach" if attach_eligible else "Safe (existing library identity)"
         safety_key = "safe"
         confidence_tier = "high"
-        recommended_action = "Attach Recording ID"
-        eligibility_reason = "Recording ID can be attached from deterministic evidence without additional review."
+        recommended_action = "Attach Recording ID" if attach_eligible else "Use existing library item"
+        eligibility_reason = (
+            "Recording ID can be attached from deterministic evidence without additional review."
+            if attach_eligible else
+            "Existing Beets library item deterministically matches artist and title; "
+            "no MusicBrainz Recording ID change is required."
+        )
     else:
         safety_result = "Needs review"
         safety_key = "review"
@@ -877,7 +908,14 @@ def build_recording_matching_decision(
 
     review_required = safety_key != "safe"
     requires_confirmation = review_required
-    attach_without_review = safety_key == "safe"
+    # Scoped to the recording-ID path specifically (never to the
+    # playlist-only library-identity bypass) -- safety_key can reach "safe"
+    # via `library_eligible` with no resolved Recording ID at all, and
+    # "attach_without_review" must never assert it's safe to attach an ID
+    # that doesn't exist. For every existing (non-playlist) caller this is
+    # exactly equivalent to the prior `safety_key == "safe"` computation,
+    # since library_eligible is always False there.
+    attach_without_review = bool(attach_eligible)
 
     reason = _s(candidate.get("reason"))
     if not reason:
@@ -1016,6 +1054,7 @@ def build_recording_matching_decision(
         "review_required": review_required,
         "action_eligibility": {
             "attach_without_review": attach_without_review,
+            "playlist_resolve_without_review": bool(attach_without_review or library_eligible),
             "destructive_use": False,
         },
         "eligibility_reason": eligibility_reason,
@@ -1085,6 +1124,7 @@ def compute_decision_version(item_id: Any, decision: "MatchingDecision") -> str:
         "safety_key": _s(d.get("safety_key")),
         "confidence_score": _finite_number(d.get("confidence_score")),
         "attach_without_review": bool(action_eligibility.get("attach_without_review")),
+        "playlist_resolve_without_review": bool(action_eligibility.get("playlist_resolve_without_review")),
         "destructive_use": bool(action_eligibility.get("destructive_use")),
         "eligibility_reason": _s(d.get("eligibility_reason")),
         "candidate_source": _s(candidate.get("source")),

--- a/backend/transaction_engine.py
+++ b/backend/transaction_engine.py
@@ -45,6 +45,7 @@ TRANSACTION_TYPES = {
     "AcoustID Match",
     "MusicBrainz Match",
     "AI Suggestion",
+    "Playlist Match",
     "Repair",
     "Rescan",
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -65,6 +65,7 @@ import type {
   PlaylistApplySuggestionsResponse,
   PlaylistsResponse,
   PlaylistSuggestionsResponse,
+  PlaylistSuggestionSubmission,
   PlaylistSource,
   PlaylistTrack,
   PlaylistRowsResponse,
@@ -644,10 +645,13 @@ export function getPlaylistSuggestions(name: string): Promise<PlaylistSuggestion
   return apiJson<PlaylistSuggestionsResponse>(`/api/playlists/${encodeURIComponent(name)}/suggestions`);
 }
 
-export function applySafePlaylistSuggestions(name: string): Promise<PlaylistApplySuggestionsResponse> {
+export function applySafePlaylistSuggestions(
+  name: string,
+  suggestions: PlaylistSuggestionSubmission[],
+): Promise<PlaylistApplySuggestionsResponse> {
   return apiJson<PlaylistApplySuggestionsResponse>(
     `/api/playlists/${encodeURIComponent(name)}/apply-safe-suggestions`,
-    jsonRequest('POST', { musicbrainz: true }),
+    jsonRequest('POST', { suggestions }),
   );
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1414,6 +1414,12 @@ export interface PlaylistApplySuggestionsResponse extends ApiOkResponse {
   conflicts: PlaylistSuggestionOutcomeRow[];
   stale: PlaylistSuggestionOutcomeRow[];
   audit_id?: string | null;
+  /** This operation only ever rewrites the desired-track manifest. */
+  manifest_updated?: boolean;
+  /** Always false today -- applying suggestions never regenerates the M3U. */
+  m3u_updated?: boolean;
+  /** True when a manifest change occurred that a later pipeline/sync run should pick up. */
+  sync_required?: boolean;
 }
 
 export interface PlaylistPlexResult {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1327,24 +1327,54 @@ export interface PlaylistResolveTrackResponse extends PlaylistDetailResponse {
   errors?: Array<{ track?: PlaylistTrack; error?: string }>;
 }
 
+/** Backend-computed action eligibility -- never assign or recompute these client-side. */
+export interface PlaylistActionEligibility {
+  playlist_resolve_without_review: boolean;
+  attach_without_review: boolean;
+  destructive_use: boolean;
+}
+
+/** Authoritative matching-contract decision, shared with Import Review (PR #19). */
+export interface PlaylistSuggestionDecision {
+  confidence_score?: number;
+  safety_key: 'safe' | 'review' | 'conflict' | 'none' | string;
+  review_required: boolean;
+  requires_confirmation: boolean;
+  conflicts: string[];
+  warnings: string[];
+  eligibility_reason: string;
+  action_eligibility: PlaylistActionEligibility;
+}
+
 export interface PlaylistTrackSuggestion {
   artist: string;
   title: string;
-  source: 'beets' | 'beets-title' | 'musicbrainz' | string;
-  confidence: number;
-  safe: boolean;
-  reason: string;
+  source: 'beets' | 'musicbrainz' | string;
   item_id?: number;
   mb_trackid?: string;
+  mb_albumid?: string;
+  mb_releasegroupid?: string;
   mb_url?: string;
   album?: string;
   year?: string;
-  title_score?: number;
-  artist_score?: number;
+  decision_version: string;
+  decision: PlaylistSuggestionDecision;
+  evidence?: {
+    acoustid?: Record<string, unknown>;
+    musicbrainz?: Record<string, unknown>;
+    library?: { item_id?: number | null; verified?: boolean };
+  };
+  /** @deprecated use decision.confidence_score */
+  confidence: number;
+  /** @deprecated use decision.action_eligibility.playlist_resolve_without_review */
+  safe: boolean;
+  /** @deprecated use decision.eligibility_reason */
+  reason: string;
 }
 
 export interface PlaylistSuggestionRow {
   track: PlaylistTrack;
+  track_key: string;
   suggestions: PlaylistTrackSuggestion[];
   best?: PlaylistTrackSuggestion | null;
 }
@@ -1356,9 +1386,34 @@ export interface PlaylistSuggestionsResponse extends ApiOkResponse {
   rows: PlaylistSuggestionRow[];
 }
 
-export interface PlaylistApplySuggestionsResponse extends PlaylistResolveTrackResponse {
-  suggested?: Array<{ track: PlaylistTrack; best?: PlaylistTrackSuggestion | null }>;
-  safe_count?: number;
+/** Minimal, non-authoritative submission for one applied suggestion row --
+ * the backend recomputes safety/eligibility fresh from track_key at apply
+ * time and ignores any other client-supplied field. */
+export interface PlaylistSuggestionSubmission {
+  track_key: string;
+  mb_trackid?: string;
+  item_id?: number;
+  decision_version: string;
+}
+
+export interface PlaylistSuggestionOutcomeRow {
+  track_key: string;
+  code?: string;
+  error?: string;
+  reason?: string;
+  conflicts?: string[];
+  candidate?: PlaylistTrackSuggestion;
+}
+
+export interface PlaylistApplySuggestionsResponse extends ApiOkResponse {
+  name: string;
+  changed: boolean;
+  applied: Array<{ track_key: string; artist: string; title: string }>;
+  unchanged: PlaylistSuggestionOutcomeRow[];
+  skipped_review: PlaylistSuggestionOutcomeRow[];
+  conflicts: PlaylistSuggestionOutcomeRow[];
+  stale: PlaylistSuggestionOutcomeRow[];
+  audit_id?: string | null;
 }
 
 export interface PlaylistPlexResult {

--- a/frontend/src/views/Playlists.tsx
+++ b/frontend/src/views/Playlists.tsx
@@ -214,9 +214,8 @@ function scoreLabel(score: number | undefined): string {
 }
 
 function suggestionLabel(suggestion: PlaylistTrackSuggestion): string {
-  const confidence = scoreLabel(suggestion.confidence);
-  const source = suggestion.source === 'beets-title' ? 'beets' : suggestion.source;
-  return `${suggestion.artist ? `${suggestion.artist} - ` : ''}${suggestion.title}${confidence ? ` · ${confidence}` : ''} · ${source}`;
+  const confidence = scoreLabel(suggestion.decision?.confidence_score ?? suggestion.confidence);
+  return `${suggestion.artist ? `${suggestion.artist} - ` : ''}${suggestion.title}${confidence ? ` · ${confidence}` : ''} · ${suggestion.source}`;
 }
 
 function durationLabel(seconds: number | undefined): string {
@@ -1181,7 +1180,9 @@ export default function Playlists() {
     [qualityRows],
   );
   const suggestionsByTrack = useMemo(() => suggestionRowsByTrack(suggestionRows), [suggestionRows]);
-  const safeSuggestionCount = suggestionRows.filter((row) => row.best?.safe).length;
+  const safeSuggestionCount = suggestionRows.filter(
+    (row) => row.best?.decision?.action_eligibility?.playlist_resolve_without_review,
+  ).length;
   const savedPlaylistName = (parseResult as { name?: string } | null)?.name || '';
   const viewingSavedPlaylist = Boolean(
     (parseResult as { m3u?: string; manifest?: string } | null)?.m3u
@@ -1818,17 +1819,32 @@ export default function Playlists() {
 
   const handleApplySafeSuggestions = async () => {
     if (!savedPlaylistName) return;
+    const submissions = suggestionRows
+      .filter((row) => row.best?.decision?.action_eligibility?.playlist_resolve_without_review)
+      .map((row) => ({
+        track_key: row.track_key,
+        mb_trackid: row.best?.mb_trackid,
+        item_id: row.best?.item_id,
+        decision_version: row.best?.decision_version ?? '',
+      }))
+      .filter((s) => s.track_key);
+    if (!submissions.length) return;
     setApplyingSuggestions(true);
     setNotice(null);
     try {
-      const result = await applySafePlaylistSuggestions(savedPlaylistName);
-      setParseResult(result);
+      const result = await applySafePlaylistSuggestions(savedPlaylistName, submissions);
       setSuggestionRows([]);
       setResolveDraft(null);
-      setNotice({
-        severity: 'success',
-        message: `Applied ${(result.resolved_count ?? 0).toLocaleString()} safe suggestion(s). ${result.matched.length.toLocaleString()} available, ${result.missing.length.toLocaleString()} missing.`,
-      });
+      const detail = await getPlaylistDetails(savedPlaylistName, { mode: 'summary' });
+      setParseResult(detail);
+      const parts = [`${result.applied.length.toLocaleString()} applied`];
+      if (result.unchanged.length) parts.push(`${result.unchanged.length.toLocaleString()} already resolved`);
+      if (result.skipped_review.length) parts.push(`${result.skipped_review.length.toLocaleString()} need review`);
+      if (result.conflicts.length) parts.push(`${result.conflicts.length.toLocaleString()} conflicts`);
+      if (result.stale.length) {
+        parts.push(`${result.stale.length.toLocaleString()} stale (refresh suggestions)`);
+      }
+      setNotice({ severity: result.applied.length ? 'success' : 'info', message: parts.join(', ') });
       await loadPlaylists();
     } catch (err) {
       setNotice({ severity: 'error', message: err instanceof Error ? err.message : String(err) });

--- a/frontend/src/views/Playlists.tsx
+++ b/frontend/src/views/Playlists.tsx
@@ -8,6 +8,7 @@ import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  apiErrorBody,
   applySafePlaylistSuggestions,
   cleanupPlaylistQuality,
   createPlaylist,
@@ -1832,6 +1833,10 @@ export default function Playlists() {
     setApplyingSuggestions(true);
     setNotice(null);
     try {
+      // Apply is atomic: this only ever resolves once every submitted row
+      // validated cleanly. Only that full success clears the suggestion
+      // list and reloads playlist detail -- any rejection (caught below)
+      // must leave the rows visible for inspection.
       const result = await applySafePlaylistSuggestions(savedPlaylistName, submissions);
       setSuggestionRows([]);
       setResolveDraft(null);
@@ -1839,15 +1844,41 @@ export default function Playlists() {
       setParseResult(detail);
       const parts = [`${result.applied.length.toLocaleString()} applied`];
       if (result.unchanged.length) parts.push(`${result.unchanged.length.toLocaleString()} already resolved`);
-      if (result.skipped_review.length) parts.push(`${result.skipped_review.length.toLocaleString()} need review`);
-      if (result.conflicts.length) parts.push(`${result.conflicts.length.toLocaleString()} conflicts`);
-      if (result.stale.length) {
-        parts.push(`${result.stale.length.toLocaleString()} stale (refresh suggestions)`);
-      }
+      if (result.sync_required) parts.push('run the playlist sync to reflect this in the M3U/Plex');
       setNotice({ severity: result.applied.length ? 'success' : 'info', message: parts.join(', ') });
       await loadPlaylists();
     } catch (err) {
-      setNotice({ severity: 'error', message: err instanceof Error ? err.message : String(err) });
+      const body = apiErrorBody(err) as
+        | { code?: string; stale?: unknown[]; conflicts?: unknown[]; skipped_review?: unknown[]; invalid?: unknown[] }
+        | undefined;
+      const code = body?.code;
+      if (code === 'playlist_suggestions_stale' || code === 'playlist_track_not_found') {
+        setNotice({
+          severity: 'warning',
+          message: 'Suggestions changed. The list was refreshed; review it before applying.',
+        });
+        await handleLoadSuggestions();
+      } else if (code === 'playlist_update_in_progress') {
+        setNotice({ severity: 'warning', message: 'Another playlist update is already running.' });
+      } else if (code === 'playlist_batch_rejected'
+        || code === 'playlist_review_required'
+        || code === 'playlist_conflict'
+        || code === 'candidate_not_in_trusted_set'
+        || code === 'decision_version_required'
+        || code === 'playlist_duplicate_submission'
+        || code === 'playlist_candidate_required') {
+        const parts: string[] = [];
+        if (body?.stale?.length) parts.push(`${body.stale.length} stale`);
+        if (body?.conflicts?.length) parts.push(`${body.conflicts.length} conflicted`);
+        if (body?.skipped_review?.length) parts.push(`${body.skipped_review.length} need review`);
+        if (body?.invalid?.length) parts.push(`${body.invalid.length} invalid`);
+        setNotice({
+          severity: 'warning',
+          message: `Nothing was applied (${parts.join(', ') || 'batch rejected'}). Review the suggestions below.`,
+        });
+      } else {
+        setNotice({ severity: 'error', message: err instanceof Error ? err.message : String(err) });
+      }
     } finally {
       setApplyingSuggestions(false);
     }

--- a/tests/test_matching_contract.py
+++ b/tests/test_matching_contract.py
@@ -800,7 +800,7 @@ class MatchingContractEligibilityTests(unittest.TestCase):
         self.assertNotIn("submit_metadata", decision["decision"]["action_eligibility"])
         self.assertEqual(
             set(decision["decision"]["action_eligibility"].keys()),
-            {"attach_without_review", "destructive_use"},
+            {"attach_without_review", "playlist_resolve_without_review", "destructive_use"},
         )
 
     def test_safe_candidate_is_attach_without_review(self):

--- a/tests/test_playlist_backend_job.py
+++ b/tests/test_playlist_backend_job.py
@@ -86,7 +86,7 @@ class PlaylistBackendJobTests(unittest.TestCase):
         self.assertIn("def playlist_resolve_track", app_source)
         self.assertIn("def playlist_suggestions", app_source)
         self.assertIn("def playlist_apply_safe_suggestions", app_source)
-        self.assertIn("def _playlist_suggestions_for_track", app_source)
+        self.assertIn("def _playlist_decisions_for_track", app_source)
         self.assertIn('def playlist_delete', app_source)
         self.assertIn('"library_tracks_deleted": 0', app_source)
         self.assertIn('"/api/playlists/quality-cleanup"', app_source)

--- a/tests/test_playlist_matching_contract.py
+++ b/tests/test_playlist_matching_contract.py
@@ -1,0 +1,226 @@
+"""Tests for the playlist-specific additions to the shared matching
+contract (backend/matching_contract.py): `library_identity_verified`,
+`extra_conflicts`, and the `playlist_resolve_without_review` action
+eligibility field added for the playlist missing-track-suggestions
+consumer (migrated after PR #19's Import Review attach enforcement).
+
+These are pure contract-level tests -- no Flask app, no Beets library --
+covering exactly the same kind of decision logic Import Review's own
+tests/test_matching_contract.py exercises, plus the playlist-only
+behavior layered on top. Route-level behavior (candidate generation,
+staleness, batching, concurrency, rollback) lives in
+tests/test_playlist_safe_suggestions.py and
+tests/test_playlist_suggestion_integrity.py.
+"""
+import unittest
+
+from backend.matching_contract import (
+    build_recording_matching_decision,
+    compute_decision_version,
+)
+
+RECORDING_ID = "11111111-1111-1111-1111-111111111111"
+RELEASE_ID = "22222222-2222-2222-2222-222222222222"
+RGID = "33333333-3333-3333-3333-333333333333"
+OTHER_RECORDING_ID = "44444444-4444-4444-4444-444444444444"
+
+
+def _current(**overrides):
+    data = {"title": "Midnight City", "artist": "M83"}
+    data.update(overrides)
+    return data
+
+
+def _library_candidate(**overrides):
+    data = {"artist": "M83", "title": "Midnight City", "source": "beets", "item_id": 7}
+    data.update(overrides)
+    return data
+
+
+def _mb_candidate(**overrides):
+    data = {
+        "artist": "M83", "title": "Midnight City", "source": "musicbrainz",
+        "mb_trackid": RECORDING_ID, "mb_albumid": RELEASE_ID, "mb_releasegroupid": RGID,
+        "_match_score": {"total": 0.90, "source": "mb"},
+    }
+    data.update(overrides)
+    return data
+
+
+class LibraryIdentityBypassTests(unittest.TestCase):
+    """Section 6 "Existing Beets library identity": a deterministic
+    artist+title match to an existing library item is safe for playlist
+    resolution even with no MusicBrainz Recording ID at all -- but this
+    must never leak into attach_without_review (PR #19's own field)."""
+
+    def test_exact_match_with_no_recording_id_is_playlist_safe(self):
+        decision = build_recording_matching_decision(
+            current=_current(), candidate=_library_candidate(),
+            library_identity_verified=True,
+        ).to_dict()
+        d = decision["decision"]
+        self.assertEqual(d["safety_key"], "safe")
+        self.assertFalse(d["review_required"])
+        self.assertFalse(d["requires_confirmation"])
+        self.assertTrue(d["action_eligibility"]["playlist_resolve_without_review"])
+
+    def test_exact_match_never_grants_attach_without_review(self):
+        """A library-identity-only match has no Recording ID to attach --
+        attach_without_review must stay scoped to the recording-ID path
+        Import Review actually uses, even though safety_key reads "safe"."""
+        decision = build_recording_matching_decision(
+            current=_current(), candidate=_library_candidate(),
+            library_identity_verified=True,
+        ).to_dict()
+        self.assertFalse(decision["decision"]["action_eligibility"]["attach_without_review"])
+
+    def test_not_verified_stays_unsafe_with_no_recording_id(self):
+        decision = build_recording_matching_decision(
+            current=_current(), candidate=_library_candidate(),
+            library_identity_verified=False,
+        ).to_dict()
+        d = decision["decision"]
+        self.assertEqual(d["safety_key"], "none")
+        self.assertFalse(d["action_eligibility"]["playlist_resolve_without_review"])
+
+    def test_fuzzy_title_mismatch_requires_review_even_when_verified(self):
+        decision = build_recording_matching_decision(
+            current=_current(title="Midnight City"),
+            candidate=_library_candidate(title="Completely Different Song"),
+            library_identity_verified=True,
+        ).to_dict()
+        d = decision["decision"]
+        self.assertNotEqual(d["safety_key"], "safe")
+        self.assertFalse(d["action_eligibility"]["playlist_resolve_without_review"])
+
+    def test_fuzzy_artist_mismatch_requires_review_even_when_verified(self):
+        decision = build_recording_matching_decision(
+            current=_current(artist="M83"),
+            candidate=_library_candidate(artist="Some Other Band"),
+            library_identity_verified=True,
+        ).to_dict()
+        self.assertFalse(
+            decision["decision"]["action_eligibility"]["playlist_resolve_without_review"]
+        )
+
+    def test_existing_recording_conflict_blocks_library_bypass(self):
+        """current already carries a different Recording ID than the
+        candidate resolves to -- a genuine identity conflict must still
+        block the playlist bypass, not just the attach path."""
+        decision = build_recording_matching_decision(
+            current=_current(mb_trackid=OTHER_RECORDING_ID),
+            candidate=_library_candidate(mb_trackid=RECORDING_ID),
+            library_identity_verified=True,
+        ).to_dict()
+        d = decision["decision"]
+        self.assertIn("recording_id_conflict", d["conflicts"])
+        self.assertFalse(d["action_eligibility"]["playlist_resolve_without_review"])
+
+
+class RecordingIdPlaylistEligibilityTests(unittest.TestCase):
+    """A MusicBrainz-only recording candidate is playlist-safe exactly
+    when it's already attach_without_review-safe -- no separate, looser
+    bar for MB text-search candidates (conservative per spec)."""
+
+    def test_safe_recording_candidate_is_playlist_safe(self):
+        decision = build_recording_matching_decision(
+            current=_current(), candidate=_mb_candidate(),
+            selected_release={"release_id": RELEASE_ID, "release_group_id": RGID,
+                              "title": "Hurry Up, We're Dreaming", "artist": "M83"},
+            linked_releases=[{"release_id": RELEASE_ID, "release_group_id": RGID}],
+        ).to_dict()
+        d = decision["decision"]
+        self.assertTrue(d["action_eligibility"]["attach_without_review"])
+        self.assertTrue(d["action_eligibility"]["playlist_resolve_without_review"])
+
+    def test_fuzzy_recording_without_release_group_requires_review(self):
+        """No release-group resolution (plain MB text search) -- must not
+        be auto-applied on text score alone."""
+        decision = build_recording_matching_decision(
+            current=_current(), candidate=_mb_candidate(mb_releasegroupid=""),
+        ).to_dict()
+        self.assertFalse(
+            decision["decision"]["action_eligibility"]["playlist_resolve_without_review"]
+        )
+
+
+class ExtraConflictsTests(unittest.TestCase):
+    """extra_conflicts is the mechanism the playlist adapter uses to fold
+    a competing-candidate tie into the decision *before* decision_version
+    is computed, so the hash and the displayed safety state can never
+    diverge (see app.py's _playlist_decisions_for_track)."""
+
+    def test_extra_conflict_forces_review_and_blocks_playlist_bypass(self):
+        decision = build_recording_matching_decision(
+            current=_current(), candidate=_library_candidate(),
+            library_identity_verified=True,
+            extra_conflicts=("competing_candidates_tie",),
+        ).to_dict()
+        d = decision["decision"]
+        self.assertIn("competing_candidates_tie", d["conflicts"])
+        self.assertNotEqual(d["safety_key"], "safe")
+        self.assertFalse(d["action_eligibility"]["playlist_resolve_without_review"])
+
+    def test_extra_conflict_changes_decision_version(self):
+        base = build_recording_matching_decision(
+            current=_current(), candidate=_library_candidate(),
+            library_identity_verified=True,
+        )
+        tied = build_recording_matching_decision(
+            current=_current(), candidate=_library_candidate(),
+            library_identity_verified=True,
+            extra_conflicts=("competing_candidates_tie",),
+        )
+        self.assertNotEqual(
+            compute_decision_version("track-key", base),
+            compute_decision_version("track-key", tied),
+        )
+
+    def test_no_extra_conflicts_is_a_no_op(self):
+        a = build_recording_matching_decision(
+            current=_current(), candidate=_library_candidate(), library_identity_verified=True,
+        ).to_dict()
+        b = build_recording_matching_decision(
+            current=_current(), candidate=_library_candidate(),
+            library_identity_verified=True, extra_conflicts=(),
+        ).to_dict()
+        self.assertEqual(a["decision"], b["decision"])
+
+    def test_duplicate_extra_conflict_not_added_twice(self):
+        decision = build_recording_matching_decision(
+            current=_current(artist="Nobody", title="Nothing"),
+            candidate=_library_candidate(artist="Someone Else", title="Something Else"),
+            library_identity_verified=True,
+            extra_conflicts=("title_conflict", "title_conflict"),
+        ).to_dict()
+        self.assertEqual(decision["decision"]["conflicts"].count("title_conflict"), 1)
+
+
+class PlaylistDecisionVersionTests(unittest.TestCase):
+    def test_decision_version_keyed_by_track_key_not_item_id(self):
+        decision = build_recording_matching_decision(
+            current=_current(), candidate=_library_candidate(), library_identity_verified=True,
+        )
+        v1 = compute_decision_version("ptk_aaaa", decision)
+        v2 = compute_decision_version("ptk_bbbb", decision)
+        self.assertNotEqual(v1, v2)
+        self.assertTrue(v1.startswith("drv2:"))
+
+    def test_decision_version_changes_when_identity_changes(self):
+        d1 = build_recording_matching_decision(
+            current=_current(), candidate=_mb_candidate(mb_trackid=RECORDING_ID),
+            selected_release={"release_id": RELEASE_ID, "release_group_id": RGID},
+            linked_releases=[{"release_id": RELEASE_ID, "release_group_id": RGID}],
+        )
+        d2 = build_recording_matching_decision(
+            current=_current(), candidate=_mb_candidate(mb_trackid=OTHER_RECORDING_ID),
+            selected_release={"release_id": RELEASE_ID, "release_group_id": RGID},
+            linked_releases=[{"release_id": RELEASE_ID, "release_group_id": RGID}],
+        )
+        self.assertNotEqual(
+            compute_decision_version("ptk_x", d1), compute_decision_version("ptk_x", d2)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_playlist_safe_suggestions.py
+++ b/tests/test_playlist_safe_suggestions.py
@@ -202,27 +202,39 @@ class SuggestionsEndpointTests(PlaylistSuggestionsRouteTestCase):
         status, body = self._get_suggestions()
         self.assertEqual(body["safe_count"], 0)
 
-    def test_duplicate_titles_get_distinct_track_keys(self):
-        # The desired-track manifest itself deduplicates identical
-        # (artist, title) entries (_playlist_merge_desired_tracks) -- a
-        # playlist that intentionally repeats a song surfaces as repeated
-        # rows in the *missing* list this function is given, not as
-        # duplicate manifest entries. Exercise the key generator directly
-        # against two such rows, exactly as the routes call it.
-        rows = APP._playlist_missing_rows_with_keys(self.clean_name, [
+    def test_duplicate_titles_get_distinct_stable_row_ids(self):
+        # Two structurally-identical entries in the *same* merge group
+        # (e.g. a playlist's own M3U genuinely repeating a song) each get
+        # their own stable row_id -- _playlist_merge_desired_tracks only
+        # dedupes a fresh (no-row_id) entry against an *earlier* group,
+        # never against a same-group sibling.
+        merged = APP._playlist_merge_desired_tracks([
             {"artist": "Repeat Artist", "title": "Same Song"},
             {"artist": "Repeat Artist", "title": "Same Song"},
         ])
-        keys = [key for key, _track in rows]
+        self.assertEqual(len(merged), 2)
+        ids = [t.get("row_id") for t in merged]
+        self.assertTrue(all(ids))
+        self.assertNotEqual(ids[0], ids[1])
+
+        # Once assigned, row_ids are stable across a second merge pass
+        # (the normal read -> merge -> maybe-rewrite cycle) rather than
+        # being re-minted every time.
+        merged_again = APP._playlist_merge_desired_tracks(merged)
+        self.assertEqual(ids, [t.get("row_id") for t in merged_again])
+
+    def test_missing_rows_with_keys_uses_the_manifest_row_id(self):
+        self._seed_missing_tracks([
+            {"artist": "Repeat Artist", "title": "Same Song"},
+            {"artist": "Repeat Artist", "title": "Same Song"},
+        ])
+        status, body = self._get_suggestions()
+        self.assertEqual(status, 200)
+        keys = [row["track_key"] for row in body["rows"]]
         self.assertEqual(len(keys), 2)
         self.assertNotEqual(keys[0], keys[1])
-        # Deterministic: recomputing for the identical input list reproduces
-        # the same two keys in the same order.
-        rows_again = APP._playlist_missing_rows_with_keys(self.clean_name, [
-            {"artist": "Repeat Artist", "title": "Same Song"},
-            {"artist": "Repeat Artist", "title": "Same Song"},
-        ])
-        self.assertEqual(keys, [key for key, _track in rows_again])
+        tracks = self._manifest_tracks()
+        self.assertEqual(sorted(keys), sorted(t.get("row_id") for t in tracks))
 
     def test_client_cannot_disable_musicbrainz_and_get_a_safer_result(self):
         """musicbrainz=0 only narrows the *displayed* candidate set; it must
@@ -275,12 +287,21 @@ class ApplySafeSuggestionsTests(PlaylistSuggestionsRouteTestCase):
         tx = APP.transactions.get(body["audit_id"])
         self.assertEqual(tx["status"], "Completed")
         self.assertEqual(tx["operation_type"], "Playlist Match")
+        self.assertEqual(tx["changes"][0]["persisted_identity"]["artist"], "M83")
+        self.assertEqual(tx["changes"][0]["persisted_identity"]["title"], "Midnight City")
+        # Truthful derived-state accounting: only the manifest was
+        # rewritten here -- the M3U was not regenerated.
+        self.assertTrue(body["manifest_updated"])
+        self.assertFalse(body["m3u_updated"])
+        self.assertTrue(body["sync_required"])
 
-    def test_mixed_batch_applies_safe_row_and_reports_stale_row_at_200(self):
-        """A batch with at least one non-stale outcome returns 200 with
-        per-row buckets -- only a batch where every row is stale (nothing
-        else to report) escalates to a whole-batch 409."""
+    def test_mixed_batch_with_one_stale_row_applies_nothing(self):
+        """Atomic batch semantics: a batch containing one otherwise-safe
+        row and one stale/unresolvable row applies ZERO rows and creates
+        NO transaction -- the whole batch is rejected, never partially
+        applied."""
         track_key, best = self._safe_submission()
+        before = self._manifest_tracks()
         status, body = self._apply_suggestions([
             {
                 "track_key": track_key,
@@ -288,14 +309,26 @@ class ApplySafeSuggestionsTests(PlaylistSuggestionsRouteTestCase):
                 "item_id": best.get("item_id"),
                 "decision_version": best["decision_version"],
             },
-            {"track_key": "ptk_unrelated_missing", "decision_version": "drv2:x"},
+            {"track_key": "ptr_unrelated_missing", "decision_version": "drv2:x"},
         ])
-        self.assertEqual(status, 200)
-        self.assertEqual(len(body["applied"]), 1)
+        self.assertEqual(status, 409)
+        self.assertEqual(body["ok"], False)
+        self.assertEqual(body["changed"], False)
+        # Every blocking row shares one cause here (the single unrelated
+        # stale row), so the top-level code is that specific cause rather
+        # than the generic fallback.
+        self.assertEqual(body["code"], "playlist_track_not_found")
         self.assertEqual(len(body["stale"]), 1)
-        self.assertEqual(body["stale"][0]["track_key"], "ptk_unrelated_missing")
+        self.assertEqual(body["stale"][0]["track_key"], "ptr_unrelated_missing")
+        self.assertEqual(body["conflicts"], [])
+        # The otherwise-safe row was never written, and no transaction was
+        # created for it.
+        self.assertEqual(before, self._manifest_tracks())
+        _rows, total_for_playlist = APP.transactions.list(
+            operation="Playlist Match", query=self.clean_name)
+        self.assertEqual(total_for_playlist, 0)
 
-    def test_reapplying_the_same_row_is_unchanged_not_duplicated(self):
+    def test_replay_of_an_accepted_submission_is_idempotent(self):
         track_key, best = self._safe_submission()
         row = {
             "track_key": track_key,
@@ -304,19 +337,52 @@ class ApplySafeSuggestionsTests(PlaylistSuggestionsRouteTestCase):
             "decision_version": best["decision_version"],
         }
         status1, body1 = self._apply_suggestions([row])
+        self.assertEqual(status1, 200)
         self.assertEqual(len(body1["applied"]), 1)
         first_audit_id = body1["audit_id"]
 
-        # Recompute suggestions fresh -- the track has moved from "missing"
-        # into "matched" now that its manifest identity equals the library
-        # item, so a second identical apply request has nothing left to
-        # find under the *original* track_key. With no other rows in the
-        # batch this is reported as a whole-batch stale 409 (never silently
-        # re-applied or re-audited), matching the single-row-batch case.
+        # Exact replay of the identical, already-applied submission: the
+        # row (looked up by its stable row_id, not by "is it still
+        # missing") already has exactly this resolved identity, so this
+        # must be a true idempotent no-op -- 200, changed:false,
+        # already_resolved -- never a stale rejection and never a second
+        # write or transaction.
+        status2, body2 = self._apply_suggestions([row])
+        self.assertEqual(status2, 200)
+        self.assertEqual(body2["applied"], [])
+        self.assertEqual(len(body2["unchanged"]), 1)
+        self.assertEqual(body2["unchanged"][0]["reason"], "already_resolved")
+        self.assertIsNone(body2["audit_id"])
+        self.assertFalse(body2["changed"])
+
+        # No duplicate transaction was created for the replay.
+        second_tx = APP.transactions.get(first_audit_id)
+        self.assertEqual(second_tx["status"], "Completed")
+
+    def test_replay_after_row_changed_again_is_rejected_not_reapplied(self):
+        track_key, best = self._safe_submission()
+        row = {
+            "track_key": track_key,
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+            "decision_version": best["decision_version"],
+        }
+        status1, _ = self._apply_suggestions([row])
+        self.assertEqual(status1, 200)
+
+        # Something else (e.g. manual resolve-track) changes the row's
+        # identity again after our apply.
+        APP._playlist_replace_rows_by_id(self.clean_name, [{
+            "row_id": track_key, "artist": "Someone Else", "title": "Something Else",
+        }])
+
         status2, body2 = self._apply_suggestions([row])
         self.assertEqual(status2, 409)
-        self.assertEqual(body2["code"], "playlist_suggestions_stale")
-        self.assertEqual(body2["stale"][0]["track_key"], track_key)
+        # No longer an idempotent no-op -- the row's current identity no
+        # longer matches either the old or the newly-submitted target, so
+        # it is correctly rejected (stale/conflict), never silently
+        # overwritten back to the old resolution.
+        self.assertTrue(body2["stale"] or body2["conflicts"])
 
     def test_untrusted_candidate_is_rejected_without_mutation(self):
         track_key, best = self._safe_submission()
@@ -326,8 +392,8 @@ class ApplySafeSuggestionsTests(PlaylistSuggestionsRouteTestCase):
             "mb_trackid": "ffffffff-ffff-ffff-ffff-ffffffffffff",
             "decision_version": best["decision_version"],
         }])
-        self.assertEqual(status, 200)
-        self.assertEqual(body["applied"], [])
+        self.assertEqual(status, 409)
+        self.assertEqual(body["applied"] if "applied" in body else [], [])
         self.assertEqual(len(body["conflicts"]), 1)
         self.assertEqual(body["conflicts"][0]["code"], "candidate_not_in_trusted_set")
         self.assertEqual(before, self._manifest_tracks())
@@ -335,11 +401,11 @@ class ApplySafeSuggestionsTests(PlaylistSuggestionsRouteTestCase):
     def test_unknown_track_key_is_reported_stale_without_mutation(self):
         self._seed_missing_tracks([{"artist": "Someone", "title": "Some Song"}])
         status, body = self._apply_suggestions([{
-            "track_key": "ptk_doesnotexist",
+            "track_key": "ptr_doesnotexist",
             "decision_version": "drv2:whatever",
         }])
         self.assertEqual(status, 409)
-        self.assertEqual(body["code"], "playlist_suggestions_stale")
+        self.assertEqual(body["code"], "playlist_track_not_found")
         self.assertEqual(body["stale"][0]["code"], "playlist_track_not_found")
 
     def test_stale_decision_version_is_rejected_without_mutation(self):
@@ -367,16 +433,18 @@ class ApplySafeSuggestionsTests(PlaylistSuggestionsRouteTestCase):
         candidate = row["suggestions"][0] if row["suggestions"] else None
         self.assertIsNotNone(candidate, "expected a (review-required) candidate for this fixture")
         self.assertFalse(candidate["decision"]["action_eligibility"]["playlist_resolve_without_review"])
+        before = self._manifest_tracks()
         status, apply_body = self._apply_suggestions([{
             "track_key": row["track_key"],
             "item_id": candidate.get("item_id"),
             "mb_trackid": candidate.get("mb_trackid") or "",
             "decision_version": candidate["decision_version"],
         }])
-        self.assertEqual(status, 200)
-        self.assertEqual(apply_body["applied"], [])
+        self.assertEqual(status, 409)
+        self.assertEqual(apply_body["code"], "playlist_review_required")
         self.assertEqual(len(apply_body["skipped_review"]), 1)
         self.assertEqual(apply_body["skipped_review"][0]["code"], "playlist_review_required")
+        self.assertEqual(before, self._manifest_tracks())
 
     def test_client_supplied_fields_beyond_the_minimal_shape_are_ignored(self):
         """Submitting extra safety-shaped fields (safe/confidence/conflicts)
@@ -407,9 +475,245 @@ class ApplySafeSuggestionsTests(PlaylistSuggestionsRouteTestCase):
             "safe": True,
             "action_eligibility": {"playlist_resolve_without_review": True, "attach_without_review": True},
         }])
-        self.assertEqual(status, 200)
-        self.assertEqual(body["applied"], [])
+        self.assertEqual(status, 409)
         self.assertEqual(body["conflicts"][0]["code"], "candidate_not_in_trusted_set")
+
+    def test_missing_decision_version_is_rejected_as_malformed(self):
+        track_key, best = self._safe_submission()
+        before = self._manifest_tracks()
+        status, body = self._apply_suggestions([{
+            "track_key": track_key,
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+        }])
+        self.assertEqual(status, 400)
+        self.assertEqual(body["code"], "decision_version_required")
+        self.assertEqual(body["invalid"][0]["code"], "decision_version_required")
+        self.assertEqual(before, self._manifest_tracks())
+        self.assertFalse(body.get("changed", False))
+        _rows, total_for_playlist = APP.transactions.list(
+            operation="Playlist Match", query=self.clean_name)
+        self.assertEqual(total_for_playlist, 0)
+
+    def test_empty_decision_version_is_rejected_as_malformed(self):
+        track_key, best = self._safe_submission()
+        status, body = self._apply_suggestions([{
+            "track_key": track_key,
+            "mb_trackid": best.get("mb_trackid") or "",
+            "decision_version": "   ",
+        }])
+        self.assertEqual(status, 400)
+        self.assertEqual(body["code"], "decision_version_required")
+
+    def test_forged_decision_version_cannot_bypass_the_requirement(self):
+        """A row that supplies *some* decision_version string (even a
+        forged one) is not malformed -- it must be rejected for staleness,
+        never silently trusted."""
+        track_key, best = self._safe_submission()
+        status, body = self._apply_suggestions([{
+            "track_key": track_key,
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+            "decision_version": "drv2:0000000000000000000000",
+        }])
+        self.assertEqual(status, 409)
+        self.assertEqual(body["code"], "playlist_suggestions_stale")
+
+    def test_duplicate_submission_with_different_candidates_is_rejected(self):
+        track_key, best = self._safe_submission()
+        before = self._manifest_tracks()
+        status, body = self._apply_suggestions([
+            {
+                "track_key": track_key,
+                "mb_trackid": best.get("mb_trackid") or "",
+                "item_id": best.get("item_id"),
+                "decision_version": best["decision_version"],
+            },
+            {
+                "track_key": track_key,
+                "mb_trackid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "decision_version": "drv2:different",
+            },
+        ])
+        self.assertEqual(status, 409)
+        self.assertEqual(body["conflicts"][0]["code"], "playlist_duplicate_submission")
+        self.assertEqual(before, self._manifest_tracks())
+
+    def test_duplicate_identical_submission_is_deduplicated_not_double_applied(self):
+        track_key, best = self._safe_submission()
+        row = {
+            "track_key": track_key,
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+            "decision_version": best["decision_version"],
+        }
+        status, body = self._apply_suggestions([dict(row), dict(row)])
+        self.assertEqual(status, 200)
+        self.assertEqual(len(body["applied"]), 1)
+
+
+class AcoustIdEvidenceStateTests(unittest.TestCase):
+    """Direct unit coverage of APP._playlist_acoustid_evidence's truthful,
+    non-contradictory fingerprint state model (no Flask needed)."""
+
+    def setUp(self):
+        if APP is None:
+            self.skipTest(f"app import failed: {_APP_IMPORT_ERROR}")
+
+    def test_no_path_is_not_attempted(self):
+        result = APP._playlist_acoustid_evidence("", "some-mbid")
+        self.assertEqual(result, {"attempted": False, "matched": False, "status": "not_attempted", "mapped_recording_id": ""})
+
+    def test_lookup_exception_is_lookup_failed_not_no_evidence(self):
+        with mock.patch.object(APP, "_acoustid_fingerprint_ids", side_effect=RuntimeError("fpcalc missing")):
+            result = APP._playlist_acoustid_evidence("/music/track.flac", "some-mbid")
+        self.assertEqual(result["attempted"], True)
+        self.assertEqual(result["matched"], False)
+        self.assertEqual(result["status"], "lookup_failed")
+        self.assertEqual(result["mapped_recording_id"], "")
+
+    def test_no_returned_ids_is_no_match(self):
+        with mock.patch.object(APP, "_acoustid_fingerprint_ids", return_value=[]):
+            result = APP._playlist_acoustid_evidence("/music/track.flac", "some-mbid")
+        self.assertEqual(result["status"], "no_match")
+        self.assertEqual(result["mapped_recording_id"], "")
+
+    def test_matching_id_is_matched(self):
+        with mock.patch.object(APP, "_acoustid_fingerprint_ids", return_value=["mbid-a", "mbid-b"]):
+            result = APP._playlist_acoustid_evidence("/music/track.flac", "mbid-a")
+        self.assertEqual(result["status"], "matched")
+        self.assertTrue(result["matched"])
+        self.assertEqual(result["mapped_recording_id"], "mbid-a")
+
+    def test_disagreeing_id_is_conflict_not_silently_matched(self):
+        with mock.patch.object(APP, "_acoustid_fingerprint_ids", return_value=["mbid-other"]):
+            result = APP._playlist_acoustid_evidence("/music/track.flac", "mbid-a")
+        self.assertEqual(result["status"], "conflict")
+        self.assertFalse(result["matched"])
+        self.assertEqual(result["mapped_recording_id"], "mbid-other")
+
+    def test_ids_with_no_local_recording_id_is_mapped_unverified(self):
+        with mock.patch.object(APP, "_acoustid_fingerprint_ids", return_value=["mbid-x", "mbid-y"]):
+            result = APP._playlist_acoustid_evidence("/music/track.flac", "")
+        self.assertEqual(result["status"], "mapped_unverified")
+        self.assertFalse(result["matched"])
+        self.assertEqual(result["mapped_recording_id"], "mbid-x")
+
+    def test_conflict_state_feeds_into_the_contract_as_a_hard_mismatch(self):
+        """The 'conflict' status must reach build_recording_matching_decision
+        as a genuine fingerprint conflict (never neutral/no-evidence),
+        blocking both attach and playlist-library eligibility."""
+        from backend.matching_contract import build_recording_matching_decision
+        candidate = {
+            "artist": "M83", "title": "Midnight City", "source": "beets", "item_id": 1,
+            "mb_trackid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "fingerprint_attempted": True, "fingerprint_matched": False,
+            "fingerprint_status": "conflict",
+            "mapped_recording_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        }
+        decision = build_recording_matching_decision(
+            current={"title": "Midnight City", "artist": "M83"},
+            candidate=candidate,
+            library_identity_verified=True,
+        ).to_dict()
+        self.assertIn("fingerprint_conflict", decision["decision"]["conflicts"])
+        self.assertFalse(decision["decision"]["action_eligibility"]["playlist_resolve_without_review"])
+
+
+class ExactRowIdentityTests(PlaylistSuggestionsRouteTestCase):
+    """Section 6: persisted-state verification and rollback must key off
+    the exact manifest row_id, never "any row with this text" -- which
+    could double-count one persisted row as proof of two different
+    changes."""
+
+    def test_two_distinct_rows_resolving_to_the_same_identity_both_verify_independently(self):
+        self._set_library_items([_fake_lib_item()])
+        self._seed_missing_tracks([
+            {"artist": "M83", "title": "Midnight  City"},
+            {"artist": "M83", "title": "Midnight   City"},
+        ])
+        _, body = self._get_suggestions()
+        self.assertEqual(body["total_missing"], 2)
+        submissions = []
+        for row in body["rows"]:
+            best = row["best"]
+            self.assertIsNotNone(best)
+            submissions.append({
+                "track_key": row["track_key"],
+                "mb_trackid": best.get("mb_trackid") or "",
+                "item_id": best.get("item_id"),
+                "decision_version": best["decision_version"],
+            })
+        status, apply_body = self._apply_suggestions(submissions)
+        self.assertEqual(status, 200)
+        self.assertEqual(len(apply_body["applied"]), 2)
+        tracks = self._manifest_tracks()
+        resolved = [t for t in tracks if t.get("artist") == "M83" and t.get("title") == "Midnight City"]
+        self.assertEqual(len(resolved), 2)
+        # Both rows kept their own distinct row_id through the resolution.
+        self.assertEqual(len({t.get("row_id") for t in resolved}), 2)
+        tx = APP.transactions.get(apply_body["audit_id"])
+        self.assertEqual(len(tx["changes"]), 2)
+        row_ids_in_changes = {c["row_id"] for c in tx["changes"]}
+        self.assertEqual(row_ids_in_changes, {s["track_key"] for s in submissions})
+
+    def test_pre_existing_unrelated_row_with_target_identity_does_not_confuse_verification(self):
+        self._set_library_items([_fake_lib_item()])
+        # Seed a missing row we intend to resolve, PLUS an already-matched
+        # row that happens to already carry the exact target identity
+        # ("Midnight City") -- this pre-existing row must never be mistaken
+        # for proof that the *other* row's replacement landed.
+        self._seed_missing_tracks([
+            {"artist": "M83", "title": "Midnight City"},
+            {"artist": "M83", "title": "Midnight  City"},
+        ])
+        manifest_before = self._manifest_tracks()
+        preexisting_row_id = next(
+            t["row_id"] for t in manifest_before if t.get("title") == "Midnight City"
+        )
+        _, body = self._get_suggestions()
+        target_row = next(r for r in body["rows"] if r["track_key"] != preexisting_row_id)
+        best = target_row["best"]
+        self.assertIsNotNone(best)
+        status, apply_body = self._apply_suggestions([{
+            "track_key": target_row["track_key"],
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+            "decision_version": best["decision_version"],
+        }])
+        self.assertEqual(status, 200)
+        self.assertEqual(len(apply_body["applied"]), 1)
+        self.assertEqual(apply_body["applied"][0]["track_key"], target_row["track_key"])
+        tracks = self._manifest_tracks()
+        resolved_target = next(t for t in tracks if t["row_id"] == target_row["track_key"])
+        self.assertEqual(resolved_target["title"], "Midnight City")
+        # The pre-existing row is untouched and still has its own row_id.
+        preexisting_after = next(t for t in tracks if t["row_id"] == preexisting_row_id)
+        self.assertEqual(preexisting_after["title"], "Midnight City")
+
+
+class LibraryIdentityFreshReadTests(PlaylistSuggestionsRouteTestCase):
+    """Section 10: library-identity verification must re-read the exact
+    item by id and confirm it still exists -- never trust a cached index
+    payload alone."""
+
+    def test_deleted_item_cannot_stay_safe_from_cached_candidate_data(self):
+        item = _fake_lib_item()
+        self._set_library_items([item])
+        self._seed_missing_tracks([{"artist": "M83", "title": "Midnight  City"}])
+        _, body = self._get_suggestions()
+        self.assertEqual(body["safe_count"], 1, "expected the exact match to be safe before deletion")
+
+        # The item is deleted from the library (e.g. file removed) but the
+        # cached library index (built before the deletion) hasn't been
+        # invalidated yet -- a stale candidate must not be offered as safe.
+        self._lib_items = []
+        status, body2 = self._get_suggestions()
+        self.assertEqual(status, 200)
+        self.assertEqual(body2["safe_count"], 0)
+        best = body2["rows"][0]["best"]
+        if best is not None:
+            self.assertFalse(best["decision"]["action_eligibility"]["playlist_resolve_without_review"])
 
 
 if __name__ == "__main__":

--- a/tests/test_playlist_safe_suggestions.py
+++ b/tests/test_playlist_safe_suggestions.py
@@ -1,0 +1,416 @@
+"""Route-level tests for the playlist missing-track-suggestions migration
+to the shared backend-authoritative matching contract (the same contract
+PR #19 enforces for Import Review's attach-recording endpoint):
+
+  GET  /api/playlists/<name>/suggestions
+  POST /api/playlists/<name>/apply-safe-suggestions
+
+Imports the real app.py (same isolated-temp-environment pattern as
+tests/test_import_review_attach_enforcement.py) and drives the actual
+Flask routes. The Beets library is a fake object (no real Beets/SQLite
+item semantics needed for these matching-decision-shaped tests); AcoustID
+lookups and MusicBrainz recording search are patched out so tests are
+deterministic and never touch the network.
+
+Concurrency (reservation), rollback, and secret-redaction coverage live in
+tests/test_playlist_suggestion_integrity.py, which imports this module's
+harness rather than re-deriving it.
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+import unittest.mock as mock
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_TMP_ROOT = Path(tempfile.mkdtemp(prefix="beets_playlist_suggestions_"))
+unittest.addModuleCleanup(shutil.rmtree, str(_TMP_ROOT), ignore_errors=True)
+
+_ENV_OVERRIDES = {
+    "BEETSDIR": str(_TMP_ROOT / "config"),
+    "LIB_PATH": str(_TMP_ROOT / "config" / "musiclibrary.blb"),
+    "AI_BATCH_STATE_DIR": str(_TMP_ROOT / "ai_batch_jobs"),
+    "METADATA_CACHE_DIR": str(_TMP_ROOT / "cache"),
+    "BEETS_TRANSACTION_DIR": str(_TMP_ROOT / "transactions"),
+    "PLAYLIST_DIR": str(_TMP_ROOT / "playlists"),
+    "PLAYLIST_DOWNLOAD_ROOT": str(_TMP_ROOT / "playlist_downloads"),
+    "BEETS_WEB_AUTH_DISABLED": "1",
+}
+(_TMP_ROOT / "config").mkdir(parents=True, exist_ok=True)
+(_TMP_ROOT / "playlists").mkdir(parents=True, exist_ok=True)
+_env_patcher = mock.patch.dict(os.environ, _ENV_OVERRIDES, clear=False)
+_env_patcher.start()
+unittest.addModuleCleanup(_env_patcher.stop)
+
+
+def setUpModule():
+    # Other test modules sharing this process may mutate BEETS_WEB_AUTH_*
+    # without reverting (see test_import_review_attach_enforcement.py's
+    # identical comment for the incident this guards against).
+    os.environ.update(_ENV_OVERRIDES)
+
+
+def _import_app():
+    sys.path.insert(0, str(ROOT))
+    import app as app_module
+    return app_module
+
+
+try:
+    APP = _import_app()
+    _APP_IMPORT_ERROR = None
+except Exception as exc:  # pragma: no cover - environment-dependent
+    APP = None
+    _APP_IMPORT_ERROR = exc
+
+
+def _fake_lib_item(**overrides):
+    # The playlist matcher also derives artist/title guesses from the file
+    # path (_playlist_item_text_variants), so the default path must stay in
+    # sync with title/artist -- otherwise a test overriding only `title`
+    # would still exact-match via the stale default path's filename text.
+    title = overrides.get("title", "Midnight City")
+    artist = overrides.get("artist", "M83")
+    base = dict(
+        id=1, title=title, artist=artist, albumartist=artist,
+        album="Hurry Up, We're Dreaming", path=f"/music/{artist}/{title}.flac",
+        mb_trackid="", mb_albumid="", mb_releasegroupid="",
+        length=244.0, bitrate=320000, format="FLAC",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class PlaylistSuggestionsRouteTestCase(unittest.TestCase):
+    """Shared harness: isolated per-test playlist, a fake Beets library the
+    test controls directly, and no real AcoustID/MusicBrainz network
+    access. Subclasses/other modules should use self._set_library_items()
+    and self._seed_missing_tracks() rather than touching APP globals
+    directly."""
+
+    def setUp(self):
+        if APP is None:  # pragma: no cover - environment-dependent
+            self.skipTest(f"app import failed: {_APP_IMPORT_ERROR}")
+        self.client = APP.app.test_client()
+        self.playlist_name = f"Test Playlist {uuid.uuid4().hex[:8]}"
+        self.clean_name = APP._clean_playlist_name(self.playlist_name)
+        self._lib_items = []
+        self._mb_candidates = []
+
+        fake_lib = SimpleNamespace(
+            items=lambda q=None: list(self._lib_items),
+            get_item=lambda iid: next((i for i in self._lib_items if i.id == iid), None),
+        )
+        self._patch(APP, "lib", fake_lib)
+        self._patch(APP, "_acoustid_fingerprint_ids", lambda path, limit=5: [])
+        self._patch(
+            APP, "_playlist_recording_search_candidates",
+            lambda title, artist, current_mbid="": list(self._mb_candidates),
+        )
+        APP._invalidate_lib_cache()
+
+    def _patch(self, target, name, value):
+        patcher = mock.patch.object(target, name, value)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _set_library_items(self, items):
+        self._lib_items = items
+        APP._invalidate_lib_cache()
+
+    def _set_mb_candidates(self, candidates):
+        self._mb_candidates = candidates
+
+    def _seed_missing_tracks(self, tracks):
+        """Writes tracks directly into the playlist's desired-track
+        manifest (the real, atomic manifest-write path) so the route
+        under test sees them as "missing" for any track that doesn't
+        fuzzy-match a current fake library item."""
+        APP._playlist_write_manifest(self.clean_name, tracks, source="test")
+
+    def _get_suggestions(self, **params):
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        url = f"/api/playlists/{self.clean_name}/suggestions"
+        if qs:
+            url += f"?{qs}"
+        resp = self.client.get(url)
+        return resp.status_code, resp.get_json()
+
+    def _apply_suggestions(self, suggestions):
+        resp = self.client.post(
+            f"/api/playlists/{self.clean_name}/apply-safe-suggestions",
+            data=json.dumps({"suggestions": suggestions}),
+            content_type="application/json",
+        )
+        return resp.status_code, resp.get_json()
+
+    def _manifest_tracks(self):
+        manifest = APP._playlist_read_manifest(self.clean_name)
+        return APP._playlist_clean_track_list(manifest.get("desired_tracks") or [])
+
+
+class SuggestionsEndpointTests(PlaylistSuggestionsRouteTestCase):
+    def test_playlist_not_found_returns_structured_code(self):
+        resp = self.client.get("/api/playlists/does-not-exist-xyz/suggestions")
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.get_json()["code"], "playlist_not_found")
+
+    def test_exact_library_match_is_reported_safe_with_decision_fields(self):
+        # "Midnight  City" (double space) fails app.py's own strict, exact-
+        # normalized matched-vs-missing classifier (so this track stays
+        # "missing" going into the suggestions endpoint), while the shared
+        # matching contract's whitespace-collapsing similarity treats it as
+        # identical to the library item's real title -- exactly the "video
+        # title needs light cleanup" case suggestions exist to fix.
+        self._set_library_items([_fake_lib_item()])
+        self._seed_missing_tracks([{"artist": "M83", "title": "Midnight  City"}])
+
+        status, body = self._get_suggestions()
+        self.assertEqual(status, 200)
+        self.assertEqual(body["total_missing"], 1)
+        self.assertEqual(body["safe_count"], 1)
+        row = body["rows"][0]
+        self.assertTrue(row["track_key"])
+        best = row["best"]
+        self.assertEqual(best["source"], "beets")
+        self.assertEqual(best["item_id"], 1)
+        self.assertTrue(best["decision_version"].startswith("drv2:"))
+        self.assertTrue(best["decision"]["action_eligibility"]["playlist_resolve_without_review"])
+        self.assertFalse(best["decision"]["action_eligibility"]["attach_without_review"])
+        # Deprecated legacy fields stay in sync with the decision.
+        self.assertTrue(best["safe"])
+        self.assertEqual(best["reason"], best["decision"]["eligibility_reason"])
+
+    def test_no_candidates_reports_review_required_not_safe(self):
+        self._set_library_items([])
+        self._seed_missing_tracks([{"artist": "Nobody Known", "title": "Totally Obscure Song"}])
+        status, body = self._get_suggestions()
+        self.assertEqual(status, 200)
+        self.assertEqual(body["safe_count"], 0)
+        self.assertEqual(body["rows"][0]["suggestions"], [])
+        self.assertIsNone(body["rows"][0]["best"])
+
+    def test_fuzzy_title_mismatch_is_not_safe(self):
+        self._set_library_items([_fake_lib_item(title="A Totally Different Song")])
+        self._seed_missing_tracks([{"artist": "M83", "title": "Midnight City"}])
+        status, body = self._get_suggestions()
+        self.assertEqual(body["safe_count"], 0)
+
+    def test_duplicate_titles_get_distinct_track_keys(self):
+        # The desired-track manifest itself deduplicates identical
+        # (artist, title) entries (_playlist_merge_desired_tracks) -- a
+        # playlist that intentionally repeats a song surfaces as repeated
+        # rows in the *missing* list this function is given, not as
+        # duplicate manifest entries. Exercise the key generator directly
+        # against two such rows, exactly as the routes call it.
+        rows = APP._playlist_missing_rows_with_keys(self.clean_name, [
+            {"artist": "Repeat Artist", "title": "Same Song"},
+            {"artist": "Repeat Artist", "title": "Same Song"},
+        ])
+        keys = [key for key, _track in rows]
+        self.assertEqual(len(keys), 2)
+        self.assertNotEqual(keys[0], keys[1])
+        # Deterministic: recomputing for the identical input list reproduces
+        # the same two keys in the same order.
+        rows_again = APP._playlist_missing_rows_with_keys(self.clean_name, [
+            {"artist": "Repeat Artist", "title": "Same Song"},
+            {"artist": "Repeat Artist", "title": "Same Song"},
+        ])
+        self.assertEqual(keys, [key for key, _track in rows_again])
+
+    def test_client_cannot_disable_musicbrainz_and_get_a_safer_result(self):
+        """musicbrainz=0 only narrows the *displayed* candidate set; it must
+        never change the safety outcome for an otherwise-identical apply."""
+        self._set_library_items([_fake_lib_item()])
+        self._seed_missing_tracks([{"artist": "M83", "title": "Midnight  City"}])
+        _, with_mb = self._get_suggestions(musicbrainz=1)
+        _, without_mb = self._get_suggestions(musicbrainz=0)
+        self.assertEqual(with_mb["safe_count"], without_mb["safe_count"])
+
+
+class ApplySafeSuggestionsTests(PlaylistSuggestionsRouteTestCase):
+    def _safe_submission(self):
+        self._set_library_items([_fake_lib_item()])
+        self._seed_missing_tracks([{"artist": "M83", "title": "Midnight  City"}])
+        _, body = self._get_suggestions()
+        best = body["rows"][0]["best"]
+        return body["rows"][0]["track_key"], best
+
+    def test_playlist_not_found_returns_404(self):
+        resp = self.client.post(
+            "/api/playlists/does-not-exist-xyz/apply-safe-suggestions",
+            data=json.dumps({"suggestions": []}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.get_json()["code"], "playlist_not_found")
+
+    def test_empty_batch_is_a_no_op(self):
+        self._seed_missing_tracks([{"artist": "Solo Artist", "title": "Solo Song"}])
+        status, body = self._apply_suggestions([])
+        self.assertEqual(status, 200)
+        self.assertFalse(body["changed"])
+        self.assertEqual(body["applied"], [])
+
+    def test_safe_row_is_applied_and_manifest_verified(self):
+        track_key, best = self._safe_submission()
+        status, body = self._apply_suggestions([{
+            "track_key": track_key,
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+            "decision_version": best["decision_version"],
+        }])
+        self.assertEqual(status, 200)
+        self.assertTrue(body["changed"])
+        self.assertEqual(len(body["applied"]), 1)
+        self.assertTrue(body["audit_id"])
+        tracks = self._manifest_tracks()
+        self.assertTrue(any(t.get("artist") == "M83" and t.get("title") == "Midnight City" for t in tracks))
+        tx = APP.transactions.get(body["audit_id"])
+        self.assertEqual(tx["status"], "Completed")
+        self.assertEqual(tx["operation_type"], "Playlist Match")
+
+    def test_mixed_batch_applies_safe_row_and_reports_stale_row_at_200(self):
+        """A batch with at least one non-stale outcome returns 200 with
+        per-row buckets -- only a batch where every row is stale (nothing
+        else to report) escalates to a whole-batch 409."""
+        track_key, best = self._safe_submission()
+        status, body = self._apply_suggestions([
+            {
+                "track_key": track_key,
+                "mb_trackid": best.get("mb_trackid") or "",
+                "item_id": best.get("item_id"),
+                "decision_version": best["decision_version"],
+            },
+            {"track_key": "ptk_unrelated_missing", "decision_version": "drv2:x"},
+        ])
+        self.assertEqual(status, 200)
+        self.assertEqual(len(body["applied"]), 1)
+        self.assertEqual(len(body["stale"]), 1)
+        self.assertEqual(body["stale"][0]["track_key"], "ptk_unrelated_missing")
+
+    def test_reapplying_the_same_row_is_unchanged_not_duplicated(self):
+        track_key, best = self._safe_submission()
+        row = {
+            "track_key": track_key,
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+            "decision_version": best["decision_version"],
+        }
+        status1, body1 = self._apply_suggestions([row])
+        self.assertEqual(len(body1["applied"]), 1)
+        first_audit_id = body1["audit_id"]
+
+        # Recompute suggestions fresh -- the track has moved from "missing"
+        # into "matched" now that its manifest identity equals the library
+        # item, so a second identical apply request has nothing left to
+        # find under the *original* track_key. With no other rows in the
+        # batch this is reported as a whole-batch stale 409 (never silently
+        # re-applied or re-audited), matching the single-row-batch case.
+        status2, body2 = self._apply_suggestions([row])
+        self.assertEqual(status2, 409)
+        self.assertEqual(body2["code"], "playlist_suggestions_stale")
+        self.assertEqual(body2["stale"][0]["track_key"], track_key)
+
+    def test_untrusted_candidate_is_rejected_without_mutation(self):
+        track_key, best = self._safe_submission()
+        before = self._manifest_tracks()
+        status, body = self._apply_suggestions([{
+            "track_key": track_key,
+            "mb_trackid": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "decision_version": best["decision_version"],
+        }])
+        self.assertEqual(status, 200)
+        self.assertEqual(body["applied"], [])
+        self.assertEqual(len(body["conflicts"]), 1)
+        self.assertEqual(body["conflicts"][0]["code"], "candidate_not_in_trusted_set")
+        self.assertEqual(before, self._manifest_tracks())
+
+    def test_unknown_track_key_is_reported_stale_without_mutation(self):
+        self._seed_missing_tracks([{"artist": "Someone", "title": "Some Song"}])
+        status, body = self._apply_suggestions([{
+            "track_key": "ptk_doesnotexist",
+            "decision_version": "drv2:whatever",
+        }])
+        self.assertEqual(status, 409)
+        self.assertEqual(body["code"], "playlist_suggestions_stale")
+        self.assertEqual(body["stale"][0]["code"], "playlist_track_not_found")
+
+    def test_stale_decision_version_is_rejected_without_mutation(self):
+        track_key, best = self._safe_submission()
+        before = self._manifest_tracks()
+        status, body = self._apply_suggestions([{
+            "track_key": track_key,
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+            "decision_version": "drv2:0000000000000000000000",
+        }])
+        self.assertEqual(status, 409)
+        self.assertEqual(body["code"], "playlist_suggestions_stale")
+        self.assertEqual(before, self._manifest_tracks())
+
+    def test_review_required_row_is_skipped_not_applied(self):
+        # "Midnight City Anthem" scores just high enough (~0.79) to surface
+        # as a candidate but well below the deterministic-match bar
+        # (library bypass needs >=0.94) -- exactly the "fuzzy title with no
+        # further corroboration must require review" case from the spec.
+        self._set_library_items([_fake_lib_item(title="Midnight City Anthem")])
+        self._seed_missing_tracks([{"artist": "M83", "title": "Midnight City"}])
+        _, body = self._get_suggestions()
+        row = body["rows"][0]
+        candidate = row["suggestions"][0] if row["suggestions"] else None
+        self.assertIsNotNone(candidate, "expected a (review-required) candidate for this fixture")
+        self.assertFalse(candidate["decision"]["action_eligibility"]["playlist_resolve_without_review"])
+        status, apply_body = self._apply_suggestions([{
+            "track_key": row["track_key"],
+            "item_id": candidate.get("item_id"),
+            "mb_trackid": candidate.get("mb_trackid") or "",
+            "decision_version": candidate["decision_version"],
+        }])
+        self.assertEqual(status, 200)
+        self.assertEqual(apply_body["applied"], [])
+        self.assertEqual(len(apply_body["skipped_review"]), 1)
+        self.assertEqual(apply_body["skipped_review"][0]["code"], "playlist_review_required")
+
+    def test_client_supplied_fields_beyond_the_minimal_shape_are_ignored(self):
+        """Submitting extra safety-shaped fields (safe/confidence/conflicts)
+        must have zero effect -- only track_key/mb_trackid/item_id/
+        decision_version are ever read."""
+        track_key, best = self._safe_submission()
+        status, body = self._apply_suggestions([{
+            "track_key": track_key,
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+            "decision_version": best["decision_version"],
+            "safe": True,
+            "confidence": 1.0,
+            "conflicts": [],
+            "action_eligibility": {"playlist_resolve_without_review": True},
+        }])
+        self.assertEqual(status, 200)
+        self.assertEqual(len(body["applied"]), 1)
+
+    def test_untrusted_candidate_with_forged_safety_still_rejected(self):
+        """A row claiming an arbitrary UUID plus forged safety fields must
+        still be rejected -- the backend never trusts client safety claims."""
+        track_key, _ = self._safe_submission()
+        status, body = self._apply_suggestions([{
+            "track_key": track_key,
+            "mb_trackid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "decision_version": "drv2:forged",
+            "safe": True,
+            "action_eligibility": {"playlist_resolve_without_review": True, "attach_without_review": True},
+        }])
+        self.assertEqual(status, 200)
+        self.assertEqual(body["applied"], [])
+        self.assertEqual(body["conflicts"][0]["code"], "candidate_not_in_trusted_set")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_playlist_suggestion_frontend.py
+++ b/tests/test_playlist_suggestion_frontend.py
@@ -76,14 +76,67 @@ class PlaylistSuggestionPageTests(unittest.TestCase):
         self.assertNotIn("safe: true", region)
         self.assertNotIn("row.best?.safe,", region)
 
-    def test_apply_handler_reports_all_outcome_buckets(self):
+    def test_apply_handler_reports_success_outcome_counts(self):
         region = PAGE_SOURCE[
             PAGE_SOURCE.index("const handleApplySafeSuggestions"):
             PAGE_SOURCE.index("const handleRepairQualityRows")
         ]
-        for bucket in ("result.applied", "result.unchanged", "result.skipped_review",
-                      "result.conflicts", "result.stale"):
-            self.assertIn(bucket, region)
+        self.assertIn("result.applied", region)
+        self.assertIn("result.unchanged", region)
+
+    def test_apply_handler_uses_structured_error_body(self):
+        region = PAGE_SOURCE[
+            PAGE_SOURCE.index("const handleApplySafeSuggestions"):
+            PAGE_SOURCE.index("const handleRepairQualityRows")
+        ]
+        self.assertIn("apiErrorBody(err)", region)
+        self.assertIn("body?.code", region)
+
+    def test_apply_handler_refreshes_on_stale_without_clearing_first(self):
+        region = PAGE_SOURCE[
+            PAGE_SOURCE.index("const handleApplySafeSuggestions"):
+            PAGE_SOURCE.index("const handleRepairQualityRows")
+        ]
+        self.assertIn("'playlist_suggestions_stale'", region)
+        self.assertIn("handleLoadSuggestions()", region)
+        # The catch branch must not itself clear suggestionRows -- only the
+        # try (full-success) branch above does.
+        catch_start = region.index("} catch (err) {")
+        catch_region = region[catch_start:]
+        self.assertNotIn("setSuggestionRows([])", catch_region)
+
+    def test_apply_handler_handles_update_in_progress_without_clearing_rows(self):
+        region = PAGE_SOURCE[
+            PAGE_SOURCE.index("const handleApplySafeSuggestions"):
+            PAGE_SOURCE.index("const handleRepairQualityRows")
+        ]
+        self.assertIn("'playlist_update_in_progress'", region)
+
+    def test_apply_handler_reports_batch_rejected_counts_without_clearing_rows(self):
+        region = PAGE_SOURCE[
+            PAGE_SOURCE.index("const handleApplySafeSuggestions"):
+            PAGE_SOURCE.index("const handleRepairQualityRows")
+        ]
+        for code in (
+            "'playlist_batch_rejected'", "'playlist_review_required'", "'playlist_conflict'",
+            "'candidate_not_in_trusted_set'", "'decision_version_required'",
+            "'playlist_duplicate_submission'",
+        ):
+            self.assertIn(code, region)
+        self.assertIn("body?.stale?.length", region)
+        self.assertIn("body?.conflicts?.length", region)
+        self.assertIn("body?.skipped_review?.length", region)
+        self.assertIn("body?.invalid?.length", region)
+
+    def test_apply_handler_clears_rows_only_in_the_success_path(self):
+        region = PAGE_SOURCE[
+            PAGE_SOURCE.index("const handleApplySafeSuggestions"):
+            PAGE_SOURCE.index("const handleRepairQualityRows")
+        ]
+        try_start = region.index("try {")
+        catch_start = region.index("} catch (err) {")
+        try_region = region[try_start:catch_start]
+        self.assertIn("setSuggestionRows([])", try_region)
 
     def test_apply_handler_refreshes_detail_after_apply_not_from_response(self):
         """The apply response itself no longer carries a full playlist-detail

--- a/tests/test_playlist_suggestion_frontend.py
+++ b/tests/test_playlist_suggestion_frontend.py
@@ -1,0 +1,107 @@
+"""Static-source assertions for the playlist suggestions frontend
+migration -- same convention as tests/test_playlist_saved_discovery.py and
+tests/test_playlist_backend_job.py: read the actual frontend source and
+assert the properties that matter aren't silently regressed, without
+needing a JS/TS test runner in this Python test suite.
+
+Covers section 14 of the migration: the frontend displays backend-
+computed decision fields, never calculates safety itself, submits only
+the minimal (track_key/mb_trackid/item_id/decision_version) shape, and
+handles the stale/in-progress error codes.
+"""
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIENT_SOURCE = (ROOT / "frontend" / "src" / "api" / "client.ts").read_text(encoding="utf-8")
+TYPES_SOURCE = (ROOT / "frontend" / "src" / "api" / "types.ts").read_text(encoding="utf-8")
+PAGE_SOURCE = (ROOT / "frontend" / "src" / "views" / "Playlists.tsx").read_text(encoding="utf-8")
+
+
+class PlaylistSuggestionTypesTests(unittest.TestCase):
+    def test_decision_shaped_types_are_declared(self):
+        self.assertIn("interface PlaylistSuggestionDecision", TYPES_SOURCE)
+        self.assertIn("action_eligibility: PlaylistActionEligibility", TYPES_SOURCE)
+        self.assertIn("playlist_resolve_without_review: boolean", TYPES_SOURCE)
+        self.assertIn("decision_version: string", TYPES_SOURCE)
+        self.assertIn("decision: PlaylistSuggestionDecision", TYPES_SOURCE)
+
+    def test_legacy_fields_are_marked_deprecated(self):
+        region = TYPES_SOURCE[
+            TYPES_SOURCE.index("export interface PlaylistTrackSuggestion"):
+            TYPES_SOURCE.index("export interface PlaylistSuggestionRow")
+        ]
+        for field in ("confidence", "safe", "reason"):
+            self.assertIn(f"@deprecated", region)
+        self.assertIn("@deprecated use decision.confidence_score", region)
+        self.assertIn("@deprecated use decision.action_eligibility.playlist_resolve_without_review", region)
+        self.assertIn("@deprecated use decision.eligibility_reason", region)
+
+    def test_minimal_submission_type_excludes_safety_fields(self):
+        region = TYPES_SOURCE[
+            TYPES_SOURCE.index("export interface PlaylistSuggestionSubmission"):
+            TYPES_SOURCE.index("export interface PlaylistSuggestionOutcomeRow")
+        ]
+        self.assertIn("track_key: string", region)
+        self.assertIn("decision_version: string", region)
+        for forbidden in ("safe:", "confidence:", "action_eligibility:", "conflicts:", "warnings:"):
+            self.assertNotIn(forbidden, region)
+
+    def test_apply_response_has_bucketed_outcomes(self):
+        region = TYPES_SOURCE[TYPES_SOURCE.index("export interface PlaylistApplySuggestionsResponse"):]
+        region = region[:region.index("\n}\n") + 3]
+        for bucket in ("applied", "unchanged", "skipped_review", "conflicts", "stale"):
+            self.assertIn(bucket, region)
+
+
+class PlaylistSuggestionClientTests(unittest.TestCase):
+    def test_apply_endpoint_sends_only_suggestions_list(self):
+        region = CLIENT_SOURCE[CLIENT_SOURCE.index("export function applySafePlaylistSuggestions"):]
+        region = region[:region.index("\n}\n") + 3]
+        self.assertIn("suggestions: PlaylistSuggestionSubmission[]", region)
+        self.assertIn("{ suggestions }", region)
+        self.assertNotIn("musicbrainz", region)
+
+
+class PlaylistSuggestionPageTests(unittest.TestCase):
+    def test_apply_handler_builds_minimal_submission(self):
+        region = PAGE_SOURCE[
+            PAGE_SOURCE.index("const handleApplySafeSuggestions"):
+            PAGE_SOURCE.index("const handleRepairQualityRows")
+        ]
+        self.assertIn("playlist_resolve_without_review", region)
+        self.assertIn("track_key: row.track_key", region)
+        self.assertIn("decision_version: row.best?.decision_version", region)
+        # Never recomputes or submits a client-side safety verdict.
+        self.assertNotIn("safe: true", region)
+        self.assertNotIn("row.best?.safe,", region)
+
+    def test_apply_handler_reports_all_outcome_buckets(self):
+        region = PAGE_SOURCE[
+            PAGE_SOURCE.index("const handleApplySafeSuggestions"):
+            PAGE_SOURCE.index("const handleRepairQualityRows")
+        ]
+        for bucket in ("result.applied", "result.unchanged", "result.skipped_review",
+                      "result.conflicts", "result.stale"):
+            self.assertIn(bucket, region)
+
+    def test_apply_handler_refreshes_detail_after_apply_not_from_response(self):
+        """The apply response itself no longer carries a full playlist-detail
+        shape (matched/missing tracks) -- the frontend must re-fetch detail
+        rather than assume the apply response has it."""
+        region = PAGE_SOURCE[
+            PAGE_SOURCE.index("const handleApplySafeSuggestions"):
+            PAGE_SOURCE.index("const handleRepairQualityRows")
+        ]
+        self.assertIn("getPlaylistDetails(savedPlaylistName", region)
+        self.assertIn("setParseResult(detail)", region)
+
+    def test_safe_suggestion_count_reads_from_decision_not_legacy_flag(self):
+        self.assertIn(
+            "row.best?.decision?.action_eligibility?.playlist_resolve_without_review",
+            PAGE_SOURCE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_playlist_suggestion_integrity.py
+++ b/tests/test_playlist_suggestion_integrity.py
@@ -1,0 +1,272 @@
+"""Concurrency, rollback, persistence-verification, and secret-redaction
+coverage for the playlist safe-suggestions migration -- the same class of
+hardening tests/test_import_review_attach_integrity.py adds on top of
+tests/test_import_review_attach_enforcement.py for PR #19's attach-
+recording endpoint, applied here to:
+
+  POST /api/playlists/<name>/apply-safe-suggestions
+  POST /api/transactions/<id>/rollback  (playlist_track_restore operations)
+
+Reuses the harness from tests/test_playlist_safe_suggestions.py rather
+than re-deriving the isolated-temp-environment app import.
+"""
+import json
+import threading
+import time
+import unittest
+import unittest.mock as mock
+import uuid
+
+from tests.test_playlist_safe_suggestions import (
+    APP,
+    PlaylistSuggestionsRouteTestCase,
+    _fake_lib_item,
+)
+
+
+def _wait_job(job_id, timeout=10):
+    deadline = time.time() + timeout
+    job = APP.jobs.get(job_id)
+    while job is not None and job.status == "running" and time.time() < deadline:
+        time.sleep(0.02)
+        job = APP.jobs.get(job_id)
+    return job
+
+
+class ConcurrencyTests(PlaylistSuggestionsRouteTestCase):
+    def _safe_row(self):
+        self._set_library_items([_fake_lib_item()])
+        self._seed_missing_tracks([{"artist": "M83", "title": "Midnight  City"}])
+        _, body = self._get_suggestions()
+        row = body["rows"][0]
+        best = row["best"]
+        return {
+            "track_key": row["track_key"],
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+            "decision_version": best["decision_version"],
+        }
+
+    def test_same_playlist_second_apply_gets_409_while_first_is_running(self):
+        row = self._safe_row()
+        entered = threading.Event()
+        release = threading.Event()
+        original = APP._playlist_apply_manifest_replacements
+
+        def slow_apply(*args, **kwargs):
+            entered.set()
+            release.wait(timeout=5)
+            return original(*args, **kwargs)
+
+        results = {}
+
+        def run_first():
+            with mock.patch.object(APP, "_playlist_apply_manifest_replacements", slow_apply):
+                results["first"] = self._apply_suggestions([row])
+
+        t = threading.Thread(target=run_first)
+        t.start()
+        try:
+            self.assertTrue(entered.wait(timeout=5), "first request never entered the critical section")
+            status2, body2 = self._apply_suggestions([row])
+        finally:
+            release.set()
+            t.join(timeout=5)
+
+        self.assertEqual(status2, 409)
+        self.assertEqual(body2["code"], "playlist_update_in_progress")
+        self.assertEqual(results["first"][0], 200)
+        self.assertEqual(len(results["first"][1]["applied"]), 1)
+
+    def test_different_playlists_proceed_concurrently(self):
+        row_a = self._safe_row()
+        other_clean = APP._clean_playlist_name("Other Playlist For Concurrency")
+        APP._playlist_write_manifest(other_clean, [{"artist": "Other Artist", "title": "Other  Song"}], source="test")
+        self._set_library_items(self._lib_items + [_fake_lib_item(id=2, title="Other Song", artist="Other Artist")])
+        APP._invalidate_lib_cache()
+
+        both_entered = threading.Barrier(2, timeout=5)
+        original = APP._playlist_apply_manifest_replacements
+
+        def barrier_apply(*args, **kwargs):
+            both_entered.wait()
+            return original(*args, **kwargs)
+
+        results = {}
+
+        def apply_for(clean_name, key, out_key):
+            resp = self.client.post(
+                f"/api/playlists/{clean_name}/apply-safe-suggestions",
+                data=json.dumps({"suggestions": [key]}),
+                content_type="application/json",
+            )
+            results[out_key] = (resp.status_code, resp.get_json())
+
+        # Recompute suggestions for the second playlist under its own name.
+        resp = self.client.get(f"/api/playlists/{other_clean}/suggestions")
+        other_row = resp.get_json()["rows"][0]
+        other_best = other_row["best"]
+        row_b = {
+            "track_key": other_row["track_key"],
+            "mb_trackid": other_best.get("mb_trackid") or "",
+            "item_id": other_best.get("item_id"),
+            "decision_version": other_best["decision_version"],
+        }
+
+        with mock.patch.object(APP, "_playlist_apply_manifest_replacements", barrier_apply):
+            t1 = threading.Thread(target=apply_for, args=(self.clean_name, row_a, "a"))
+            t2 = threading.Thread(target=apply_for, args=(other_clean, row_b, "b"))
+            t1.start()
+            t2.start()
+            t1.join(timeout=5)
+            t2.join(timeout=5)
+
+        self.assertEqual(results["a"][0], 200)
+        self.assertEqual(results["b"][0], 200)
+        self.assertEqual(len(results["a"][1]["applied"]), 1)
+        self.assertEqual(len(results["b"][1]["applied"]), 1)
+
+    def test_reservation_released_after_success(self):
+        row = self._safe_row()
+        status, _ = self._apply_suggestions([row])
+        self.assertEqual(status, 200)
+        self.assertNotIn(self.clean_name, APP._PLAYLIST_APPLY_RESERVED_NAMES)
+
+    def test_reservation_released_after_stale_rejection(self):
+        row = self._safe_row()
+        row["decision_version"] = "drv2:stale"
+        status, body = self._apply_suggestions([row])
+        self.assertEqual(status, 409)
+        self.assertNotIn(self.clean_name, APP._PLAYLIST_APPLY_RESERVED_NAMES)
+
+    def test_reservation_released_after_unhandled_exception(self):
+        row = self._safe_row()
+        with mock.patch.object(
+            APP, "_playlist_apply_manifest_replacements",
+            side_effect=RuntimeError("simulated failure"),
+        ):
+            resp = self.client.post(
+                f"/api/playlists/{self.clean_name}/apply-safe-suggestions",
+                data=json.dumps({"suggestions": [row]}),
+                content_type="application/json",
+            )
+        self.assertEqual(resp.status_code, 500)
+        self.assertNotIn(self.clean_name, APP._PLAYLIST_APPLY_RESERVED_NAMES)
+
+
+class PersistenceVerificationTests(PlaylistSuggestionsRouteTestCase):
+    def test_manifest_write_that_does_not_verify_is_reported_failed(self):
+        self._set_library_items([_fake_lib_item()])
+        self._seed_missing_tracks([{"artist": "M83", "title": "Midnight  City"}])
+        _, body = self._get_suggestions()
+        row = body["rows"][0]
+        best = row["best"]
+
+        # Simulate a write that silently no-ops (e.g. a filesystem issue) --
+        # the route re-reads the manifest afterward and must not claim
+        # success for a row that didn't actually land.
+        with mock.patch.object(APP, "_playlist_apply_manifest_replacements",
+                              return_value={"ok": True, "resolved_count": 0}):
+            status, apply_body = self._apply_suggestions([{
+                "track_key": row["track_key"],
+                "mb_trackid": best.get("mb_trackid") or "",
+                "item_id": best.get("item_id"),
+                "decision_version": best["decision_version"],
+            }])
+        self.assertEqual(status, 200)
+        self.assertEqual(apply_body["applied"], [])
+        self.assertEqual(apply_body["conflicts"][0]["code"], "playlist_persistence_failed")
+        tx = APP.transactions.get(apply_body["audit_id"])
+        self.assertEqual(tx["status"], "Failed")
+
+
+class RollbackTests(PlaylistSuggestionsRouteTestCase):
+    def test_rollback_restores_previous_desired_track_identity(self):
+        self._set_library_items([_fake_lib_item()])
+        self._seed_missing_tracks([{"artist": "M83", "title": "Midnight  City"}])
+        _, body = self._get_suggestions()
+        row = body["rows"][0]
+        best = row["best"]
+        status, apply_body = self._apply_suggestions([{
+            "track_key": row["track_key"],
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+            "decision_version": best["decision_version"],
+        }])
+        self.assertEqual(status, 200)
+        audit_id = apply_body["audit_id"]
+        tracks_after_apply = self._manifest_tracks()
+        self.assertTrue(any(t.get("title") == "Midnight City" for t in tracks_after_apply))
+
+        resp = self.client.post(f"/api/transactions/{audit_id}/rollback")
+        self.assertEqual(resp.status_code, 200)
+        job_id = resp.get_json()["job_id"]
+        job = _wait_job(job_id)
+        self.assertIsNotNone(job)
+        self.assertNotEqual(job.status, "running")
+
+        tx = APP.transactions.get(audit_id)
+        self.assertEqual(tx["status"], "Rolled Back")
+        tracks_after_rollback = self._manifest_tracks()
+        self.assertTrue(any(t.get("title") == "Midnight  City" for t in tracks_after_rollback))
+        self.assertFalse(any(t.get("title") == "Midnight City" for t in tracks_after_rollback))
+
+    def test_failed_restore_is_not_reported_rolled_back(self):
+        self._set_library_items([_fake_lib_item()])
+        self._seed_missing_tracks([{"artist": "M83", "title": "Midnight  City"}])
+        _, body = self._get_suggestions()
+        row = body["rows"][0]
+        best = row["best"]
+        _, apply_body = self._apply_suggestions([{
+            "track_key": row["track_key"],
+            "mb_trackid": best.get("mb_trackid") or "",
+            "item_id": best.get("item_id"),
+            "decision_version": best["decision_version"],
+        }])
+        audit_id = apply_body["audit_id"]
+
+        with mock.patch.object(
+            APP, "_playlist_apply_manifest_replacements",
+            return_value={"ok": True, "resolved_count": 0},
+        ):
+            resp = self.client.post(f"/api/transactions/{audit_id}/rollback")
+            job = _wait_job(resp.get_json()["job_id"])
+
+        self.assertIsNotNone(job)
+        tx = APP.transactions.get(audit_id)
+        self.assertEqual(tx["status"], "Partially Rolled Back")
+
+
+class SecretRedactionTests(PlaylistSuggestionsRouteTestCase):
+    def test_exception_text_with_secret_shaped_value_never_reaches_response(self):
+        secret = uuid.uuid4().hex
+        self._set_library_items([_fake_lib_item()])
+        self._seed_missing_tracks([{"artist": "M83", "title": "Midnight  City"}])
+        _, body = self._get_suggestions()
+        row = body["rows"][0]
+        best = row["best"]
+
+        with mock.patch.object(
+            APP, "_playlist_apply_manifest_replacements",
+            side_effect=RuntimeError(f"boom mysql://user:{secret}@db.internal/beets"),
+        ):
+            resp = self.client.post(
+                f"/api/playlists/{self.clean_name}/apply-safe-suggestions",
+                data=json.dumps({"suggestions": [{
+                    "track_key": row["track_key"],
+                    "mb_trackid": best.get("mb_trackid") or "",
+                    "item_id": best.get("item_id"),
+                    "decision_version": best["decision_version"],
+                }]}),
+                content_type="application/json",
+            )
+        self.assertEqual(resp.status_code, 500)
+        self.assertNotIn(secret, resp.get_data(as_text=True))
+        # The reservation must still be released even though the handler
+        # raised (matching attach-recording's "released on any exception"
+        # rule -- see _reserve_attach_recording_item's own finally block).
+        self.assertNotIn(self.clean_name, APP._PLAYLIST_APPLY_RESERVED_NAMES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_playlist_suggestion_integrity.py
+++ b/tests/test_playlist_suggestion_integrity.py
@@ -51,7 +51,7 @@ class ConcurrencyTests(PlaylistSuggestionsRouteTestCase):
         row = self._safe_row()
         entered = threading.Event()
         release = threading.Event()
-        original = APP._playlist_apply_manifest_replacements
+        original = APP._playlist_replace_rows_by_id
 
         def slow_apply(*args, **kwargs):
             entered.set()
@@ -61,7 +61,7 @@ class ConcurrencyTests(PlaylistSuggestionsRouteTestCase):
         results = {}
 
         def run_first():
-            with mock.patch.object(APP, "_playlist_apply_manifest_replacements", slow_apply):
+            with mock.patch.object(APP, "_playlist_replace_rows_by_id", slow_apply):
                 results["first"] = self._apply_suggestions([row])
 
         t = threading.Thread(target=run_first)
@@ -86,7 +86,7 @@ class ConcurrencyTests(PlaylistSuggestionsRouteTestCase):
         APP._invalidate_lib_cache()
 
         both_entered = threading.Barrier(2, timeout=5)
-        original = APP._playlist_apply_manifest_replacements
+        original = APP._playlist_replace_rows_by_id
 
         def barrier_apply(*args, **kwargs):
             both_entered.wait()
@@ -113,7 +113,7 @@ class ConcurrencyTests(PlaylistSuggestionsRouteTestCase):
             "decision_version": other_best["decision_version"],
         }
 
-        with mock.patch.object(APP, "_playlist_apply_manifest_replacements", barrier_apply):
+        with mock.patch.object(APP, "_playlist_replace_rows_by_id", barrier_apply):
             t1 = threading.Thread(target=apply_for, args=(self.clean_name, row_a, "a"))
             t2 = threading.Thread(target=apply_for, args=(other_clean, row_b, "b"))
             t1.start()
@@ -142,7 +142,7 @@ class ConcurrencyTests(PlaylistSuggestionsRouteTestCase):
     def test_reservation_released_after_unhandled_exception(self):
         row = self._safe_row()
         with mock.patch.object(
-            APP, "_playlist_apply_manifest_replacements",
+            APP, "_playlist_replace_rows_by_id",
             side_effect=RuntimeError("simulated failure"),
         ):
             resp = self.client.post(
@@ -163,18 +163,18 @@ class PersistenceVerificationTests(PlaylistSuggestionsRouteTestCase):
         best = row["best"]
 
         # Simulate a write that silently no-ops (e.g. a filesystem issue) --
-        # the route re-reads the manifest afterward and must not claim
-        # success for a row that didn't actually land.
-        with mock.patch.object(APP, "_playlist_apply_manifest_replacements",
-                              return_value={"ok": True, "resolved_count": 0}):
+        # the route re-reads the manifest afterward by exact row_id and
+        # must not claim success for a row that didn't actually land.
+        with mock.patch.object(APP, "_playlist_replace_rows_by_id",
+                              return_value={"resolved_ids": set(), "not_found_ids": set()}):
             status, apply_body = self._apply_suggestions([{
                 "track_key": row["track_key"],
                 "mb_trackid": best.get("mb_trackid") or "",
                 "item_id": best.get("item_id"),
                 "decision_version": best["decision_version"],
             }])
-        self.assertEqual(status, 200)
-        self.assertEqual(apply_body["applied"], [])
+        self.assertEqual(status, 500)
+        self.assertEqual(apply_body["code"], "playlist_persistence_failed")
         self.assertEqual(apply_body["conflicts"][0]["code"], "playlist_persistence_failed")
         tx = APP.transactions.get(apply_body["audit_id"])
         self.assertEqual(tx["status"], "Failed")
@@ -226,8 +226,8 @@ class RollbackTests(PlaylistSuggestionsRouteTestCase):
         audit_id = apply_body["audit_id"]
 
         with mock.patch.object(
-            APP, "_playlist_apply_manifest_replacements",
-            return_value={"ok": True, "resolved_count": 0},
+            APP, "_playlist_replace_rows_by_id",
+            return_value={"resolved_ids": set(), "not_found_ids": set()},
         ):
             resp = self.client.post(f"/api/transactions/{audit_id}/rollback")
             job = _wait_job(resp.get_json()["job_id"])
@@ -247,7 +247,7 @@ class SecretRedactionTests(PlaylistSuggestionsRouteTestCase):
         best = row["best"]
 
         with mock.patch.object(
-            APP, "_playlist_apply_manifest_replacements",
+            APP, "_playlist_replace_rows_by_id",
             side_effect=RuntimeError(f"boom mysql://user:{secret}@db.internal/beets"),
         ):
             resp = self.client.post(

--- a/tests/test_transaction_integration.py
+++ b/tests/test_transaction_integration.py
@@ -45,7 +45,7 @@ class TransactionIntegrationSourceTests(unittest.TestCase):
         start = source.index('@app.post("/api/transactions/<transaction_id>/rollback")')
         end = source.index('@app.get("/api/transactions/<transaction_id>/export")', start)
         route = source[start:end]
-        self.assertIn('op.get("type") != "metadata_restore"', route)
+        self.assertIn('_ROLLBACK_OP_TYPES = {"metadata_restore", "recording_id_restore", "playlist_track_restore"}', route)
         self.assertIn('_run_item_metadata_restore(item_id, fields, log', route)
         self.assertIn('status = "Rolled Back" if failed_count == 0 else "Partially Rolled Back"', route)
         self.assertIn('metadata={"transaction": False, "transaction_id": transaction_id', route)


### PR DESCRIPTION
## Summary

Migrates one additional matching consumer -- playlist missing-track suggestions -- to the shared backend-authoritative matching contract PR #19 established for Import Review's attach-recording endpoint.

- Base SHA: `14c7f02d778326792cf9984aed9d2a8224536dfc` (main, includes merged PR #19 and PR #30/Next.js 16.2.11)
- Head SHA: `4884819094a57f0aa54b7efbebcd4fbb1ffe7145`

**Update (review-correction pass, head `4884819`):** independent review found the first pass (`1880970`) accepted a missing `decision_version`, allowed a batch to partially apply when one row was stale/conflicted, and verified/rolled back persisted rows by matching artist/title text instead of an exact row identity (both false-positive- and cross-row-prone). All three are fixed below -- see "Review-correction summary."

## Endpoints migrated

```
GET  /api/playlists/<name>/suggestions
POST /api/playlists/<name>/apply-safe-suggestions
```

`POST /api/playlists/<name>/resolve-track` (manual resolution) is untouched -- it stays an explicit, separately-audited user action, not folded into automatic eligibility (per scope).

## Trust boundary

The backend rebuilds candidates and the matching decision fresh on every request; the browser never supplies or is trusted for safety, confidence, conflicts, or eligibility.

- `POST apply-safe-suggestions` now accepts only `{ suggestions: [{ track_key, mb_trackid?, item_id?, decision_version }] }`. Any other client-supplied field (`safe`, `confidence`, `conflicts`, `action_eligibility`, ...) is parsed and ignored.
- `GET suggestions` responses are enriched with the same decision shape Import Review uses: `mb_trackid` / `mb_albumid` / `mb_releasegroupid`, `decision_version` (`drv2:`), and a full `decision` object (`confidence_score`, `safety_key`, `review_required`, `requires_confirmation`, `conflicts`, `warnings`, `eligibility_reason`, `action_eligibility`), plus an `evidence` block. The legacy top-level `confidence` / `safe` / `reason` fields remain for compatibility but are now *derived only* from the decision and marked `@deprecated` in TypeScript.

## Matching-contract changes (`backend/matching_contract.py`)

`build_recording_matching_decision()` gained two additive, opt-in parameters -- Import Review's own call sites never pass them, so its behavior is bit-for-bit unchanged:

- `library_identity_verified: bool = False` -- lets a caller assert "this candidate is an existing Beets library item whose artist/title deterministically match the query." When true and the match is strong (title/artist similarity >= 0.94/0.90, no conflicts), the safety ladder reaches `safety_key: "safe"` **without requiring a MusicBrainz Recording ID at all** -- playlist resolution never needs to write a Recording ID, only correct the playlist's own desired-track entry.
  - New `action_eligibility.playlist_resolve_without_review` field reflects this (`attach_without_review OR library_eligible`).
  - `attach_without_review` was re-scoped from `safety_key == "safe"` to the underlying recording-ID-specific boolean directly, so a library-identity-only "safe" decision can never be misread as "safe to attach a Recording ID" (there may be none).
- `extra_conflicts: Sequence[str] = ()` -- lets a caller fold an adapter-level conflict (e.g. a competing-candidate tie) into the *same* conflicts list the safety ladder and `decision_version` hash both already consume, so a forced-review state can never be applied after the version was computed (which would desync the hash from what was displayed).

## Safe eligibility rules (playlist_resolve_without_review)

- **Existing Beets library item**: deterministic artist+title match (>=0.94/0.90 similarity), no recording-ID conflicts, no competing top candidate, any available fingerprint evidence supports rather than contradicts. No MusicBrainz Recording ID required.
- **MusicBrainz-only recording candidate**: identical bar to Import Review's `attach_without_review` (resolved Recording ID, release-group identity present, no conflicts, evidence-supported). A plain MB text-search hit without release-group resolution stays review-required -- this PR does not add release-group resolution to the playlist MB path (scoped out; see Known limitations).
- Candidate list order and raw score never substitute for these checks; the decision function computes eligibility from the same evidence regardless of how the adapter ranks/displays candidates.

## AcoustID / AI

- AcoustID is attempted via the existing `_acoustid_fingerprint_ids()` helper whenever the top library candidate has a resolvable file path; when it doesn't, fingerprint state is truthfully `not_attempted` (never reported as matched/verified).
- No AI involvement was added to playlist suggestions in this PR -- the shared contract's AI fields simply report "not evaluated at this boundary," so AI configuration/availability can never block or influence playlist suggestions.

## Review-correction summary

- **Mandatory `decision_version`**: every submitted row must include a nonempty `decision_version` or the whole batch is rejected `400 decision_version_required` (or the generic `400 playlist_batch_rejected` when mixed with other malformed rows) before any candidate lookup happens. A row that supplies *some* version (even forged) is no longer "malformed" -- it is correctly evaluated and rejected for staleness instead, never silently trusted.
- **Strict all-or-nothing batches**: the whole submitted batch is validated -- structural checks, then duplicate-submission checks, then fresh candidate/staleness/eligibility checks -- **before anything is written**. Any row that is malformed, stale, untrusted, still review-required, or conflicted rejects the *entire* batch (`409` for business-rule rejections, `400` for structurally malformed ones) with **zero** manifest writes and **no transaction created**. Only a batch where every row is either already-resolved (idempotent no-op) or newly safe-to-apply proceeds, and then exactly one manifest write covers all of it.
- **Duplicate submissions**: the same `track_key` submitted twice with different candidates/versions is rejected (`playlist_duplicate_submission`, folds into the same all-or-nothing rejection); an exact duplicate of the same row is silently deduplicated before validation (not applied twice, no duplicate rollback record).
- **Stable per-row identity (`row_id`)**: the desired-track manifest schema gained a `row_id` field, minted once (self-healing/idempotent migration for manifests written before this existed) and preserved through every read/write/merge. `track_key` in the API *is* this `row_id`. Persistence verification and rollback now locate and confirm the **exact** row by `row_id` -- never "any row whose text happens to match" -- so two rows resolving to the same artist/title, or a pre-existing unrelated row that already has the target text, can never be confused with each other or double-counted as proof of a change.
- **True idempotent replay**: replaying an already-applied submission now looks the row up by its stable `row_id` in the *full* manifest (not just the "still missing" subset) and compares its current identity to what the submission would resolve to. An exact match is a genuine `200 {"changed": false, "unchanged": [...], "reason": "already_resolved"}` no-op -- no second write, no second transaction -- rather than the previous behavior of reporting a `409` stale rejection just because the row had moved out of the "missing" list.
- **Truthful AcoustID evidence**: the playlist candidate adapter now reports one of `not_attempted` / `lookup_failed` / `no_match` / `matched` / `conflict` / `mapped_unverified` instead of collapsing a real fpcalc/network exception into "no evidence," or reporting a real mapped recording id while simultaneously claiming `no_result`. `conflict` (AcoustID disagrees with the item's own Recording ID) reaches the shared contract as a genuine fingerprint mismatch and blocks eligibility, exactly like Import Review's own AcoustID handling.
- **Fresh library-identity re-read**: the playlist candidate adapter now re-reads the exact Beets item by `item_id` (`lib.get_item`) rather than trusting the (possibly stale-cached) library index payload; a deleted/moved item is dropped from the candidate set entirely instead of being offered as a safe suggestion from cached data.
- **Truthful transaction failure handling**: a manifest-write exception after a transaction was created now marks it `Failed` (sanitized message, no raw paths/exceptions) and returns `500`/`playlist_persistence_failed` -- it can never end a request left `Running`.
- **Frontend structured-error handling**: `handleApplySafeSuggestions` now inspects the response's structured `code` via the existing `apiErrorBody()` helper instead of treating every rejection identically. `playlist_suggestions_stale` reloads suggestions; `playlist_update_in_progress` and batch-rejection codes (`playlist_batch_rejected`, `playlist_review_required`, `playlist_conflict`, `candidate_not_in_trusted_set`, `decision_version_required`, `playlist_duplicate_submission`) show counts/reasons without clearing the suggestion rows; only a fully atomic success clears rows and reloads playlist detail.
- **Truthful derived-state accounting**: the response now includes `manifest_updated` / `m3u_updated` (always `false`) / `sync_required`, so the UI never implies the M3U or Plex sync already reflects a manifest-only change (consistent with the pre-existing, unaudited `resolve-track` action's own scope).

## Stale-decision / staleness behavior

At apply time the backend: acquires a per-playlist reservation -> reloads the manifest (self-healing `row_id` migration happens here if needed) -> rebuilds the trusted candidate set fresh for every row -> verifies every row's structure (nonempty `decision_version`) -> verifies every row's candidate is in the trusted set -> checks idempotency (row already resolved to this identity) -> verifies `decision_version` matches -> verifies `playlist_resolve_without_review` is still true. Any single row failing any of these checks (other than the idempotent-no-op case) rejects the **entire batch**: `409 playlist_suggestions_stale`/`playlist_review_required`/`playlist_conflict`/etc. (the specific code when every blocking row shares one cause, else the generic `playlist_batch_rejected`), or `400 decision_version_required`/`playlist_batch_rejected` for structurally malformed rows. Zero rows are written and no transaction is created for a rejected batch.

## Batch / atomicity behavior

`apply-safe-suggestions` validates the **entire** submitted batch in two phases -- structural (dict shape, nonempty `track_key`/`decision_version`, duplicate-submission detection) then business (trusted-set membership, idempotency, staleness, eligibility) -- before writing anything. Any blocking row anywhere in the batch rejects it wholesale with zero mutation. Only when every row is either an idempotent no-op or newly safe does it proceed: exactly **one** manifest write (`_playlist_replace_rows_by_id`, keyed by each row's exact `row_id`) covers every applied row. The manifest is re-read afterward and each applied row's `row_id` is individually confirmed to hold its exact intended identity before the transaction is marked `Completed`; if any row fails this exact-identity verification the transaction is marked `Failed` and the response is `500 playlist_persistence_failed` (never a false partial success). Reapplying an already-resolved row is a true no-op (`unchanged`, reason `already_resolved`) with no duplicate manifest write or transaction.

## Concurrency

Reuses the same process-local, per-key-reservation pattern PR #19 established for attach-recording (`_reserve_attach_recording_item` / `_ATTACH_RECORDING_RESERVATIONS_LOCK`), scoped to playlist name: a second `apply-safe-suggestions` request for the *same* playlist gets `409 playlist_update_in_progress` immediately; different playlists proceed fully in parallel. The reservation is released on success, every rejection path, and any unhandled exception. This deployment runs a single `python app.py` process (see `Dockerfile`), so process-local locking is sufficient here, matching the existing attach-recording assumption -- documented as a known limitation if that ever changes.

## Transaction / audit behavior

Each successful batch creates one `TransactionStore` record, `operation_type: "Playlist Match"` (added to `backend/transaction_engine.py`'s `TRANSACTION_TYPES`), with one `changes[]` entry per resolved row keyed by `row_id`: `current_metadata` / `new_metadata` / `metadata_diff`, `candidate_identity`, `persisted_identity` (populated only from the post-write, per-row_id re-read -- never left `{}` on a `Completed` transaction), `decision_version`, `confidence`, `reason`, `warnings`, `evidence`. Rollback data (`playlist_track_restore` operations, one per row, each carrying that row's exact `row_id` plus its previous/applied identity) is recorded before the manifest write. Any exception during the write/verify sequence marks the transaction `Failed` with a sanitized message -- it is never left `Running`.

## Rollback behavior

`playlist_track_restore` is a new operation type wired into the existing generic `/api/transactions/<id>/rollback` dispatcher (`_run_playlist_track_restore`). It locates the **exact** row by its recorded `row_id` (never by artist/title text), verifies the row's current identity still matches the recorded *applied* state (`playlist_rollback_state_changed` if something else changed it since -- refuses to overwrite blindly), restores the *previous* identity via the same `_playlist_replace_rows_by_id` path, then re-reads the manifest and confirms that exact `row_id` now holds the previous identity (`playlist_rollback_persistence_failed` if not; `playlist_rollback_row_missing` if the row no longer exists at all). A restore that doesn't verify contributes to `Partially Rolled Back`, never a false `Rolled Back`. This is a metadata/manifest rollback only -- like attach-recording's own rollback, it does not restore downloaded audio or deleted files.

## Frontend changes

- `frontend/src/api/types.ts`: new `PlaylistSuggestionDecision` / `PlaylistActionEligibility` / `PlaylistSuggestionSubmission` / `PlaylistSuggestionOutcomeRow` types; `PlaylistTrackSuggestion` gained the decision-shaped fields and marked `confidence` / `safe` / `reason` `@deprecated`; `PlaylistApplySuggestionsResponse` now matches the actual bucketed response shape.
- `frontend/src/api/client.ts`: `applySafePlaylistSuggestions(name, suggestions)` now takes and sends only the minimal submission list.
- `frontend/src/views/Playlists.tsx`: `handleApplySafeSuggestions` builds submissions only from `track_key` / `mb_trackid` / `item_id` / `decision_version`, filters by `decision.action_eligibility.playlist_resolve_without_review`, reports all five outcome buckets to the user, and re-fetches playlist detail afterward (the apply response no longer carries a full detail payload). `safeSuggestionCount` reads the decision field directly. No redesign of the page, no new state library, existing pipeline controls untouched.

## Structured error codes

`playlist_not_found`, `playlist_track_not_found`, `playlist_candidate_required`, `candidate_not_in_trusted_set`, `decision_version_required`, `playlist_suggestions_stale`, `playlist_batch_rejected`, `playlist_duplicate_submission`, `playlist_review_required`, `playlist_conflict`, `playlist_update_in_progress`, `playlist_persistence_failed`, `playlist_rollback_row_missing`, `playlist_rollback_state_changed`, `playlist_rollback_persistence_failed`.
(`invalid_recording_id`, `playlist_evidence_unavailable` are reserved for future use; not reachable in this slice's scope.)

## Explicitly out of scope (untouched)

Playlist download methods (SLSKD/SpotiFLAC/yt-dlp/SoundCloud), staged-folder naming, import-downloaded workflow, Beets import behavior, Plex path mapping/sync, playlist source parsing/syncing, quality cleanup, Library Cleanup, Replacement jobs, submission workflows, album matching, Import Review behavior, PR #19 attachment behavior, AI provider configuration, manual `resolve-track` (still a separate, unaudited-in-this-PR explicit action).

## Files changed

```
app.py
backend/matching_contract.py
backend/transaction_engine.py            (added "Playlist Match" to TRANSACTION_TYPES)
frontend/src/api/client.ts
frontend/src/api/types.ts
frontend/src/views/Playlists.tsx
tests/test_matching_contract.py          (existing action_eligibility key-set assertion updated)
tests/test_playlist_backend_job.py       (existing source-presence assertion updated for the renamed helper)
tests/test_transaction_integration.py    (existing rollback-route source assertion updated for the op-type set refactor)
tests/test_playlist_matching_contract.py       (new)
tests/test_playlist_safe_suggestions.py        (new)
tests/test_playlist_suggestion_integrity.py    (new)
tests/test_playlist_suggestion_frontend.py     (new)
```
No package/dependency files, screenshots, or documentation changed.

## Tests

- New playlist matching-contract suite (69 tests across 4 files, up from 49) run 5x consecutively: **OK every time.**
- PR #19 + related regression modules (`test_import_review_attach_enforcement`, `test_import_review_attach_integrity`, `test_security_hardening`, `test_transaction_engine`, `test_transaction_integration`, `test_ai_batch_retry_race`, `test_ai_batch_import_reliability`, `test_matching_contract`, `test_routes_setup`, `test_review_queue_singleton_items`): **367 tests, OK.**
- Full existing playlist regression modules (`test_playlist_saved_discovery`, `test_playlist_backend_job`, `test_playlist_pipeline`, `test_playlist_match_quality`, `test_playlist_resume`, `test_playlist_provider_album_guard`, `test_playlist_detail_performance`): **87 tests, OK** (pre-existing static-assertion tests updated only for the intentional rename/refactor, not weakened).
- Full `unittest discover -s tests -p "test_*.py"` run twice: **1286 tests, OK (1 skipped)** both times (up from 1264; +22 new tests this pass covering mandatory decision_version, atomic-batch rejection, duplicate submissions, exact-row identity, AcoustID states, fresh library-identity re-read, and true idempotent replay).
- `py_compile`, `security_secret_scan.py`, `validate_compose_security.py`, `git diff --check`, `git status --short`: all clean.
- Frontend (`npm ci` / `typecheck` / `lint` / `build`): all clean. `npm audit --audit-level=high`: **0 vulnerabilities.**
- Docker (`RUN_DOCKER_SMOKE=1`, `BeetsFreshInstallDockerSmokeTests`): **OK.**

## Known limitations

- MB-only (non-library) candidates are eligible only at the same bar as Import Review's `attach_without_review` (full release-group resolution required); this PR does not add MusicBrainz release-group resolution to the playlist search path, so a plain MB text-search hit always requires review here. Documented rather than expanded, to keep this slice narrow.
- Concurrency reservation is process-local (matches the existing attach-recording assumption and this deployment's single-process `python app.py` entrypoint); if the deployment ever moves to multiple web workers, this (and attach-recording's own reservation) would need a persistent/shared reservation instead.
- M3U regeneration and pipeline "checkpoint" state are untouched by this operation, consistent with the pre-existing `resolve-track` action's own scope -- suggestion application only ever rewrites the desired-track manifest, never the M3U file or pipeline checkpoint. The response now says so truthfully (`manifest_updated` / `m3u_updated: false` / `sync_required`) instead of implying otherwise.
- Manual `resolve-track` remains unaudited via `TransactionStore` in this PR (out of scope, per spec) and still uses the original text-based `_playlist_apply_manifest_replacements` path (unchanged); it stays entirely separate from automatic eligibility and from the new `row_id`-based apply/rollback path.
- The `row_id` manifest-schema migration is self-healing (assigned on first read/write of a legacy manifest) but not instantaneous: two concurrent first-time migrations of the same never-yet-migrated manifest could each mint different ids for the same logical row before either write lands; this fails closed (a mismatched `row_id` is reported `stale`/`not found`, never applied to the wrong row) rather than silently misapplying anything.

