### PR TITLE
fix: resolve PR #39 CodeQL security alerts

### DIFF
--- a/app.py
+++ b/app.py
@@ -10613,7 +10613,8 @@ def album_delete_art(aid):
     try:
         beets_client.clear_album_artpath(aid)
     except Exception as ex:
-        return jsonify({"ok": False, "error": f"Could not clear artpath: {ex}"}), 500
+        app.logger.warning("Could not clear album artpath for album %s: %s", aid, type(ex).__name__)
+        return jsonify({"ok": False, "error": "Could not clear artpath."}), 500
 
     _invalidate_lib_cache()
     return jsonify({

--- a/backend/beets_client.py
+++ b/backend/beets_client.py
@@ -167,9 +167,8 @@ class BeetsClient:
         return self._request("GET", "/config/status", timeout=5.0)
 
     def raw_sqlite_query(self, sql: str, params: tuple = (), offset: int = 0, limit: int = 1000) -> List[Dict[str, Any]]:
-        """Run a strictly read-only SELECT query against the Beets database via the control agent."""
-        res = self._request("POST", "/library/raw_query", {"query": sql, "params": list(params), "offset": offset, "limit": limit})
-        return res.get("rows", [])
+        """Raw SQL is intentionally unavailable; use structured query helpers."""
+        raise BeetsError("Raw SQLite queries are not permitted; use structured library query helpers")
 
     def run_command(self, command: str, args: Optional[List[str]] = None, timeout: float = 120.0, config_override: str = "", source_path: str = "", target_path: str = "") -> Dict[str, Any]:
         """Execute a beet command synchronously on the Beets control agent."""

--- a/backend/beets_control_agent.py
+++ b/backend/beets_control_agent.py
@@ -51,6 +51,32 @@ ALLOWED_COMMANDS = {
     "version", "config", "check", "remove", "rm", "submit", "mbsubmit"
 }
 
+_ITEM_UPDATE_COLUMN_NAMES = (
+    "album_id", "title", "artist", "artist_sort", "artist_credit", "album",
+    "albumartist", "albumartist_sort", "albumartist_credit", "genre", "year",
+    "month", "day", "original_year", "original_month", "original_day",
+    "track", "tracktotal", "disc", "disctotal", "lyrics", "comments",
+    "composer", "composer_sort", "grouping", "label", "catalognum",
+    "country", "media", "albumdisambig", "disctitle", "mb_trackid",
+    "mb_albumid", "mb_artistid", "mb_albumartistid", "mb_releasegroupid",
+    "asin", "isrc", "bpm", "comp", "path",
+)
+_ALBUM_UPDATE_COLUMN_NAMES = (
+    "album", "albumartist", "albumartist_sort", "albumartist_credit",
+    "genre", "year", "month", "day", "original_year", "original_month",
+    "original_day", "tracktotal", "disctotal", "label", "catalognum",
+    "country", "albumdisambig", "mb_albumid", "mb_albumartistid",
+    "mb_releasegroupid", "asin", "artpath", "comp", "path",
+)
+_ITEM_UPDATE_STATEMENTS = {name: f"UPDATE items SET {name} = ? WHERE id = ?" for name in _ITEM_UPDATE_COLUMN_NAMES}
+_ALBUM_UPDATE_STATEMENTS = {name: f"UPDATE albums SET {name} = ? WHERE id = ?" for name in _ALBUM_UPDATE_COLUMN_NAMES}
+_TAG_WRITE_FIELDS = {
+    "title", "artist", "album", "albumartist", "year", "month", "day",
+    "track", "tracktotal", "disc", "disctotal", "genre", "comments",
+    "lyrics", "composer", "mb_trackid", "mb_albumid", "mb_artistid",
+    "mb_albumartistid", "mb_releasegroupid",
+}
+
 JOBS = {}
 JOBS_LOCK = threading.Lock()
 
@@ -379,58 +405,94 @@ def require_command_capability(command: str) -> Optional[dict]:
     return {"error": error_msg, "reason": reason}
 
 
-def is_safe_path(path: str, allowed_types: list = None) -> bool:
-    """Verify that path stays strictly within allowed root directories without traversal or symlink escape."""
-    if not path or not isinstance(path, str):
-        return False
-    if "\x00" in path:
-        return False
+def _decode_untrusted_path(raw_path: str) -> Optional[str]:
+    decoded = raw_path
+    for _ in range(5):
+        try:
+            next_decoded = urllib.parse.unquote(decoded)
+        except Exception:
+            return None
+        if next_decoded == decoded:
+            return decoded
+        decoded = next_decoded
+    return None
 
-    # Decode URL encoding if present
-    try:
-        decoded = urllib.parse.unquote(path)
-    except Exception:
-        decoded = path
 
-    if "\x00" in decoded or "\\" in decoded:
-        return False
-
-    # Path must be absolute
-    if not decoded.startswith("/"):
-        return False
-
-    parts = decoded.split("/")
-    if ".." in parts or "." in parts:
-        return False
-
+def _allowed_root_paths(allowed_types: list = None) -> list[str]:
     all_roots = {
         "config": [os.path.abspath(BEETSDIR), "/config"],
         "music": [os.path.abspath(MUSIC_LIBRARY_PATH), "/data/media/music"],
         "staging": [os.path.abspath(DOWNLOAD_PATH), "/data/torrents"],
         "tmp": ["/tmp", tempfile.gettempdir()],
     }
-
-    roots_to_check = []
+    roots_to_check: list[str] = []
     if allowed_types:
-        for t in allowed_types:
-            if t in all_roots:
-                roots_to_check.extend(all_roots[t])
+        for root_type in allowed_types:
+            roots_to_check.extend(all_roots.get(root_type, []))
     else:
-        for r_list in all_roots.values():
-            roots_to_check.extend(r_list)
+        for root_list in all_roots.values():
+            roots_to_check.extend(root_list)
+    return roots_to_check
 
+
+def _path_is_within(candidate: str, root: str) -> bool:
     try:
-        abs_path = os.path.abspath(decoded)
-        real_path = os.path.realpath(abs_path)
-
-        for root in roots_to_check:
-            real_root = os.path.realpath(root)
-            if real_path == real_root or real_path.startswith(real_root + os.sep) or real_path.startswith(real_root + "/"):
-                return True
-        return False
+        real_candidate = os.path.realpath(candidate)
+        real_root = os.path.realpath(root)
+        return os.path.commonpath([real_candidate, real_root]) == real_root
     except Exception:
         return False
 
+
+def resolve_safe_path(path: str, allowed_types: list = None) -> Optional[str]:
+    """Return a canonical path under an approved root, or None.
+
+    Callers must use this returned value for filesystem operations. Returning a
+    bool and then operating on the original request value leaves a gap for mixed
+    encodings, symlink components, and prefix-collision paths.
+    """
+    if not path or not isinstance(path, str):
+        return None
+    if "\x00" in path or "\\" in path:
+        return None
+
+    decoded = _decode_untrusted_path(path)
+    if decoded is None:
+        return None
+    if "\x00" in decoded or "\\" in decoded:
+        return None
+    if not decoded.startswith("/"):
+        return None
+
+    parts = decoded.split("/")
+    if ".." in parts or "." in parts:
+        return None
+
+    abs_path = os.path.abspath(decoded)
+    real_path = os.path.realpath(abs_path)
+    for root in _allowed_root_paths(allowed_types):
+        if _path_is_within(real_path, root):
+            return real_path
+    return None
+
+
+def is_safe_path(path: str, allowed_types: list = None) -> bool:
+    """Verify that path stays strictly within allowed roots."""
+    return resolve_safe_path(path, allowed_types) is not None
+
+
+def _validated_update_assignments(fields: Any, allowed_statements: dict[str, str]) -> tuple[list[tuple[str, Any]], list[str]]:
+    if not isinstance(fields, dict):
+        return [], ["fields"]
+    assignments: list[tuple[str, Any]] = []
+    invalid: list[str] = []
+    for key, value in fields.items():
+        statement = allowed_statements.get(str(key))
+        if statement is None:
+            invalid.append(str(key))
+            continue
+        assignments.append((statement, value))
+    return assignments, invalid
 
 def acquire_os_lock(read_only: bool = False):
     """Acquire an OS file lock on LOCK_PATH for Beets concurrency protection."""
@@ -704,7 +766,7 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 "allowed_commands": list(ALLOWED_COMMANDS),
                 "os_locking": True,
                 "strict_path_validation": True,
-                "read_only_raw_query": True,
+                "read_only_raw_query": False,
             })
             return
 
