### PR TITLE
Document agent workflow and review authority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ config.yaml
 # Unreviewed local docs drafts
 docs/*
 !docs/AI_ENGINEERING_RULES.md
+!docs/AGENT_WORKFLOW.md
 !docs/ARCHITECTURE.md
 !docs/TECHNICAL_DEBT.md
 !docs/adr/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Concise instructions for Codex and other coding agents working in this repositor
 
 ## Start Here
 
-Read `docs/AI_ENGINEERING_RULES.md` before changing code. It is the shared source of truth for architecture boundaries, product rules, safety rules, matching rules, mutation rules, testing requirements, and AI-agent behavior.
+Read `docs/AI_ENGINEERING_RULES.md` and `docs/AGENT_WORKFLOW.md` before changing code. `docs/AI_ENGINEERING_RULES.md` is the shared source of truth for architecture boundaries, product rules, safety rules, matching rules, mutation rules, testing requirements, and AI-agent behavior. `docs/AGENT_WORKFLOW.md` defines the canonical chain of command, two-stage workflow, review-and-fix policy, and safety boundaries.
 
 Use `docs/ARCHITECTURE.md` for the current architecture and intended dependency direction. Use `docs/TECHNICAL_DEBT.md` for known migration targets. Use `REVIEW.md` before opening or summarizing a change.
 
@@ -59,12 +59,11 @@ For a targeted Python test:
 python -m unittest tests.test_name
 ```
 
-## Workflow
+## Workflow & Implementation Role (Agy — Stage 1)
 
-1. Inspect current files and dirty state before editing.
-2. Keep changes small and scoped to the requested slice.
-3. Do not refactor behavior during documentation/governance work.
-4. Add or update tests for enforceable behavior when code changes are made.
-5. Run relevant checks and report actual results.
-6. Record unresolved architecture debt in `docs/TECHNICAL_DEBT.md` instead of hiding it.
-7. Do not commit directly to `main`; use a dedicated branch.
+1. **Role**: Agy acts as Implementation Engineer. Perform primary investigation, reproduction, code changes, tests, Docker runtime validation, documentation updates, and initial local commit.
+2. **Reproduction & Diagnosis**: Inspect current state and reproduce/diagnose problems before editing. Prove root cause with empirical evidence.
+3. **Upstream Research**: Check upstream issues (`beetbox/beets`), pull requests, and official fixes when modifying dependency behavior.
+4. **Testing & Runtime Validation**: Add positive, negative, regression, integration, and failure tests. Perform disposable container validation for Docker/binary/package/plugin issues.
+5. **Git Safety**: Do not commit directly to `main`. Do not push, open/modify PRs, merge, or deploy without explicit authorization from ChatGPT / project owner.
+6. **Hand-Off**: Run complete validation suite, record unresolved architecture debt in `docs/TECHNICAL_DEBT.md`, make a clean local commit when instructed, and leave the branch ready for Claude's final review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,19 @@ Concise instructions for Claude Code working in this repository.
 
 ## Required Reading
 
-Read `docs/AI_ENGINEERING_RULES.md` before code changes. It is the single shared source of truth for product invariants, architecture boundaries, matching rules, mutation safety, job requirements, testing requirements, security rules, and AI-agent behavior.
+Read `docs/AI_ENGINEERING_RULES.md` and `docs/AGENT_WORKFLOW.md` before code changes. `docs/AI_ENGINEERING_RULES.md` is the single shared source of truth for product invariants, architecture boundaries, matching rules, mutation safety, job requirements, testing requirements, security rules, and AI-agent behavior. `docs/AGENT_WORKFLOW.md` defines the canonical chain of command, two-stage workflow, review-and-fix policy, and safety boundaries.
 
 Use `docs/ARCHITECTURE.md` for the current system shape and intended dependency direction. Use `docs/TECHNICAL_DEBT.md` for known migration targets. Use `REVIEW.md` as the review checklist.
+
+## Technical Lead & Final Reviewer Role
+
+Claude acts as Technical Lead and Final Reviewer for all engineering tasks (Stage 2):
+- Inspect Agy's implementation, source diff, and surrounding architecture.
+- Verify root cause and check upstream issues/fixes (`beetbox/beets`).
+- **Fix every issue identified directly** in code, tests, docs, and configuration. Do not return findings-only reports when fixes are safe and in scope.
+- Standing Instruction: `Do not only report findings. Fix every issue you identify directly, add or correct tests, rerun all required validation, and leave the branch in a clean final state. Escalate only genuine product, architecture, dependency, or safety decisions that cannot be resolved responsibly from the repository and task requirements.`
+- Rerun full validation suite after making corrections.
+- Respect Git safety boundaries: do not push, open/modify PRs, merge, or deploy without explicit authorization.
 
 ## Architecture Summary
 

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -1,0 +1,172 @@
+# Agent Workflow and Chain of Command
+
+This document defines the canonical project hierarchy, two-stage engineering workflow, review policy, root-cause requirements, runtime validation rules, safety boundaries, and communication standards for AI coding agents and maintainers working on this codebase.
+
+## 1. Chain of Command and Roles
+
+### Project Owner — Iran
+* Makes final product, scope, risk, release, merge, migration, and deployment decisions.
+* Authorizes production deployments and schema/data migrations.
+
+### Project Manager — ChatGPT
+* Translates the project owner's goals into structured implementation plans and tasks.
+* Defines scope, requirements, acceptance criteria, safety boundaries, and validation requirements for every prompt.
+* Assigns implementation work to Agy (Stage 1).
+* Assigns technical review, cleanup, and final validation to Claude (Stage 2).
+* Controls when code may be pushed, submitted in a pull request, merged, migrated, or deployed.
+* Prevents scope creep, unnecessary review loops, and token waste.
+
+### Technical Lead and Final Reviewer — Claude
+Claude acts as the technical lead and final reviewer for engineering tasks.
+
+Claude must:
+* Independently inspect Agy’s implementation, source diff, and surrounding architecture.
+* Reproduce the original problem when practical and verify the stated root cause.
+* Check upstream issues (`beetbox/beets`), documentation, pull requests, and official fixes when relevant.
+* Identify any defects, edge cases, fragile assumptions, or maintainability issues Agy missed.
+* **Fix issues directly**: do not merely return a list of findings to Agy. Fix code, improve tests, harden error handling, update docs, and rerun validation.
+* Run the complete required validation suite after making corrections.
+* Leave the branch clean and technically approved or clearly blocked.
+* Provide the final technical approval.
+* Standing Instruction for Claude: `Do not only report findings. Fix every issue you identify directly, add or correct tests, rerun all required validation, and leave the branch in a clean final state. Escalate only genuine product, architecture, dependency, or safety decisions that cannot be resolved responsibly from the repository and task requirements.`
+
+Claude does not send routine implementation work back to Agy. Agy is re-engaged only when a genuine product decision, architectural change, unavailable dependency, or unsafe modification requires direction from the project manager or owner.
+
+### Implementation Engineer — Agy
+Agy performs the primary implementation work.
+
+Agy must:
+* Reproduce and diagnose the problem before editing code.
+* Prove the root cause using empirical evidence (logs, tracebacks, queries) rather than guessing.
+* Research upstream behavior, issues, and official fixes when modifying dependency-related features.
+* Implement the complete solution, including positive, negative, regression, integration, and failure-mode tests.
+* Perform real runtime validation using disposable Docker containers/environments when issues touch containers, installed packages, plugins, configuration, binaries, networking, or external services.
+* Update directly related documentation.
+* Run complete validation and leave the branch ready for Claude's final review.
+* Refrain from pushing, opening or modifying PRs, merging, or deploying unless explicitly authorized.
+
+## 2. Standard Two-Stage Engineering Workflow
+
+### Stage 1 — Agy Implementation
+ChatGPT provides Agy with a comprehensive implementation task containing repository state, problem statement, reproduction steps, root cause requirements, upstream research, scope/non-goals, architecture constraints, safety boundaries, acceptance criteria, test/Docker validation requirements, migration behavior, git boundaries, stop conditions, report format, and token discipline.
+
+Agy performs the full implementation, initial validation, and creates a clean local commit when instructed. Agy must not knowingly leave predictable cleanup work for Claude.
+
+### Stage 2 — Claude Review, Correction, and Approval
+Claude receives a review-and-fix task.
+
+Claude executes the following workflow:
+1. Inspects Agy's complete implementation and actual source diff (`git diff`).
+2. Independently verifies key claims and reproduces the failure when practical.
+3. Reviews implementation blast radius.
+4. Identifies defects, missing edge cases, fragile assumptions, or maintainability problems.
+5. **Fixes every identified issue directly** in code and configuration.
+6. Adds or improves unit, integration, and failure tests.
+7. Rebuilds affected Docker images and reruns runtime validation checks.
+8. Reruns the complete project test suite (`pytest`, `py_compile`, frontend `typecheck` / `build`).
+9. Leaves a clean final commit stack.
+10. Provides a final technical approval or a clearly explained blocker.
+
+## 3. One-Review Policy
+
+There should normally be exactly **one Agy implementation phase** and **one Claude final review-and-fix phase**.
+
+Avoid iterative review loops (`Agy impl -> Claude findings-only -> Agy correction -> Claude second review`).
+
+A second Claude review is required only when:
+* Claude's own fixes materially changed the implementation architecture and require an additional validation pass.
+* A new external fact or upstream constraint was discovered during review.
+* Requirements were modified by the project owner or project manager.
+* A blocker requires a product or architecture decision from the project manager.
+
+Otherwise, Claude's review phase includes its own code fixes and final validation in one pass.
+
+## 4. Root-Cause and Upstream Policy
+
+* **Reproduce Before Editing**: Reproduce the failure before modifying code whenever practical.
+* **Empirical Root Cause**: Capture decisive tracebacks, error codes, state transitions, or query results. Distinguish underlying root causes from superficial symptoms.
+* **Upstream First**: When modifying third-party behavior (e.g. Beets, MusicBrainz, AcoustID, SLSKD, Docker images), search upstream issue trackers (`beetbox/beets`), pull requests, and release notes for existing solutions.
+* **Prefer Upstream Fixes**: Prefer a confirmed upstream fix or narrow backport over custom local workarounds.
+* **Version Guards & Documentation**: Record affected and fixed versions. Use version checks for version-specific patches and document how temporary patches should be removed upon upgrading pinned dependencies.
+* **Test Against Pinned Versions**: Test against the real pinned dependency version specified in the project environment.
+
+## 5. Real-Runtime Validation Policy
+
+Mocked unit tests alone are insufficient when a defect depends on:
+* Docker image contents or container environments
+* Installed Python packages or C-extensions
+* Dynamic plugin loading or plugin class resolution
+* System binaries (`fpcalc`, `beet`, `s6-svscan`, `ffmpeg`)
+* Filesystem permissions or mounts
+* Network isolation or HTTP communication
+* Configuration parsing (`config.yaml`)
+* Database locking (`.beet_db.lock`)
+* Process cancellation and signal handling
+* External command registration
+
+For these cases, Agy and Claude must perform disposable runtime validation against the actual Docker image or environment.
+
+**Safety Rules for Runtime Validation**:
+* Do not use production TrueNAS resources during development validation unless explicitly authorized.
+* Use disposable containers, volumes, databases, configurations, test audio files, credentials, and network endpoints.
+* Never submit real test data to AcoustID or MusicBrainz servers.
+
+## 6. Safety Boundaries and Git Authority
+
+Neither Agy nor Claude may perform any of the following actions without explicit authorization from ChatGPT acting on instructions from the project owner:
+* `git push` or `git push --force`
+* Open a pull request or modify an existing pull request
+* Mark a draft PR as ready for review
+* `git merge` or merge PRs on GitHub
+* Delete local or remote branches
+* Deploy to TrueNAS or production environments
+* Migrate production database tables or configuration
+* Modify production TrueNAS files or container instances
+* Execute destructive actions on live media libraries
+
+Reading repository state, building Docker images locally, running test suites, and creating local feature branches or commits are permitted when specified by task instructions.
+
+## 7. Beets Architecture Rules
+
+For comprehensive architecture guidelines, refer to `docs/ARCHITECTURE.md` and `docs/AI_ENGINEERING_RULES.md`. Summary invariants:
+
+1. **Engine Separation**: The authoritative Beets engine runs separately from the web manager in a dedicated container.
+2. **Single Source of Truth**: Exactly one authoritative Beets installation, one `/config/config.yaml`, and one `/config/musiclibrary.blb`.
+3. **Engine Mutation Domain**: Beets database, audio tag writes, media renaming, staging imports, and library mutations belong exclusively to the Beets engine.
+4. **Web Manager Scope**: The web manager handles UI, orchestration, background jobs, and integrations. It contains no Beets executable, no Beets Python modules, no direct SQLite database access, and no direct tag/file mutations.
+5. **Control Agent Communication**: Web manager communicates with the Beets engine exclusively through the authenticated internal control agent on port `8338` (internal-only).
+6. **Concurrency & Locking**: Mutating operations must acquire and honor the shared OS lock (`.beet_db.lock`).
+7. **Fail-Closed Capabilities**: Plugin capability checks must fail closed. `mbsubmit` and `submit` are independent capabilities. AcoustID fingerprinting, lookup, and submission readiness are distinct capabilities.
+
+## 8. Token and Output Discipline
+
+### Agy Output Discipline
+* Do not restate the prompt.
+* Do not print complete source files.
+* Do not print full logs unless a decisive traceback is required.
+* Do not refactor unrelated code or rewrite unrelated files.
+* Keep explanations concise and structured.
+* Required report sections: Root Cause, Fix Implemented, Test Coverage, Real-Runtime Validation, Files Changed, Local Commit, Git Status, Remaining Limitations.
+
+### Claude Output Discipline
+* Do not repeat Agy's full report.
+* Focus on discrepancies, code corrections made, improvements, and final validation.
+* Fix issues directly in code rather than producing a findings-only report.
+* Do not print full diffs or full logs.
+* Required report sections: Upstream Predicate Adopted, Patch Integrity, Runtime Sanity Checks, Plugin Audit, Fingerprinting/Submission Readiness, Flaky Test Checks, Exact Validation Results, Files Changed, Amended Local Commit, Git Status, Final Approval State.
+
+## 9. Reporting Language Standards
+
+Distinguish clearly between distinct technical states:
+* `implemented`: Code is written and committed locally.
+* `tested`: Unit/integration tests have executed and passed.
+* `independently verified`: Technical lead has confirmed behavior via direct inspection or execution.
+* `partially supported`: Feature works under specific conditions but has known gaps.
+* `disabled`: Feature is explicitly gated off due to missing credentials or unfulfilled dependencies.
+* `known limitation`: Documented gap that is intentionally out of scope for the current slice.
+* `blocked`: Execution cannot proceed due to an external dependency or required decision.
+* `ready to push`: Local commit stack is verified and approved, pending project manager push directive.
+* `ready to merge`: Branch has been reviewed and approved on GitHub, pending merge authorization.
+* `ready to deploy`: Merged code is validated and ready for production container deployment.
+
+Do not conflate "Command registered" with "feature operational", "Tests passed" with "production ready", or "Ready to push" with "ready to merge".

--- a/docs/AI_ENGINEERING_RULES.md
+++ b/docs/AI_ENGINEERING_RULES.md
@@ -1,6 +1,6 @@
 # AI Engineering Rules
 
-This document is the shared source of truth for Codex, Claude Code, and human maintainers. `AGENTS.md` and `CLAUDE.md` must point here instead of carrying separate architecture rule sets.
+This document is the shared source of truth for Codex, Claude Code, and human maintainers for architecture boundaries, domain rules, and safety rules. See `docs/AGENT_WORKFLOW.md` for the canonical chain of command, two-stage workflow, and review policy. `AGENTS.md` and `CLAUDE.md` must point here and to `docs/AGENT_WORKFLOW.md`.
 
 ## Architecture Boundaries
 

--- a/tests/test_engineering_governance_docs.py
+++ b/tests/test_engineering_governance_docs.py
@@ -16,6 +16,7 @@ class EngineeringGovernanceDocsTest(unittest.TestCase):
             "CLAUDE.md",
             "REVIEW.md",
             "docs/AI_ENGINEERING_RULES.md",
+            "docs/AGENT_WORKFLOW.md",
             "docs/ARCHITECTURE.md",
             "docs/TECHNICAL_DEBT.md",
             "docs/operations/DEVELOPMENT_AND_DEPLOYMENT.md",
@@ -29,6 +30,7 @@ class EngineeringGovernanceDocsTest(unittest.TestCase):
     def test_agent_files_point_to_shared_source_of_truth(self) -> None:
         required_references = [
             "docs/AI_ENGINEERING_RULES.md",
+            "docs/AGENT_WORKFLOW.md",
             "docs/ARCHITECTURE.md",
             "docs/TECHNICAL_DEBT.md",
             "REVIEW.md",
@@ -141,8 +143,50 @@ class EngineeringGovernanceDocsTest(unittest.TestCase):
         self.assertIn("AGENTS.md.bak-*", gitignore)
         self.assertIn("CLAUDE.md.bak-*", gitignore)
         self.assertIn("!docs/AI_ENGINEERING_RULES.md", gitignore)
+        self.assertIn("!docs/AGENT_WORKFLOW.md", gitignore)
         self.assertIn("!docs/operations/*.md", gitignore)
         self.assertIn("!docs/incidents/*.md", gitignore)
+
+    def test_agent_workflow_defines_chain_of_command(self) -> None:
+        content = read_repo_file("docs/AGENT_WORKFLOW.md")
+        expected_roles = [
+            "Project Owner — Iran",
+            "Project Manager — ChatGPT",
+            "Technical Lead and Final Reviewer — Claude",
+            "Implementation Engineer — Agy",
+        ]
+        for role in expected_roles:
+            with self.subTest(role=role):
+                self.assertIn(role, content)
+
+    def test_agent_workflow_gives_claude_fix_authority_not_review_only(self) -> None:
+        content = read_repo_file("docs/AGENT_WORKFLOW.md")
+        self.assertIn(
+            "Do not only report findings. Fix every issue you identify directly, "
+            "add or correct tests, rerun all required validation, and leave the "
+            "branch in a clean final state.",
+            content,
+        )
+        self.assertIn("Fix issues directly in code rather than producing a findings-only report", content)
+
+    def test_agent_workflow_restricts_push_pr_merge_deploy_authority(self) -> None:
+        content = read_repo_file("docs/AGENT_WORKFLOW.md")
+        restricted_actions = [
+            "`git push` or `git push --force`",
+            "Open a pull request or modify an existing pull request",
+            "Mark a draft PR as ready for review",
+            "`git merge` or merge PRs on GitHub",
+            "Deploy to TrueNAS or production environments",
+        ]
+        for action in restricted_actions:
+            with self.subTest(action=action):
+                self.assertIn(action, content)
+
+    def test_agent_workflow_is_not_a_conversation_transcript(self) -> None:
+        content = read_repo_file("docs/AGENT_WORKFLOW.md")
+        for banned_phrase in ("as we discussed", "in this session", "in this conversation", "as requested above"):
+            with self.subTest(phrase=banned_phrase):
+                self.assertNotIn(banned_phrase, content.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Defines the permanent project chain of command:
  - Iran — Project Owner
  - ChatGPT — Project Manager
  - Claude — Technical Lead and Final Reviewer
  - Agy — Implementation Engineer
- Establishes the default two-stage engineering workflow:
  1. Agy performs investigation, implementation, tests, runtime validation, documentation, and the initial local commit.
  2. Claude independently reviews the complete result, fixes anything missed, reruns validation, and gives final technical approval.
- Establishes the one-review policy to reduce repeated correction loops and unnecessary token usage.
- Defines root-cause, upstream-research, real-runtime validation, Git authority, safety, and reporting-language requirements.
- Requires Claude to fix safely correctable findings directly rather than returning findings-only reviews.
- Requires separate explicit authorization for push, PR, merge, migration, and deployment operations.

## Canonical policy

The canonical workflow document is:

`docs/AGENT_WORKFLOW.md`

`AGENTS.md` and `CLAUDE.md` reference the shared policy while preserving role-specific instructions.

## Validation

- 13 governance tests passed.
- 89 governance subtests passed.
- Canonical workflow location and references verified.
- Chain-of-command coverage verified.
- Claude direct-fix authority verified.
- Push, PR, merge, and deployment restrictions verified.
- No conflicting repository instruction language found.
- `git diff --check` passed.

## Scope and safety

- This is a documentation and governance change.
- It contains no Chroma, Docker, or application implementation changes.
- This PR targets the draft architecture branch.
- It does not authorize merge or production deployment.