@@ -994,75 +1056,8 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
             return
 
         if path == "/library/raw_query":
-            query = body.get("query", body.get("sql", "")).strip()
-            params_list = body.get("params", [])
-            offset = max(int(body.get("offset", 0)), 0)
-            limit = min(max(int(body.get("limit", 1000)), 1), 5000)
-
-            if not query:
-                self._send_json(400, {"error": "Query string is required"})
-                return
-
-            clean_q = re.sub(r'/\*.*?\*/', '', query, flags=re.DOTALL)
-            clean_q = re.sub(r'--.*$', '', clean_q, flags=re.MULTILINE).strip()
-
-            if ";" in clean_q.rstrip(";"):
-                self._send_json(400, {"error": "Multiple SQL statements are not permitted"})
-                return
-            clean_q = clean_q.rstrip(";")
-
-            forbidden = [
-                r"\bUPDATE\b", r"\bDELETE\b", r"\bINSERT\b", r"\bDROP\b",
-                r"\bCREATE\b", r"\bALTER\b", r"\bREPLACE\b", r"\bATTACH\b",
-                r"\bDETACH\b", r"\bVACUUM\b", r"\bPRAGMA\b", r"\bEXEC\b", r"\bEXECUTE\b"
-            ]
-            for pattern in forbidden:
-                if re.search(pattern, clean_q, re.IGNORECASE):
-                    self._send_json(400, {"error": f"Forbidden statement type: raw_query endpoint is strictly read-only SELECT queries"})
-                    return
-
-            if not re.match(r"^\s*(WITH\b|SELECT\b)", clean_q, re.IGNORECASE):
-                self._send_json(400, {"error": "Raw query must begin with SELECT or WITH ... SELECT"})
-                return
-
-            if not os.path.exists(LIB_PATH):
-                self._send_json(404, {"error": "Database file musiclibrary.blb not found"})
-                return
-
-            lock_file = acquire_os_lock(read_only=True)
-            try:
-                con = sqlite3.connect(LIB_PATH, timeout=10)
-                con.row_factory = sqlite3.Row
-                cur = con.cursor()
-
-                count_sql = f"SELECT COUNT(*) FROM ({clean_q}) AS _total_subquery"
-                cur.execute(count_sql, params_list)
-                total_count = cur.fetchone()[0]
-
-                page_sql = f"SELECT * FROM ({clean_q}) AS _page_subquery LIMIT ? OFFSET ?"
-                cur.execute(page_sql, list(params_list) + [limit, offset])
-                rows = [dict(r) for r in cur.fetchall()]
-                con.close()
-
-                has_more = (offset + len(rows)) < total_count
-                next_offset = (offset + len(rows)) if has_more else None
-
-                self._send_json(200, {
-                    "rows": rows,
-                    "count": len(rows),
-                    "total": total_count,
-                    "offset": offset,
-                    "limit": limit,
-                    "has_more": has_more,
-                    "next_offset": next_offset,
-                    "truncated": has_more
-                })
-            except Exception as exc:
-                self._send_json(500, {"error": f"SQLite error: {exc}"})
-            finally:
-                release_os_lock(lock_file)
+            self._send_json(403, {"error": "Raw SQL queries are not permitted"})
             return
-
         if path.startswith("/albums/") and path.endswith("/artpath"):
             parts = path.split("/")
             try:
@@ -1072,8 +1067,9 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 return
 
             artpath = body.get("artpath", "")
-            if not artpath or not is_safe_path(artpath, ["music"]):
-                self._send_json(403, {"error": f"Access denied for artpath: {artpath}"})
+            safe_artpath = resolve_safe_path(artpath, ["music"])
+            if safe_artpath is None:
+                self._send_json(403, {"error": "Access denied for artpath outside allowed roots"})
                 return
 
             lock_file = acquire_os_lock(read_only=False)
@@ -1085,12 +1081,16 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 if not cur.fetchone():
                     self._send_json(404, {"error": f"Album {album_id} not found"})
                     return
-                cur.execute("UPDATE albums SET artpath = ? WHERE id = ?", (artpath, album_id))
+                safe_artpath = resolve_safe_path(artpath, ["music"])
+                if safe_artpath is None:
+                    self._send_json(403, {"error": "Access denied for artpath outside allowed roots"})
+                    return
+                cur.execute("UPDATE albums SET artpath = ? WHERE id = ?", (safe_artpath, album_id))
                 con.commit()
                 con.close()
-                self._send_json(200, {"ok": True, "album_id": album_id, "artpath": artpath})
-            except Exception as exc:
-                self._send_json(500, {"error": f"Failed to set artpath: {exc}"})
+                self._send_json(200, {"ok": True, "album_id": album_id, "artpath": safe_artpath})
+            except Exception:
+                self._send_json(500, {"error": "Failed to set artpath"})
             finally:
                 release_os_lock(lock_file)
             return
@@ -1239,18 +1239,19 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
 
         if path == "/tags/read":
             file_path = body.get("file_path", "")
-            if not is_safe_path(file_path, ["music", "staging"]):
-                self._send_json(403, {"error": f"Access denied for path: {file_path}"})
+            safe_file_path = resolve_safe_path(file_path, ["music", "staging"])
+            if safe_file_path is None:
+                self._send_json(403, {"error": "Access denied for path outside allowed roots"})
                 return
-            if not os.path.exists(file_path):
-                self._send_json(404, {"error": f"File not found: {file_path}"})
+            if not os.path.exists(safe_file_path):
+                self._send_json(404, {"error": "File not found"})
                 return
 
             try:
                 tags = {}
                 try:
                     from beets.mediafile import MediaFile
-                    mf = MediaFile(file_path)
+                    mf = MediaFile(safe_file_path)
                     tags = {
                         "title": mf.title,
                         "artist": mf.artist,
@@ -1270,7 +1271,7 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                     }
                 except Exception:
                     import mutagen
-                    f = mutagen.File(file_path, easy=True)
+                    f = mutagen.File(safe_file_path, easy=True)
                     if f is not None:
                         tags = {
                             "title": (f.get("title") or [""])[0],
@@ -1282,26 +1283,38 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                             "genre": (f.get("genre") or [""])[0],
                         }
                 self._send_json(200, {"tags": tags})
-            except Exception as exc:
-                self._send_json(500, {"error": f"Failed to read tags: {exc}"})
+            except Exception:
+                self._send_json(500, {"error": "Failed to read tags"})
             return
 
         if path == "/tags/write":
             file_path = body.get("file_path", "")
             tags = body.get("tags", {})
-            if not is_safe_path(file_path, ["music", "staging"]):
-                self._send_json(403, {"error": f"Access denied for path: {file_path}"})
+            safe_file_path = resolve_safe_path(file_path, ["music", "staging"])
+            if safe_file_path is None:
+                self._send_json(403, {"error": "Access denied for path outside allowed roots"})
                 return
-            if not os.path.exists(file_path):
-                self._send_json(404, {"error": f"File not found: {file_path}"})
+            if not os.path.exists(safe_file_path):
+                self._send_json(404, {"error": "File not found"})
+                return
+            if not isinstance(tags, dict):
+                self._send_json(400, {"error": "tags must be an object"})
+                return
+            unsafe_tags = sorted(str(k) for k in tags.keys() if str(k) not in _TAG_WRITE_FIELDS)
+            if unsafe_tags:
+                self._send_json(400, {"error": "Unsupported tag field"})
                 return
 
             lock_file = acquire_os_lock(read_only=False)
             try:
+                safe_file_path = resolve_safe_path(file_path, ["music", "staging"])
+                if safe_file_path is None or not os.path.exists(safe_file_path):
+                    self._send_json(403, {"error": "Access denied for path outside allowed roots"})
+                    return
                 written = False
                 try:
                     from beets.mediafile import MediaFile
-                    mf = MediaFile(file_path)
+                    mf = MediaFile(safe_file_path)
                     for k, v in tags.items():
                         if hasattr(mf, k):
                             setattr(mf, k, v)
@@ -1309,81 +1322,104 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                     written = True
                 except Exception:
                     import mutagen
-                    f = mutagen.File(file_path, easy=True)
+                    f = mutagen.File(safe_file_path, easy=True)
                     if f is not None:
                         for k, v in tags.items():
                             f[k] = v
                         f.save()
                         written = True
                 if written:
-                    self._send_json(200, {"ok": True, "file_path": file_path})
+                    self._send_json(200, {"ok": True, "file_path": safe_file_path})
                 else:
                     self._send_json(500, {"error": "Failed to write tags to file"})
-            except Exception as exc:
-                self._send_json(500, {"error": f"Failed to write tags: {exc}"})
+            except Exception:
+                self._send_json(500, {"error": "Failed to write tags"})
             finally:
                 release_os_lock(lock_file)
             return
-
         if path == "/files/move":
             src = body.get("source_path", "")
             dst = body.get("target_path", "")
-            if not is_safe_path(src, ["music", "staging"]) or not is_safe_path(dst, ["music", "staging"]):
+            safe_src = resolve_safe_path(src, ["music", "staging"])
+            safe_dst = resolve_safe_path(dst, ["music", "staging"])
+            if safe_src is None or safe_dst is None:
                 self._send_json(403, {"error": "Access denied for path outside allowed roots"})
                 return
-            if not os.path.exists(src):
-                self._send_json(404, {"error": f"Source path not found: {src}"})
+            if not os.path.exists(safe_src):
+                self._send_json(404, {"error": "Source path not found"})
                 return
 
             lock_file = acquire_os_lock(read_only=False)
             try:
-                os.makedirs(os.path.dirname(dst), exist_ok=True)
-                shutil.move(src, dst)
-                self._send_json(200, {"ok": True, "source_path": src, "target_path": dst})
-            except Exception as exc:
-                self._send_json(500, {"error": f"Failed to move file: {exc}"})
+                safe_src = resolve_safe_path(src, ["music", "staging"])
+                safe_dst = resolve_safe_path(dst, ["music", "staging"])
+                if safe_src is None or safe_dst is None or not os.path.exists(safe_src):
+                    self._send_json(403, {"error": "Access denied for path outside allowed roots"})
+                    return
+                os.makedirs(os.path.dirname(safe_dst), exist_ok=True)
+                safe_dst = resolve_safe_path(dst, ["music", "staging"])
+                if safe_dst is None:
+                    self._send_json(403, {"error": "Access denied for path outside allowed roots"})
+                    return
+                shutil.move(safe_src, safe_dst)
+                self._send_json(200, {"ok": True, "source_path": safe_src, "target_path": safe_dst})
+            except Exception:
+                self._send_json(500, {"error": "Failed to move file"})
             finally:
                 release_os_lock(lock_file)
             return
 
         if path == "/files/delete":
             target = body.get("path", "")
-            if not is_safe_path(target, ["music", "staging"]):
-                self._send_json(403, {"error": f"Access denied for path: {target}"})
+            safe_target = resolve_safe_path(target, ["music", "staging"])
+            if safe_target is None:
+                self._send_json(403, {"error": "Access denied for path outside allowed roots"})
                 return
-            if not os.path.exists(target):
-                self._send_json(200, {"ok": True, "path": target, "existed": False})
+            if not os.path.exists(safe_target):
+                self._send_json(200, {"ok": True, "path": safe_target, "existed": False})
                 return
 
             lock_file = acquire_os_lock(read_only=False)
             try:
-                if os.path.isdir(target):
-                    shutil.rmtree(target)
+                safe_target = resolve_safe_path(target, ["music", "staging"])
+                if safe_target is None:
+                    self._send_json(403, {"error": "Access denied for path outside allowed roots"})
+                    return
+                if os.path.isdir(safe_target):
+                    shutil.rmtree(safe_target)
                 else:
-                    os.unlink(target)
-                self._send_json(200, {"ok": True, "path": target, "existed": True})
-            except Exception as exc:
-                self._send_json(500, {"error": f"Failed to delete path: {exc}"})
+                    os.unlink(safe_target)
+                self._send_json(200, {"ok": True, "path": safe_target, "existed": True})
+            except Exception:
+                self._send_json(500, {"error": "Failed to delete path"})
             finally:
                 release_os_lock(lock_file)
             return
 
         if path == "/files/mkdir":
             target = body.get("path", "")
-            if not is_safe_path(target, ["music", "staging"]):
-                self._send_json(403, {"error": f"Access denied for path: {target}"})
+            safe_target = resolve_safe_path(target, ["music", "staging"])
+            if safe_target is None:
+                self._send_json(403, {"error": "Access denied for path outside allowed roots"})
                 return
 
             lock_file = acquire_os_lock(read_only=False)
             try:
-                os.makedirs(target, exist_ok=True)
-                self._send_json(200, {"ok": True, "path": target})
-            except Exception as exc:
-                self._send_json(500, {"error": f"Failed to create directory: {exc}"})
+                safe_target = resolve_safe_path(target, ["music", "staging"])
+                if safe_target is None:
+                    self._send_json(403, {"error": "Access denied for path outside allowed roots"})
+                    return
+                os.makedirs(safe_target, exist_ok=True)
+                safe_target = resolve_safe_path(target, ["music", "staging"])
+                if safe_target is None:
+                    self._send_json(403, {"error": "Access denied for path outside allowed roots"})
+                    return
+                self._send_json(200, {"ok": True, "path": safe_target})
+            except Exception:
+                self._send_json(500, {"error": "Failed to create directory"})
             finally:
                 release_os_lock(lock_file)
             return
-
         self._send_json(404, {"error": f"Endpoint not found: {path}"})
 
     def do_PATCH(self):
@@ -1414,6 +1450,10 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
             if not fields:
                 self._send_json(400, {"error": "No fields provided"})
                 return
+            assignments, invalid_fields = _validated_update_assignments(fields, _ITEM_UPDATE_STATEMENTS)
+            if invalid_fields:
+                self._send_json(400, {"error": "Unsupported item field"})
+                return
 
             lock_file = acquire_os_lock(read_only=False)
             try:
@@ -1425,9 +1465,8 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                     self._send_json(404, {"error": f"Item {item_id} not found"})
                     return
 
-                set_clause = ", ".join(f"{k} = ?" for k in fields.keys())
-                params = list(fields.values()) + [item_id]
-                cur.execute(f"UPDATE items SET {set_clause} WHERE id = ?", params)
+                for statement, value in assignments:
+                    cur.execute(statement, (value, item_id))
                 con.commit()
                 cur.execute("SELECT * FROM items WHERE id = ?", (item_id,))
                 updated = dict(cur.fetchone())
@@ -1449,6 +1488,10 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
             if not fields:
                 self._send_json(400, {"error": "No fields provided"})
                 return
+            assignments, invalid_fields = _validated_update_assignments(fields, _ALBUM_UPDATE_STATEMENTS)
+            if invalid_fields:
+                self._send_json(400, {"error": "Unsupported album field"})
+                return
 
             lock_file = acquire_os_lock(read_only=False)
             try:
@@ -1460,9 +1503,8 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                     self._send_json(404, {"error": f"Album {album_id} not found"})
                     return
 
-                set_clause = ", ".join(f"{k} = ?" for k in fields.keys())
-                params = list(fields.values()) + [album_id]
-                cur.execute(f"UPDATE albums SET {set_clause} WHERE id = ?", params)
+                for statement, value in assignments:
+                    cur.execute(statement, (value, album_id))
                 con.commit()
                 cur.execute("SELECT * FROM albums WHERE id = ?", (album_id,))
                 updated = dict(cur.fetchone())

--- a/routes_submissions.py
+++ b/routes_submissions.py
@@ -253,7 +253,8 @@ def _submission_readiness() -> Dict[str, Any]:
     try:
         remote_status = beets_client.get_status()
     except Exception as exc:
-        remote_error = str(exc)
+        app.logger.warning("Submission readiness status check failed: %s", type(exc).__name__)
+        remote_error = "Beets control agent status is unavailable"
 
     if not isinstance(remote_status, dict) or remote_status.get("status") != "ok":
         return {

--- a/scripts/validate_compose_security.py
+++ b/scripts/validate_compose_security.py
@@ -103,6 +103,13 @@ def _dockerfile_beets_base_is_approved() -> bool:
     return False
 
 
+def _image_lacks_tag_or_digest(image: str) -> bool:
+    ref = str(image or "").strip()
+    if not ref or "@" in ref:
+        return False
+    last_component = ref.rsplit("/", 1)[-1]
+    return ":" not in last_component
+
 def _check_image_digest_semantics(label: str, image: str, has_build: bool, errors: list[str]) -> None:
     if not image:
         errors.append(f"{label} image is missing")
@@ -121,7 +128,7 @@ def _check_image_digest_semantics(label: str, image: str, has_build: bool, error
                 f"{label} image must not attach a digest to a locally built image tag "
                 f"(docker compose build fails with 'build tag cannot contain a digest'): {image}"
             )
-        elif re.match(r"^[^:@/]+(?:/[^:@]+)*$", image):
+        elif _image_lacks_tag_or_digest(image):
             errors.append(f"{label} image has no tag: {image}")
         if not _dockerfile_beets_base_is_approved():
             errors.append(
@@ -131,7 +138,7 @@ def _check_image_digest_semantics(label: str, image: str, has_build: bool, error
     else:
         if "@sha256:" not in image:
             errors.append(f"{label} image is not digest-pinned: {image}")
-        if re.match(r"^[^:@/]+(?:/[^:@]+)*$", image):
+        if _image_lacks_tag_or_digest(image):
             errors.append(f"{label} image has no tag or digest: {image}")
 
 

--- a/tests/test_external_beets_architecture.py
+++ b/tests/test_external_beets_architecture.py
@@ -87,7 +87,7 @@ class TestBeetsControlAgentSecurity(unittest.TestCase):
             self.assertFalse(result)
 
     def test_raw_query_security_handler_execution(self):
-        """Test raw SQL handler execution rejecting mutations and multi-statements."""
+        """Test raw SQL handler execution is disabled fail-closed."""
         handler = ControlAgentHandler.__new__(ControlAgentHandler)
         handler.headers = {"X-Beets-API-Token": "testtoken"}
 
@@ -99,6 +99,7 @@ class TestBeetsControlAgentSecurity(unittest.TestCase):
         handler._authenticate = lambda: True
 
         forbidden_queries = [
+            "SELECT * FROM items",
             "UPDATE items SET title='hacked'",
             "DELETE FROM items",
             "INSERT INTO items DEFAULT VALUES",
@@ -118,8 +119,8 @@ class TestBeetsControlAgentSecurity(unittest.TestCase):
             handler.do_POST()
             self.assertTrue(len(sent_responses) > 0, f"No response sent for query: {q}")
             code, data = sent_responses[0]
-            self.assertEqual(code, 400, f"Query '{q}' should have been rejected with 400, got {code}")
-            self.assertIn("error", data)
+            self.assertEqual(code, 403, f"Query '{q}' should have been rejected with 403, got {code}")
+            self.assertEqual(data.get("error"), "Raw SQL queries are not permitted")
 
     def test_s6_service_discovery_path_in_dockerfile(self):
         """Assert Dockerfile.beets uses LinuxServer supported /custom-services.d path."""
@@ -1358,7 +1359,8 @@ class TestAcoustIDChromaCapability(unittest.TestCase):
         self.assertFalse(readiness["plugins"]["mbsubmit"])
         self.assertFalse(readiness["fpcalc_available"])
         self.assertFalse(readiness["pyacoustid_available"])
-        self.assertIn("Beets Control Agent is unavailable", readiness["reason"])
+        self.assertEqual(readiness["reason"], "Beets control agent status is unavailable")
+        self.assertNotIn("Beets Control Agent is unavailable", readiness["reason"])
 
     @mock.patch("backend.beets_client.beets_client.get_status")
     def test_submission_readiness_fails_closed_on_authentication_failure(self, mock_status):

--- a/tests/test_pr39_codeql_alerts.py
+++ b/tests/test_pr39_codeql_alerts.py
@@ -1,0 +1,248 @@
+"""Regression tests for PR #39 CodeQL alert families."""
+
+import json
+import sqlite3
+import tempfile
+import unittest
+import uuid
+from io import BytesIO
+from pathlib import Path
+from unittest import mock
+
+import app as app_module
+import routes_submissions
+import scripts.validate_compose_security as compose_security
+from backend import beets_control_agent as bca
+from backend.beets_client import BeetsClient, BeetsError
+from backend.beets_control_agent import ControlAgentHandler, resolve_safe_path
+
+
+def _post_agent(path: str, payload: dict):
+    handler = ControlAgentHandler.__new__(ControlAgentHandler)
+    body = json.dumps(payload).encode("utf-8")
+    handler.path = path
+    handler.headers = {"Content-Length": str(len(body))}
+    handler.rfile = BytesIO(body)
+    handler._authenticate = lambda: True
+    responses = []
+    handler._send_json = lambda code, data: responses.append((code, data))
+    handler.do_POST()
+    return responses[0]
+
+
+def _patch_agent(path: str, payload: dict):
+    handler = ControlAgentHandler.__new__(ControlAgentHandler)
+    body = json.dumps(payload).encode("utf-8")
+    handler.path = path
+    handler.headers = {"Content-Length": str(len(body))}
+    handler.rfile = BytesIO(body)
+    handler._authenticate = lambda: True
+    responses = []
+    handler._send_json = lambda code, data: responses.append((code, data))
+    handler.do_PATCH()
+    return responses[0]
+
+
+class ControlAgentPathBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(dir="/tmp")
+        base_name = Path(self.tmp.name).name
+        self.base = f"/tmp/{base_name}"
+        self.music = f"{self.base}/music"
+        self.staging = f"{self.base}/staging"
+        self.outside = f"{self.base}/outside"
+        Path(self.music).mkdir(parents=True, exist_ok=True)
+        Path(self.staging).mkdir(parents=True, exist_ok=True)
+        Path(self.outside).mkdir(parents=True, exist_ok=True)
+        self.patches = [
+            mock.patch.object(bca, "MUSIC_LIBRARY_PATH", self.music),
+            mock.patch.object(bca, "DOWNLOAD_PATH", self.staging),
+            mock.patch.object(bca, "LOCK_PATH", f"{self.base}/agent.lock"),
+        ]
+        for patch in self.patches:
+            patch.start()
+
+    def tearDown(self):
+        for patch in reversed(self.patches):
+            patch.stop()
+        self.tmp.cleanup()
+
+    def test_resolve_safe_path_rejects_traversal_and_prefix_collision(self):
+        good = f"{self.music}/Artist/Track.flac"
+        Path(good).parent.mkdir(parents=True, exist_ok=True)
+        Path(good).write_text("audio", encoding="utf-8")
+        self.assertEqual(resolve_safe_path(good, ["music"]), str(Path(good).resolve()))
+
+        bad_paths = [
+            f"{self.music}/../outside/secret.flac",
+            f"{self.music}/%2e%2e/outside/secret.flac",
+            f"{self.music}/%252e%252e/outside/secret.flac",
+            f"{self.base}/music-other/secret.flac",
+            f"{self.outside}/secret.flac",
+            "C:\\data\\media\\music\\track.flac",
+            "\\\\server\\share\\track.flac",
+            f"{self.music}\\Artist\\Track.flac",
+        ]
+        for candidate in bad_paths:
+            with self.subTest(candidate=candidate):
+                self.assertIsNone(resolve_safe_path(candidate, ["music"]))
+
+    def test_symlink_escape_is_rejected_where_supported(self):
+        outside_secret = f"{self.outside}/secret.flac"
+        Path(outside_secret).write_text("secret", encoding="utf-8")
+        link_path = f"{self.music}/escape.flac"
+        try:
+            Path(link_path).symlink_to(Path(outside_secret))
+        except (OSError, NotImplementedError):
+            self.skipTest("Symlink creation is unavailable")
+        self.assertIsNone(resolve_safe_path(link_path, ["music"]))
+
+    def test_delete_endpoint_rejects_encoded_escape_before_mutation(self):
+        outside_secret = f"{self.outside}/secret.flac"
+        Path(outside_secret).write_text("secret", encoding="utf-8")
+        code, data = _post_agent("/files/delete", {"path": f"{self.music}/%252e%252e/outside/secret.flac"})
+        self.assertEqual(code, 403)
+        self.assertIn("allowed roots", data["error"])
+        self.assertTrue(Path(outside_secret).exists())
+
+    def test_mkdir_endpoint_rejects_prefix_collision(self):
+        code, _ = _post_agent("/files/mkdir", {"path": f"{self.base}/music-other/new"})
+        self.assertEqual(code, 403)
+        self.assertFalse(Path(f"{self.base}/music-other/new").exists())
+
+
+class ControlAgentSqlBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(dir="/tmp")
+        self.db_path = Path(self.tmp.name) / "musiclibrary.blb"
+        base_name = Path(self.tmp.name).name
+        self.music = f"/tmp/{base_name}/music"
+        self.outside = f"/tmp/{base_name}/outside"
+        Path(self.music).mkdir(parents=True, exist_ok=True)
+        Path(self.outside).mkdir(parents=True, exist_ok=True)
+        con = sqlite3.connect(self.db_path)
+        con.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, title TEXT, artist TEXT)")
+        con.execute("CREATE TABLE albums (id INTEGER PRIMARY KEY, album TEXT, albumartist TEXT, artpath TEXT)")
+        con.execute("INSERT INTO items (id, title, artist) VALUES (1, 'Safe title', 'Artist')")
+        con.execute("INSERT INTO albums (id, album, albumartist) VALUES (1, 'Safe album', 'Artist')")
+        con.commit()
+        con.close()
+        self.patches = [
+            mock.patch.object(bca, "LIB_PATH", str(self.db_path)),
+            mock.patch.object(bca, "LOCK_PATH", str(Path(self.tmp.name) / "agent.lock")),
+            mock.patch.object(bca, "MUSIC_LIBRARY_PATH", self.music),
+        ]
+        for patch in self.patches:
+            patch.start()
+
+    def tearDown(self):
+        for patch in reversed(self.patches):
+            patch.stop()
+        self.tmp.cleanup()
+
+    def test_raw_query_endpoint_rejects_all_sql(self):
+        for query in (
+            "SELECT '/* not a comment */' AS marker, title FROM items WHERE title = ?",
+            "SELECT * FROM items; SELECT * FROM albums",
+            "UPDATE items SET title='owned' WHERE id=1",
+            "WITH changed AS (DELETE FROM items RETURNING *) SELECT * FROM changed",
+            "PRAGMA database_list",
+        ):
+            with self.subTest(query=query):
+                code, data = _post_agent("/library/raw_query", {"query": query, "params": ["Safe title"]})
+                self.assertEqual(code, 403, data)
+                self.assertEqual(data["error"], "Raw SQL queries are not permitted")
+
+        con = sqlite3.connect(self.db_path)
+        title = con.execute("SELECT title FROM items WHERE id=1").fetchone()[0]
+        con.close()
+        self.assertEqual(title, "Safe title")
+
+    def test_raw_sqlite_client_helper_fails_closed_locally(self):
+        client = BeetsClient(base_url="http://127.0.0.1:1", token="unused")
+        with self.assertRaisesRegex(BeetsError, "Raw SQLite queries are not permitted"):
+            client.raw_sqlite_query("SELECT * FROM items")
+
+    def test_item_patch_rejects_injected_column_name(self):
+        code, data = _patch_agent("/items/1", {"fields": {"title = 'owned', artist": "ignored"}})
+        self.assertEqual(code, 400, data)
+        con = sqlite3.connect(self.db_path)
+        row = con.execute("SELECT title, artist FROM items WHERE id=1").fetchone()
+        con.close()
+        self.assertEqual(row, ("Safe title", "Artist"))
+
+    def test_album_patch_updates_allowlisted_column(self):
+        code, data = _patch_agent("/albums/1", {"fields": {"album": "Updated album"}})
+        self.assertEqual(code, 200, data)
+        self.assertEqual(data["album"]["album"], "Updated album")
+
+    def test_album_artpath_endpoint_persists_only_canonical_music_path(self):
+        cover = f"{self.music}/Artist/cover.jpg"
+        Path(cover).parent.mkdir(parents=True, exist_ok=True)
+        Path(cover).write_text("cover", encoding="utf-8")
+        code, data = _post_agent("/albums/1/artpath", {"artpath": cover})
+        self.assertEqual(code, 200, data)
+        self.assertEqual(data["artpath"], str(Path(cover).resolve()))
+
+        escape = f"{self.music}/%252e%252e/outside/secret.jpg"
+        code, data = _post_agent("/albums/1/artpath", {"artpath": escape})
+        self.assertEqual(code, 403, data)
+        self.assertNotIn("%252e%252e", json.dumps(data))
+
+        con = sqlite3.connect(self.db_path)
+        artpath = con.execute("SELECT artpath FROM albums WHERE id=1").fetchone()[0]
+        con.close()
+        self.assertEqual(artpath, str(Path(cover).resolve()))
+
+
+class ComposeValidatorRegexTests(unittest.TestCase):
+    def test_image_tag_check_handles_adversarial_path_without_regex_backtracking(self):
+        image = "./" + "9/" * 2000 + "beets-engine"
+        self.assertTrue(compose_security._image_lacks_tag_or_digest(image))
+
+    def test_image_tag_check_distinguishes_registry_port_from_tag(self):
+        self.assertTrue(compose_security._image_lacks_tag_or_digest("localhost:5000/beets-engine"))
+        self.assertFalse(compose_security._image_lacks_tag_or_digest("localhost:5000/beets-engine:2.4.0"))
+        self.assertFalse(compose_security._image_lacks_tag_or_digest("example.test/beets@sha256:" + "a" * 64))
+
+
+class PublicExceptionResponseTests(unittest.TestCase):
+    def test_submission_readiness_does_not_return_remote_exception_text(self):
+        leak = "LEAK_MARKER Traceback /tmp/internal.py line 12 Authorization: Bearer abc"
+        with mock.patch.object(routes_submissions.beets_client, "get_status", side_effect=RuntimeError(leak)), \
+             mock.patch.object(routes_submissions, "_acoustid_key", return_value=""), \
+             mock.patch.object(routes_submissions, "_config_has_acoustid_key", return_value=False):
+            readiness = routes_submissions._submission_readiness()
+        self.assertEqual(readiness["reason"], "Beets control agent status is unavailable")
+        self.assertNotIn("LEAK_MARKER", json.dumps(readiness))
+        self.assertNotIn("Traceback", json.dumps(readiness))
+        self.assertNotIn("Bearer abc", json.dumps(readiness))
+
+    def test_album_delete_art_does_not_return_remote_exception_text(self):
+        leak = "LEAK_MARKER Traceback /tmp/internal.py line 12 token=abc"
+        album_dir = Path(tempfile.gettempdir()) / f"pr39-art-{uuid.uuid4().hex}"
+        album_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            with app_module.app.test_request_context("/api/albums/42/art", method="DELETE"), \
+                 mock.patch.object(app_module.lib, "get_album", return_value=object()), \
+                 mock.patch.object(app_module, "_album_dir_for_art", return_value=album_dir), \
+                 mock.patch.object(app_module, "_album_stored_art_path", return_value=""), \
+                 mock.patch.object(app_module, "_path_is_under", return_value=True), \
+                 mock.patch.object(app_module, "_ALBUM_ART_NAMES", ()), \
+                 mock.patch.object(app_module.beets_client, "clear_album_artpath", side_effect=RuntimeError(leak)):
+                response, status = app_module.album_delete_art(42)
+            data = response.get_json()
+            self.assertEqual(status, 500)
+            self.assertEqual(data["error"], "Could not clear artpath.")
+            self.assertNotIn("LEAK_MARKER", json.dumps(data))
+            self.assertNotIn("Traceback", json.dumps(data))
+            self.assertNotIn("token=abc", json.dumps(data))
+        finally:
+            try:
+                album_dir.rmdir()
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Post-Merge Status (2026-07-29 17:48:55 UTC)

PR #45 was marked ready and squash-merged into refactor/external-beets-engine as a4b347c63f3363038aed2763f1acb754c2b1db18. The source branch fix/pr39-codeql-alerts was preserved.

Authoritative PR #39 CodeQL reanalysis did run at that squash SHA (30476512884), but the CodeQL status check failed because 13 high-severity py/path-injection alerts remain open (#370-#382). Any earlier child-PR CodeQL-unavailable note is historical only.
