### PR TITLE
fix: close remaining PR #39 path-injection alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,13 @@
+# CodeQL advanced-setup configuration, used only by
+# .github/workflows/codeql-advanced.yml (currently workflow_dispatch-only,
+# not auto-triggered -- see that file's header comment for why).
+#
+# This does not change or replace the default query suite: it only adds the
+# repository-local path-injection barrier model pack
+# (.github/codeql/extensions/pr39-path-sanitizers/) alongside it, so
+# resolve_safe_path()'s return value is recognized as a path-injection
+# barrier without disabling or narrowing any default security query.
+name: "PR39 path-sanitizer model config"
+packs:
+  python:
+    - iranman/beets-web-manager-pr39-path-sanitizers

--- a/.github/codeql/extensions/pr39-path-sanitizers/codeql-pack.yml
+++ b/.github/codeql/extensions/pr39-path-sanitizers/codeql-pack.yml
@@ -1,0 +1,7 @@
+name: iranman/beets-web-manager-pr39-path-sanitizers
+version: 0.0.0
+library: true
+extensionTargets:
+  codeql/python-all: "*"
+dataExtensions:
+  - models/**/*.yml

--- a/.github/codeql/extensions/pr39-path-sanitizers/models/beets-control-agent-path.yml
+++ b/.github/codeql/extensions/pr39-path-sanitizers/models/beets-control-agent-path.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/python-all
+      extensible: barrierModel
+    data:
+      - ["backend.beets_control_agent", "Member[resolve_safe_path].ReturnValue", "path-injection"]

--- a/.github/workflows/codeql-advanced.yml
+++ b/.github/workflows/codeql-advanced.yml
@@ -1,0 +1,76 @@
+# NOT YET ACTIVE. Manual (workflow_dispatch) trigger only.
+#
+# Why this file exists: `gh api repos/Iranman/beets-web-manager/code-scanning/default-setup`
+# confirms this repository currently relies on GitHub's *default* CodeQL
+# setup (state: configured, query_suite: default). Default setup has no
+# mechanism to load a repository-local CodeQL pack -- it cannot discover
+# .github/codeql/extensions/pr39-path-sanitizers/, no matter how correctly
+# that pack is authored. Confirmed independently: `code-scanning/analyses`
+# shows zero CodeQL analyses have ever run for this branch or any PR whose
+# base is not `main` (only refs/pull/39/head and refs/heads/main have any).
+#
+# This workflow is what *advanced* setup would look like if the project
+# owner chooses to adopt it: it runs the same languages as default setup
+# and does not narrow, exclude, or disable any default security query --
+# it only additionally loads the local path-injection barrier model pack
+# via .github/codeql/codeql-config.yml, so resolve_safe_path()'s return
+# value is recognized as a barrier without weakening anything else.
+#
+# GitHub does not allow default setup and a custom analysis workflow to run
+# at the same time. Enabling this file for real requires the repository
+# owner to first disable default setup in Settings -> Code security ->
+# Code scanning, then change the trigger below from workflow_dispatch to
+# the commented-out pull_request/push/schedule block. That repository-wide
+# setting change is outside this PR's authorized scope, so the trigger is
+# left manual-only here to avoid creating a live conflict on push.
+#
+# The CodeQL CLI was not available to test this configuration locally, so
+# pack resolution here is unverified -- treat it as a documented starting
+# point for the project owner's decision, not a proven-working pipeline.
+
+name: CodeQL (advanced, local path-sanitizer pack)
+
+on:
+  workflow_dispatch: {}
+  # pull_request:
+  # push:
+  #   branches: [main]
+  # schedule:
+  #   - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  packages: read
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/backend/beets_control_agent.py
+++ b/backend/beets_control_agent.py
@@ -74,6 +74,7 @@ _TAG_WRITE_FIELDS = {
 _PATH_DECODE_LIMIT = 5
 _ENCODED_SEPARATOR_RE = re.compile(r"%(?:2f|5c|00)", re.IGNORECASE)
 _ENCODED_BYTE_RE = re.compile(r"%[0-9a-f]{2}", re.IGNORECASE)
+_DOTDOT_SEGMENT_RE = re.compile(r"(^|/)\.\.(/|$)")
 _ALLOWED_ROOT_ERROR = {
     "error": "Refusing to operate on an allowed root",
     "code": "allowed_root_operation_denied",
@@ -525,7 +526,19 @@ def resolve_safe_path(path: str, allowed_types: list = None) -> Optional[str]:
     if ".." in parts or "." in parts:
         return None
 
-    abs_path = os.path.abspath(decoded)
+    # Canonicalize from the ORIGINAL raw path, not the decoded form above:
+    # decoding is used only to detect a hidden traversal/separator/null-byte
+    # attack encoded into the request. The API contract for this endpoint
+    # family is a raw filesystem path (values arrive in a JSON POST body,
+    # never URL-encoded by any real caller) -- a legitimate literal filename
+    # that merely contains a percent-sign byte sequence (e.g.
+    # "50%20off.flac") must resolve to itself, not be silently rewritten to
+    # a different string ("50 off.flac") before it reaches the filesystem
+    # sink. Since any %2f/%5c/%00 sequence was already rejected before this
+    # point, decoding cannot have introduced a new "/" that isn't already at
+    # the same position in the raw string, so re-deriving parts/leading-slash
+    # from `decoded` above and the canonical value from `path` here is safe.
+    abs_path = os.path.abspath(path)
     real_path = os.path.realpath(abs_path)
     for root in _allowed_root_paths(allowed_types):
         if _path_is_within(real_path, root):
@@ -573,7 +586,20 @@ def _sanitize_command_path_args(args: Any, error_context: str) -> tuple[Optional
         s_arg = str(arg)
         if s_arg in ("-c", "--config") or s_arg.startswith(("-c=", "--config=")):
             return None, {"error": f"Unsupported config override in {error_context} args"}
-        if s_arg.startswith(".") or ".." in s_arg or "\\" in s_arg or "\x00" in s_arg:
+        # Reject ".." only as an actual path segment (bounded by "/" or the
+        # whole string), not as a bare substring: Beets' own query syntax
+        # uses ".." for range queries (e.g. `year:2020..2023`,
+        # `added:2020-01-01..2020-02-01`), which a blanket substring check
+        # would incorrectly reject even though these args are never
+        # filesystem-joined. A relative arg is still only relevant to
+        # traversal for a command like `import` that can accept a second
+        # positional path, so a genuine "../"-shaped segment must still be
+        # blocked.
+        if (
+            s_arg == "." or s_arg.startswith("./")
+            or _DOTDOT_SEGMENT_RE.search(s_arg)
+            or "\\" in s_arg or "\x00" in s_arg
+        ):
             return None, {"error": f"Invalid path parameter in {error_context} args"}
         if s_arg.startswith("/"):
             safe_arg = resolve_safe_path(s_arg, ["music", "staging", "config", "tmp"])

--- a/backend/beets_control_agent.py
+++ b/backend/beets_control_agent.py
@@ -71,6 +71,13 @@ _TAG_WRITE_FIELDS = {
     "lyrics", "composer", "mb_trackid", "mb_albumid", "mb_artistid",
     "mb_albumartistid", "mb_releasegroupid",
 }
+_PATH_DECODE_LIMIT = 5
+_ENCODED_SEPARATOR_RE = re.compile(r"%(?:2f|5c|00)", re.IGNORECASE)
+_ENCODED_BYTE_RE = re.compile(r"%[0-9a-f]{2}", re.IGNORECASE)
+_ALLOWED_ROOT_ERROR = {
+    "error": "Refusing to operate on an allowed root",
+    "code": "allowed_root_operation_denied",
+}
 
 
 def _invalid_field_names(fields: dict, allowed: set) -> list:
@@ -440,15 +447,29 @@ def require_command_capability(command: str) -> Optional[dict]:
 
 def _decode_untrusted_path(raw_path: str) -> Optional[str]:
     decoded = raw_path
-    for _ in range(5):
+    for _ in range(_PATH_DECODE_LIMIT):
+        if _ENCODED_SEPARATOR_RE.search(decoded):
+            return None
         try:
-            next_decoded = urllib.parse.unquote(decoded)
-        except Exception:
+            next_decoded = urllib.parse.unquote(decoded, errors="strict")
+        except (UnicodeDecodeError, ValueError):
             return None
         if next_decoded == decoded:
+            if _ENCODED_BYTE_RE.search(decoded):
+                return None
             return decoded
         decoded = next_decoded
-    return None
+        if "\x00" in decoded or "\\" in decoded:
+            return None
+
+    try:
+        if urllib.parse.unquote(decoded, errors="strict") != decoded:
+            return None
+    except (UnicodeDecodeError, ValueError):
+        return None
+    if _ENCODED_BYTE_RE.search(decoded):
+        return None
+    return decoded
 
 
 def _allowed_root_paths(allowed_types: list = None) -> list[str]:
@@ -482,9 +503,12 @@ def resolve_safe_path(path: str, allowed_types: list = None) -> Optional[str]:
 
     Callers must use this returned value for filesystem operations. Returning a
     bool and then operating on the original request value leaves a gap for mixed
-    encodings, symlink components, and prefix-collision paths.
+    encodings, symlink components, and prefix-collision paths. This is the
+    control agent's path security boundary; its ReturnValue is modeled as a
+    CodeQL path-injection barrier, so changes require adversarial tests and
+    CodeQL reanalysis.
     """
-    if not path or not isinstance(path, str):
+    if not isinstance(path, str) or not path.strip():
         return None
     if "\x00" in path or "\\" in path:
         return None
@@ -494,7 +518,7 @@ def resolve_safe_path(path: str, allowed_types: list = None) -> Optional[str]:
         return None
     if "\x00" in decoded or "\\" in decoded:
         return None
-    if not decoded.startswith("/"):
+    if not decoded.startswith("/") or decoded.startswith("//"):
         return None
 
     parts = decoded.split("/")
@@ -512,6 +536,53 @@ def resolve_safe_path(path: str, allowed_types: list = None) -> Optional[str]:
 def is_safe_path(path: str, allowed_types: list = None) -> bool:
     """Verify that path stays strictly within allowed roots."""
     return resolve_safe_path(path, allowed_types) is not None
+
+
+def _is_allowed_root_path(safe_path: str, allowed_types: list = None) -> bool:
+    try:
+        real_candidate = os.path.realpath(safe_path)
+        return any(real_candidate == os.path.realpath(root) for root in _allowed_root_paths(allowed_types))
+    except Exception:
+        return False
+
+
+def _creation_parent_is_safe(safe_path: str, allowed_types: list = None) -> bool:
+    parent = os.path.dirname(safe_path)
+    if not parent or parent == safe_path:
+        return False
+
+    existing_parent = parent
+    while existing_parent and not os.path.exists(existing_parent):
+        next_parent = os.path.dirname(existing_parent)
+        if next_parent == existing_parent:
+            return False
+        existing_parent = next_parent
+
+    real_existing_parent = os.path.realpath(existing_parent)
+    if not os.path.isdir(real_existing_parent):
+        return False
+    return any(_path_is_within(real_existing_parent, root) for root in _allowed_root_paths(allowed_types))
+
+
+def _sanitize_command_path_args(args: Any, error_context: str) -> tuple[Optional[list[str]], Optional[dict[str, str]]]:
+    if not isinstance(args, list):
+        return None, {"error": f"{error_context} args must be a list"}
+
+    sanitized: list[str] = []
+    for arg in args:
+        s_arg = str(arg)
+        if s_arg in ("-c", "--config") or s_arg.startswith(("-c=", "--config=")):
+            return None, {"error": f"Unsupported config override in {error_context} args"}
+        if s_arg.startswith(".") or ".." in s_arg or "\\" in s_arg or "\x00" in s_arg:
+            return None, {"error": f"Invalid path parameter in {error_context} args"}
+        if s_arg.startswith("/"):
+            safe_arg = resolve_safe_path(s_arg, ["music", "staging", "config", "tmp"])
+            if safe_arg is None:
+                return None, {"error": f"Access denied for path in {error_context} args"}
+            sanitized.append(safe_arg)
+        else:
+            sanitized.append(s_arg)
+    return sanitized, None
 
 
 def acquire_os_lock(read_only: bool = False):
@@ -686,17 +757,25 @@ def _handle_delete_album(album_id: int, delete_files: bool = True) -> tuple:
             file_errors = []
             if delete_files:
                 for fpath in item_files:
-                    if fpath and is_safe_path(fpath, ["music", "staging"]) and os.path.exists(fpath):
+                    safe_fpath = resolve_safe_path(fpath, ["music", "staging"])
+                    if safe_fpath is None:
+                        file_errors.append("Skipped unsafe album item path")
+                        continue
+                    if _is_allowed_root_path(safe_fpath, ["music", "staging"]):
+                        file_errors.append("Skipped allowed root path")
+                        continue
+                    if os.path.exists(safe_fpath):
                         try:
-                            os.unlink(fpath)
+                            os.unlink(safe_fpath)
                             files_deleted += 1
-                        except Exception as exc:
-                            file_errors.append(f"Failed to delete {fpath}: {exc}")
+                        except Exception:
+                            file_errors.append("Failed to delete album item file")
 
-                if album_path and is_safe_path(album_path, ["music"]) and os.path.exists(album_path):
+                safe_album_path = resolve_safe_path(album_path, ["music"]) if album_path else None
+                if safe_album_path and not _is_allowed_root_path(safe_album_path, ["music"]) and os.path.exists(safe_album_path):
                     try:
-                        if os.path.isdir(album_path) and not os.listdir(album_path):
-                            os.rmdir(album_path)
+                        if os.path.isdir(safe_album_path) and not os.listdir(safe_album_path):
+                            os.rmdir(safe_album_path)
                     except Exception:
                         pass
 
@@ -1141,30 +1220,28 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 self._send_json(409, capability_error)
                 return
 
+            safe_source_path = None
             if source_path:
                 allowed_roots = ["staging"] if command == "import" else ["music", "staging"]
-                if not is_safe_path(source_path, allowed_roots):
-                    self._send_json(403, {"error": f"Access denied for source_path: {source_path}"})
+                safe_source_path = resolve_safe_path(source_path, allowed_roots)
+                if safe_source_path is None:
+                    self._send_json(403, {"error": "Access denied for source_path outside allowed roots"})
                     return
 
             if target_path:
-                if not is_safe_path(target_path, ["music", "staging"]):
-                    self._send_json(403, {"error": f"Access denied for target_path: {target_path}"})
+                if resolve_safe_path(target_path, ["music", "staging"]) is None:
+                    self._send_json(403, {"error": "Access denied for target_path outside allowed roots"})
                     return
 
-            for arg in args:
-                s_arg = str(arg)
-                if s_arg.startswith(".") or ".." in s_arg or "\\" in s_arg or "\x00" in s_arg:
-                    self._send_json(403, {"error": f"Invalid path parameter in command args: {arg}"})
-                    return
-                if s_arg.startswith("/") and not is_safe_path(s_arg, ["music", "staging", "config", "tmp"]):
-                    self._send_json(403, {"error": f"Access denied for path in command args: {arg}"})
-                    return
+            sanitized_args, arg_error = _sanitize_command_path_args(args, "command")
+            if arg_error is not None:
+                self._send_json(403, arg_error)
+                return
 
             cmd_list = [command]
-            if source_path:
-                cmd_list.append(source_path)
-            cmd_list.extend([str(a) for a in args])
+            if safe_source_path:
+                cmd_list.append(safe_source_path)
+            cmd_list.extend(sanitized_args or [])
 
             mutating = command in {
                 "import", "update", "write", "move", "modify", "mbsync",
@@ -1200,7 +1277,7 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
             except subprocess.TimeoutExpired:
                 self._send_json(408, {"error": f"Command '{command}' timed out after {timeout}s", "returncode": 124})
             except Exception as exc:
-                self._send_json(500, {"error": f"Command execution error: {exc}"})
+                self._send_json(500, {"error": "Command execution error"})
             finally:
                 if tmp_cfg_path and os.path.exists(tmp_cfg_path):
                     try:
@@ -1226,26 +1303,24 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 self._send_json(409, capability_error)
                 return
 
+            safe_source_path = None
             if source_path:
                 allowed_roots = ["staging"] if command == "import" else ["music", "staging"]
-                if not is_safe_path(source_path, allowed_roots):
-                    self._send_json(403, {"error": f"Access denied for source_path: {source_path}"})
+                safe_source_path = resolve_safe_path(source_path, allowed_roots)
+                if safe_source_path is None:
+                    self._send_json(403, {"error": "Access denied for source_path outside allowed roots"})
                     return
 
-            for arg in args:
-                s_arg = str(arg)
-                if s_arg.startswith(".") or ".." in s_arg or "\\" in s_arg or "\x00" in s_arg:
-                    self._send_json(403, {"error": f"Invalid path parameter in job args: {arg}"})
-                    return
-                if s_arg.startswith("/") and not is_safe_path(s_arg, ["music", "staging", "config", "tmp"]):
-                    self._send_json(403, {"error": f"Access denied for path in job args: {arg}"})
-                    return
+            sanitized_args, arg_error = _sanitize_command_path_args(args, "job")
+            if arg_error is not None:
+                self._send_json(403, arg_error)
+                return
 
             job_id = uuid.uuid4().hex
             cmd_list = [command]
-            if source_path:
-                cmd_list.append(source_path)
-            cmd_list.extend([str(a) for a in args])
+            if safe_source_path:
+                cmd_list.append(safe_source_path)
+            cmd_list.extend(sanitized_args or [])
 
             job = AgentJob(job_id, cmd_list, label=label, config_override=config_override)
             with JOBS_LOCK:
@@ -1374,6 +1449,12 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
             if safe_src is None or safe_dst is None:
                 self._send_json(403, {"error": "Access denied for path outside allowed roots"})
                 return
+            if _is_allowed_root_path(safe_src, ["music", "staging"]) or _is_allowed_root_path(safe_dst, ["music", "staging"]):
+                self._send_json(403, _ALLOWED_ROOT_ERROR)
+                return
+            if not _creation_parent_is_safe(safe_dst, ["music", "staging"]):
+                self._send_json(403, {"error": "Access denied for destination parent outside allowed roots"})
+                return
             if not os.path.exists(safe_src):
                 self._send_json(404, {"error": "Source path not found"})
                 return
@@ -1385,9 +1466,16 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 if safe_src is None or safe_dst is None or not os.path.exists(safe_src):
                     self._send_json(403, {"error": "Access denied for path outside allowed roots"})
                     return
-                os.makedirs(os.path.dirname(safe_dst), exist_ok=True)
+                if _is_allowed_root_path(safe_src, ["music", "staging"]) or _is_allowed_root_path(safe_dst, ["music", "staging"]):
+                    self._send_json(403, _ALLOWED_ROOT_ERROR)
+                    return
+                if not _creation_parent_is_safe(safe_dst, ["music", "staging"]):
+                    self._send_json(403, {"error": "Access denied for destination parent outside allowed roots"})
+                    return
+                safe_dst_parent = os.path.dirname(safe_dst)
+                os.makedirs(safe_dst_parent, exist_ok=True)
                 safe_dst = resolve_safe_path(dst, ["music", "staging"])
-                if safe_dst is None:
+                if safe_dst is None or _is_allowed_root_path(safe_dst, ["music", "staging"]):
                     self._send_json(403, {"error": "Access denied for path outside allowed roots"})
                     return
                 shutil.move(safe_src, safe_dst)
@@ -1404,6 +1492,9 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
             if safe_target is None:
                 self._send_json(403, {"error": "Access denied for path outside allowed roots"})
                 return
+            if _is_allowed_root_path(safe_target, ["music", "staging"]):
+                self._send_json(403, _ALLOWED_ROOT_ERROR)
+                return
             if not os.path.exists(safe_target):
                 self._send_json(200, {"ok": True, "path": safe_target, "existed": False})
                 return
@@ -1413,6 +1504,12 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 safe_target = resolve_safe_path(target, ["music", "staging"])
                 if safe_target is None:
                     self._send_json(403, {"error": "Access denied for path outside allowed roots"})
+                    return
+                if _is_allowed_root_path(safe_target, ["music", "staging"]):
+                    self._send_json(403, _ALLOWED_ROOT_ERROR)
+                    return
+                if not os.path.exists(safe_target):
+                    self._send_json(200, {"ok": True, "path": safe_target, "existed": False})
                     return
                 if os.path.isdir(safe_target):
                     shutil.rmtree(safe_target)
@@ -1431,12 +1528,24 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
             if safe_target is None:
                 self._send_json(403, {"error": "Access denied for path outside allowed roots"})
                 return
+            if _is_allowed_root_path(safe_target, ["music", "staging"]):
+                self._send_json(403, _ALLOWED_ROOT_ERROR)
+                return
+            if not _creation_parent_is_safe(safe_target, ["music", "staging"]):
+                self._send_json(403, {"error": "Access denied for parent outside allowed roots"})
+                return
 
             lock_file = acquire_os_lock(read_only=False)
             try:
                 safe_target = resolve_safe_path(target, ["music", "staging"])
                 if safe_target is None:
                     self._send_json(403, {"error": "Access denied for path outside allowed roots"})
+                    return
+                if _is_allowed_root_path(safe_target, ["music", "staging"]):
+                    self._send_json(403, _ALLOWED_ROOT_ERROR)
+                    return
+                if not _creation_parent_is_safe(safe_target, ["music", "staging"]):
+                    self._send_json(403, {"error": "Access denied for parent outside allowed roots"})
                     return
                 os.makedirs(safe_target, exist_ok=True)
                 safe_target = resolve_safe_path(target, ["music", "staging"])

--- a/tests/test_external_beets_architecture.py
+++ b/tests/test_external_beets_architecture.py
@@ -352,6 +352,7 @@ class TestBeetsClientRemoteOnly(unittest.TestCase):
             con.close()
 
             with mock.patch("backend.beets_control_agent.LIB_PATH", str(db_path)), \
+                 mock.patch("backend.beets_control_agent.MUSIC_LIBRARY_PATH", str(music_path)), \
                  mock.patch("backend.beets_control_agent.is_safe_path", return_value=True), \
                  mock.patch("os.unlink", side_effect=PermissionError("Permission denied")):
                 code, res = _handle_delete_album(1, delete_files=True)

--- a/tests/test_pr39_codeql_alerts.py
+++ b/tests/test_pr39_codeql_alerts.py
@@ -137,6 +137,59 @@ class ControlAgentPathBoundaryTests(unittest.TestCase):
         self.assertEqual(code, 403)
         self.assertFalse(Path(f"{self.base}/music-other/new").exists())
 
+    def test_resolve_safe_path_preserves_literal_percent_filename(self):
+        """Regression test: resolve_safe_path must canonicalize from the
+        original raw path, not its decoded form. Decoding is used only to
+        detect a hidden traversal/separator/null-byte attack; a legitimate
+        literal filename that happens to contain a percent-sign byte
+        sequence (e.g. "50%20off.flac") must resolve to itself and not be
+        silently rewritten to a different string ("50 off.flac") before it
+        reaches the filesystem sink -- this API's contract is a raw
+        filesystem path (values arrive in a JSON body, never URL-encoded by
+        any real caller), so decoding must never change what gets operated on."""
+        literal = f"{self.music}/convention%20album.flac"
+        Path(literal).write_text("audio", encoding="utf-8")
+        decoded_sibling = f"{self.music}/convention album.flac"
+        self.assertFalse(Path(decoded_sibling).exists())
+
+        result = resolve_safe_path(literal, ["music"])
+        self.assertEqual(result, str(Path(literal).resolve()))
+        self.assertNotEqual(result, str(Path(decoded_sibling).resolve()))
+
+        with mock.patch.object(bca.os, "unlink") as unlink_mock:
+            code, data = _post_agent("/files/delete", {"path": literal})
+        self.assertEqual(code, 200, data)
+        unlink_mock.assert_called_once_with(str(Path(literal).resolve()))
+
+    def test_command_args_allow_beets_range_query_syntax(self):
+        """Regression test: a blanket '".." in arg' substring check rejected
+        legitimate Beets range-query syntax (e.g. `year:2020..2023`,
+        `added:2020-01-01..2020-02-01`), which is never filesystem-joined --
+        only an actual relative path segment ("..", "../x", "x/..") is a
+        real traversal-relevant shape and must still be rejected."""
+        source = Path(self.staging) / "import-source"
+        source.mkdir()
+        fake_result = mock.MagicMock(returncode=0, stdout="", stderr="")
+
+        legitimate_args = ["year:2020..2023", "added:2020-01-01..2020-02-01", "artist:Weird Al..."]
+        with mock.patch.object(bca.subprocess, "run", return_value=fake_result) as run_mock:
+            code, data = _post_agent("/commands/execute", {
+                "command": "ls",
+                "args": legitimate_args,
+            })
+        self.assertEqual(code, 200, data)
+        full_cmd = run_mock.call_args.args[0]
+        self.assertEqual(full_cmd[-len(legitimate_args):], legitimate_args)
+
+        for traversal_arg in ["..", "../etc/passwd", "foo/../bar", "./relative"]:
+            with self.subTest(arg=traversal_arg):
+                with mock.patch.object(bca.subprocess, "run") as run_mock:
+                    code, data = _post_agent("/commands/execute", {
+                        "command": "ls",
+                        "args": [traversal_arg],
+                    })
+                self.assertEqual(code, 403, data)
+                run_mock.assert_not_called()
 
     def test_resolve_safe_path_rejects_extended_malicious_inputs(self):
         bad_paths = [

--- a/tests/test_pr39_codeql_alerts.py
+++ b/tests/test_pr39_codeql_alerts.py
@@ -1,8 +1,11 @@
 """Regression tests for PR #39 CodeQL alert families."""
 
 import json
+import shutil
 import sqlite3
+import sys
 import tempfile
+import types
 import unittest
 import uuid
 from io import BytesIO
@@ -41,6 +44,30 @@ def _patch_agent(path: str, payload: dict):
     handler._send_json = lambda code, data: responses.append((code, data))
     handler.do_PATCH()
     return responses[0]
+
+
+def _delete_agent(path: str, payload: dict):
+    handler = ControlAgentHandler.__new__(ControlAgentHandler)
+    body = json.dumps(payload).encode("utf-8")
+    handler.path = path
+    handler.headers = {"Content-Length": str(len(body))}
+    handler.rfile = BytesIO(body)
+    handler._authenticate = lambda: True
+    responses = []
+    handler._send_json = lambda code, data: responses.append((code, data))
+    handler.do_DELETE()
+    return responses[0]
+
+
+def _encoded_dotdot(layers: int) -> str:
+    dot = "%2e"
+    for _ in range(layers - 1):
+        dot = dot.replace("%", "%25")
+    return f"{dot}{dot}"
+
+
+def _api_path(path: Path) -> str:
+    return str(path).replace("\\", "/")
 
 
 class ControlAgentPathBoundaryTests(unittest.TestCase):
@@ -110,6 +137,289 @@ class ControlAgentPathBoundaryTests(unittest.TestCase):
         self.assertEqual(code, 403)
         self.assertFalse(Path(f"{self.base}/music-other/new").exists())
 
+
+    def test_resolve_safe_path_rejects_extended_malicious_inputs(self):
+        bad_paths = [
+            "",
+            "   ",
+            None,
+            f"{self.music}/Artist/./Track.flac",
+            f"{self.music}/{_encoded_dotdot(1)}/outside/secret.flac",
+            f"{self.music}/{_encoded_dotdot(2)}/outside/secret.flac",
+            f"{self.music}/{_encoded_dotdot(5)}/outside/secret.flac",
+            f"{self.music}/{_encoded_dotdot(6)}/outside/secret.flac",
+            f"{self.music}/Artist%2fTrack.flac",
+            f"{self.outside}/secret.flac",
+            f"{self.music}/Track.flac\x00.jpg",
+            f"{self.music}\\Artist\\Track.flac",
+            "C:/data/media/music/track.flac",
+            "\\\\server\\share\\track.flac",
+            "//server/share/track.flac",
+        ]
+        for candidate in bad_paths:
+            with self.subTest(candidate=candidate):
+                self.assertIsNone(resolve_safe_path(candidate, ["music"]))
+
+    def test_symlink_directory_escape_is_rejected_where_supported(self):
+        link_dir = f"{self.music}/escape-dir"
+        try:
+            Path(link_dir).symlink_to(Path(self.outside), target_is_directory=True)
+        except (OSError, NotImplementedError):
+            self.skipTest("Symlink creation is unavailable")
+        self.assertIsNone(resolve_safe_path(f"{link_dir}/secret.flac", ["music"]))
+
+    def test_delete_endpoint_uses_canonical_path_and_refuses_root(self):
+        code, data = _post_agent("/files/delete", {"path": self.music})
+        self.assertEqual(code, 403, data)
+        self.assertEqual(data["code"], "allowed_root_operation_denied")
+
+        safe_missing = f"{self.music}/Artist/missing.flac"
+        code, data = _post_agent("/files/delete", {"path": safe_missing})
+        self.assertEqual(code, 200, data)
+        self.assertFalse(data["existed"])
+        self.assertEqual(data["path"], str(Path(safe_missing).resolve()))
+
+        existing = f"{self.music}/Artist/Track.flac"
+        Path(existing).parent.mkdir(parents=True, exist_ok=True)
+        Path(existing).write_text("audio", encoding="utf-8")
+        with mock.patch.object(bca.os, "unlink") as unlink_mock:
+            code, data = _post_agent("/files/delete", {"path": existing})
+        self.assertEqual(code, 200, data)
+        self.assertTrue(data["existed"])
+        unlink_mock.assert_called_once_with(str(Path(existing).resolve()))
+
+    def test_delete_endpoint_rejects_symlink_escape_before_unlink(self):
+        outside_secret = Path(self.outside) / "secret.flac"
+        outside_secret.write_text("secret", encoding="utf-8")
+        link_path = Path(self.music) / "escape.flac"
+        try:
+            link_path.symlink_to(outside_secret)
+        except (OSError, NotImplementedError):
+            self.skipTest("Symlink creation is unavailable")
+        with mock.patch.object(bca.os, "unlink") as unlink_mock:
+            code, data = _post_agent("/files/delete", {"path": _api_path(link_path)})
+        self.assertEqual(code, 403, data)
+        unlink_mock.assert_not_called()
+        self.assertTrue(outside_secret.exists())
+
+    def test_mkdir_endpoint_validates_parent_and_revalidates_after_creation(self):
+        target = f"{self.music}/Artist/New Album"
+        code, data = _post_agent("/files/mkdir", {"path": target})
+        self.assertEqual(code, 200, data)
+        self.assertEqual(data["path"], str(Path(target).resolve()))
+        self.assertTrue(Path(target).is_dir())
+
+        code, data = _post_agent("/files/mkdir", {"path": self.music})
+        self.assertEqual(code, 403, data)
+        self.assertEqual(data["code"], "allowed_root_operation_denied")
+
+    def test_mkdir_rejects_symlink_parent_escape_where_supported(self):
+        link_dir = Path(self.music) / "linked-parent"
+        try:
+            link_dir.symlink_to(Path(self.outside), target_is_directory=True)
+        except (OSError, NotImplementedError):
+            self.skipTest("Symlink creation is unavailable")
+        target = link_dir / "child"
+        code, data = _post_agent("/files/mkdir", {"path": _api_path(target)})
+        self.assertEqual(code, 403, data)
+        self.assertFalse((Path(self.outside) / "child").exists())
+
+    def test_mkdir_rejects_parent_symlink_replacement_race(self):
+        race_parent = Path(self.music) / "race-parent"
+        race_parent.mkdir()
+        target = race_parent / "child"
+
+        def replace_parent_with_symlink(path, exist_ok=False):
+            shutil.rmtree(race_parent)
+            race_parent.symlink_to(Path(self.outside), target_is_directory=True)
+
+        with mock.patch.object(bca, "acquire_os_lock", return_value=None), \
+             mock.patch.object(bca, "release_os_lock"), \
+             mock.patch.object(bca.os, "makedirs", side_effect=replace_parent_with_symlink):
+            code, data = _post_agent("/files/mkdir", {"path": _api_path(target)})
+        self.assertEqual(code, 403, data)
+        self.assertFalse((Path(self.outside) / "child").exists())
+
+    def test_move_endpoint_uses_canonical_paths_and_rejects_symlink_parent(self):
+        src = Path(self.staging) / "download.flac"
+        src.write_text("audio", encoding="utf-8")
+        dst = Path(self.music) / "Artist" / "Album" / "download.flac"
+        with mock.patch.object(bca.shutil, "move") as move_mock:
+            code, data = _post_agent("/files/move", {"source_path": _api_path(src), "target_path": _api_path(dst)})
+        self.assertEqual(code, 200, data)
+        move_mock.assert_called_once_with(str(src.resolve()), str(dst.resolve()))
+        self.assertEqual(data["source_path"], str(src.resolve()))
+        self.assertEqual(data["target_path"], str(dst.resolve()))
+
+        link_dir = Path(self.music) / "escape-destination"
+        try:
+            link_dir.symlink_to(Path(self.outside), target_is_directory=True)
+        except (OSError, NotImplementedError):
+            self.skipTest("Symlink creation is unavailable")
+        with mock.patch.object(bca.shutil, "move") as move_mock:
+            code, data = _post_agent("/files/move", {"source_path": _api_path(src), "target_path": _api_path(link_dir / "file.flac")})
+        self.assertEqual(code, 403, data)
+        move_mock.assert_not_called()
+
+    def test_move_revalidates_parent_after_symlink_race(self):
+        src = Path(self.staging) / "download.flac"
+        src.write_text("audio", encoding="utf-8")
+        race_parent = Path(self.music) / "race-move"
+        race_parent.mkdir()
+        dst = race_parent / "download.flac"
+
+        def replace_parent_with_symlink(path, exist_ok=False):
+            shutil.rmtree(race_parent)
+            race_parent.symlink_to(Path(self.outside), target_is_directory=True)
+
+        with mock.patch.object(bca, "acquire_os_lock", return_value=None), \
+             mock.patch.object(bca, "release_os_lock"), \
+             mock.patch.object(bca.os, "makedirs", side_effect=replace_parent_with_symlink), \
+             mock.patch.object(bca.shutil, "move") as move_mock:
+            code, data = _post_agent("/files/move", {"source_path": _api_path(src), "target_path": _api_path(dst)})
+        self.assertEqual(code, 403, data)
+        move_mock.assert_not_called()
+        self.assertTrue(src.exists())
+
+    def test_commands_execute_and_jobs_create_use_canonical_paths(self):
+        source = Path(self.staging) / "import-source"
+        source.mkdir()
+        arg_file = Path(self.music) / "Artist" / "Track.flac"
+        arg_file.parent.mkdir(parents=True, exist_ok=True)
+        arg_file.write_text("audio", encoding="utf-8")
+
+        fake_result = mock.MagicMock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(bca.subprocess, "run", return_value=fake_result) as run_mock:
+            code, data = _post_agent("/commands/execute", {
+                "command": "import",
+                "source_path": _api_path(source),
+                "args": ["--quiet", _api_path(arg_file)],
+            })
+        self.assertEqual(code, 200, data)
+        full_cmd = run_mock.call_args.args[0]
+        self.assertEqual(full_cmd[-4:], ["import", str(source.resolve()), "--quiet", str(arg_file.resolve())])
+
+        created = {}
+
+        class FakeJob:
+            def __init__(self, job_id, command, label="", config_override=""):
+                self.command = command
+                created["job_id"] = job_id
+                created["command"] = command
+
+        with mock.patch.object(bca, "AgentJob", FakeJob):
+            code, data = _post_agent("/jobs/create", {
+                "command": "import",
+                "source_path": _api_path(source),
+                "args": ["--quiet", _api_path(arg_file)],
+            })
+        try:
+            self.assertEqual(code, 200, data)
+            self.assertEqual(created["command"], ["import", str(source.resolve()), "--quiet", str(arg_file.resolve())])
+        finally:
+            bca.JOBS.pop(created.get("job_id"), None)
+
+    def test_command_path_rejections_do_not_echo_unsafe_values(self):
+        unsafe = f"{self.staging}/{_encoded_dotdot(2)}/outside"
+        with mock.patch.object(bca.subprocess, "run") as run_mock:
+            code, data = _post_agent("/commands/execute", {"command": "import", "source_path": unsafe, "args": []})
+        self.assertEqual(code, 403, data)
+        run_mock.assert_not_called()
+        self.assertNotIn(_encoded_dotdot(2), json.dumps(data))
+
+        with mock.patch.object(bca.subprocess, "run") as run_mock:
+            code, data = _post_agent("/commands/execute", {
+                "command": "import",
+                "source_path": self.staging,
+                "args": ["--config=/etc/passwd"],
+            })
+        self.assertEqual(code, 403, data)
+        run_mock.assert_not_called()
+        self.assertNotIn("/etc/passwd", json.dumps(data))
+
+        before_jobs = set(bca.JOBS)
+        code, data = _post_agent("/jobs/create", {"command": "import", "source_path": unsafe, "args": []})
+        self.assertEqual(code, 403, data)
+        self.assertEqual(set(bca.JOBS), before_jobs)
+        self.assertNotIn(_encoded_dotdot(2), json.dumps(data))
+
+        code, data = _post_agent("/jobs/create", {
+            "command": "import",
+            "source_path": self.staging,
+            "args": ["-c", "/etc/passwd"],
+        })
+        self.assertEqual(code, 403, data)
+        self.assertEqual(set(bca.JOBS), before_jobs)
+        self.assertNotIn("/etc/passwd", json.dumps(data))
+
+    def test_tag_read_and_write_use_canonical_mediafile_path(self):
+        track = Path(self.music) / "Artist" / "Track.flac"
+        track.parent.mkdir(parents=True, exist_ok=True)
+        track.write_text("audio", encoding="utf-8")
+        seen_paths = []
+        saved_paths = []
+
+        class FakeMediaFile:
+            def __init__(self, path):
+                seen_paths.append(path)
+                self.title = "Title"
+                self.artist = "Artist"
+                self.album = "Album"
+                self.albumartist = "Artist"
+                self.year = 2026
+                self.track = 1
+                self.tracktotal = 1
+                self.disc = 1
+                self.disctotal = 1
+                self.genre = "Genre"
+                self.mb_trackid = "recording-id"
+                self.mb_albumid = "release-id"
+                self.mb_artistid = "artist-id"
+                self.mb_albumartistid = "albumartist-id"
+                self.mb_releasegroupid = "release-group-id"
+
+            def save(self):
+                saved_paths.append(seen_paths[-1])
+
+        beets_module = types.ModuleType("beets")
+        mediafile_module = types.ModuleType("beets.mediafile")
+        mediafile_module.MediaFile = FakeMediaFile
+        with mock.patch.dict(sys.modules, {"beets": beets_module, "beets.mediafile": mediafile_module}):
+            code, data = _post_agent("/tags/read", {"file_path": _api_path(track)})
+            self.assertEqual(code, 200, data)
+            self.assertEqual(data["tags"]["title"], "Title")
+            code, data = _post_agent("/tags/write", {"file_path": _api_path(track), "tags": {"title": "New"}})
+            self.assertEqual(code, 200, data)
+        self.assertEqual(seen_paths, [str(track.resolve()), str(track.resolve())])
+        self.assertEqual(saved_paths, [str(track.resolve())])
+
+    def test_album_delete_uses_canonical_database_paths_and_sanitized_errors(self):
+        db_path = Path(self.base) / "musiclibrary.blb"
+        track = Path(self.music) / "Artist" / "Album" / "Track.flac"
+        track.parent.mkdir(parents=True, exist_ok=True)
+        track.write_text("audio", encoding="utf-8")
+        outside_track = Path(self.outside) / "secret.flac"
+        outside_track.write_text("secret", encoding="utf-8")
+        con = sqlite3.connect(db_path)
+        con.execute("CREATE TABLE albums (id INTEGER PRIMARY KEY, album TEXT, path TEXT)")
+        con.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, album_id INTEGER, path TEXT)")
+        con.execute("INSERT INTO albums (id, album, path) VALUES (1, 'Album', ?)", (self.music,))
+        con.execute("INSERT INTO items (id, album_id, path) VALUES (10, 1, ?)", (_api_path(track),))
+        con.execute("INSERT INTO items (id, album_id, path) VALUES (11, 1, ?)", (_api_path(outside_track),))
+        con.commit()
+        con.close()
+
+        with mock.patch.object(bca, "LIB_PATH", str(db_path)), \
+             mock.patch.object(bca.os, "unlink") as unlink_mock, \
+             mock.patch.object(bca.os, "rmdir") as rmdir_mock:
+            code, data = bca._handle_delete_album(1, delete_files=True)
+        self.assertEqual(code, 200, data)
+        unlink_mock.assert_any_call(str(track.resolve()))
+        self.assertNotIn(mock.call(str(outside_track.resolve())), unlink_mock.mock_calls)
+        rmdir_mock.assert_not_called()
+        self.assertEqual(data["files_failed"], 1)
+        self.assertNotIn(str(outside_track), json.dumps(data))
+        self.assertNotIn("secret.flac", json.dumps(data))
 
 class ControlAgentSqlBoundaryTests(unittest.TestCase):
     def setUp(self):
@@ -244,5 +554,45 @@ class PublicExceptionResponseTests(unittest.TestCase):
                 pass
 
 
+
+class CodeQLPathModelIntegrityTests(unittest.TestCase):
+    def test_path_barrier_model_is_narrow(self):
+        model = Path(".github/codeql/extensions/pr39-path-sanitizers/models/beets-control-agent-path.yml")
+        self.assertTrue(model.exists())
+        text = model.read_text(encoding="utf-8")
+        self.assertIn("extensible: barrierModel", text)
+        self.assertIn("codeql/python-all", text)
+        self.assertIn('"backend.beets_control_agent"', text)
+        self.assertIn('"Member[resolve_safe_path].ReturnValue"', text)
+        self.assertIn('"path-injection"', text)
+        self.assertNotIn("Argument[", text)
+        self.assertNotIn("sourceModel", text)
+        self.assertNotIn("sinkModel", text)
+        self.assertNotIn("barrierGuardModel", text)
+        self.assertEqual(text.count("path-injection"), 1)
+
+    def test_model_pack_does_not_weaken_codeql_policy(self):
+        pack = Path(".github/codeql/extensions/pr39-path-sanitizers/codeql-pack.yml")
+        self.assertTrue(pack.exists())
+        pack_text = pack.read_text(encoding="utf-8")
+        self.assertIn("extensionTargets:", pack_text)
+        self.assertIn("codeql/python-all", pack_text)
+        self.assertIn("dataExtensions:", pack_text)
+
+        github_text = "\n".join(
+            p.read_text(encoding="utf-8")
+            for p in Path(".github").rglob("*.yml")
+        )
+        forbidden = [
+            "continue-on-error",
+            "paths-ignore",
+            "paths:",
+            "exclude:",
+            "security-severity",
+            "disable-default-queries",
+        ]
+        for token in forbidden:
+            with self.subTest(token=token):
+                self.assertNotIn(token, github_text)
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Starting state

Parent head: `a4b347c63f3363038aed2763f1acb754c2b1db18`

Initial open alerts: 13 high-severity `py/path-injection` alerts: #370-#382.

Base: `refactor/external-beets-engine`

## Alert accounting

| Alert | Source | Sink | Root cause | Production correction | Test coverage | Model coverage |
|---|---|---|---|---|---|---|
| #370 | `/tags/read` JSON `file_path` | `os.path.exists` then tag reader path | CodeQL did not treat canonical `resolve_safe_path()` return as a path barrier | Kept sink on `safe_file_path`; hardened resolver against encoded/ambiguous escapes | `test_tag_read_and_write_use_canonical_mediafile_path`, runtime valid tag read and traversal rejection | `resolve_safe_path().ReturnValue` path-injection barrier |
| #371 | `/tags/write` JSON `file_path` | pre-lock `os.path.exists` | Same canonical-return modeling gap | Uses only `safe_file_path`; no raw request fallback | `test_tag_read_and_write_use_canonical_mediafile_path`, runtime valid tag write | Same barrier |
| #372 | `/tags/write` JSON `file_path` | under-lock exists/write path | Same canonical-return modeling gap, with mutation lock revalidation | Re-resolves under lock and uses only returned canonical path | `test_tag_read_and_write_use_canonical_mediafile_path` | Same barrier |
| #373 | `/files/move` JSON `source_path` | pre-lock source existence check | Same canonical-return modeling gap | Uses `safe_src`, refuses allowed roots, validates destination parent | `test_move_endpoint_uses_canonical_paths_and_rejects_symlink_parent`, runtime valid move | Same barrier |
| #374 | `/files/move` JSON `source_path`/`target_path` | under-lock revalidation/existence | TOCTOU-sensitive mutation needed revalidation proof | Re-resolves both paths under lock and rejects unsafe/replaced parents | `test_move_revalidates_parent_after_symlink_race`, runtime symlink destination rejection | Same barrier |
| #375 | `/files/move` JSON `target_path` | `os.makedirs(destination parent)` | Creation target parent validation needed explicit nearest-existing-parent containment | Validates destination parent before and under lock, creates only canonical parent | `test_move_endpoint_uses_canonical_paths_and_rejects_symlink_parent`, race test, runtime valid move | Same barrier |
| #376 | `/files/move` JSON `source_path` | `shutil.move` source | Same canonical-return modeling gap | Uses only re-resolved `safe_src` under lock | `test_move_endpoint_uses_canonical_paths_and_rejects_symlink_parent`, runtime valid move | Same barrier |
| #377 | `/files/move` JSON `target_path` | `shutil.move` destination | Same canonical-return modeling gap plus destination parent concern | Uses only re-resolved `safe_dst`, validates parent, refuses allowed roots | move canonical/symlink/race tests, runtime symlink destination rejection | Same barrier |
| #378 | `/files/delete` JSON `path` | pre-lock `os.path.exists` | Same canonical-return modeling gap | Uses `safe_target`, refuses allowed root, preserves safe idempotent missing delete | `test_delete_endpoint_uses_canonical_path_and_refuses_root`, runtime missing delete | Same barrier |
| #379 | `/files/delete` JSON `path` | `os.path.isdir` | Same canonical-return modeling gap | Re-resolves under lock before directory/file branch | delete canonical/root/symlink tests, runtime delete cases | Same barrier |
| #380 | `/files/delete` JSON `path` | `shutil.rmtree` | Destructive directory sink needed root and symlink escape protection proof | Re-resolves under lock, refuses allowed roots, uses only canonical returned path | `test_delete_endpoint_uses_canonical_path_and_refuses_root`, runtime root/symlink rejection | Same barrier |
| #381 | `/files/delete` JSON `path` | `os.unlink` | Destructive file sink needed canonical-return and symlink escape proof | Re-resolves under lock, refuses allowed roots, uses only canonical returned path | delete canonical/symlink tests, runtime valid delete and symlink rejection | Same barrier |
| #382 | `/files/mkdir` JSON `path` | `os.makedirs` | Creation target validation needed nearest-existing-parent containment and race recheck | Validates nearest existing parent before and under lock, re-resolves after creation, refuses allowed roots | mkdir valid/root/symlink/race tests, runtime valid mkdir and symlink parent rejection | Same barrier |

## Production corrections

- Removed remaining boolean-check/original-value path patterns in command execution, job creation, album deletion, move, delete, mkdir, and tag operations.
- Strengthened `resolve_safe_path()` as the central canonicalization and containment boundary: strings only, nonblank, no nulls/backslashes, bounded repeated URL decode, encoded slash/backslash/null rejection, encoded residue rejection, absolute Unix path requirement, no `.` or `..`, realpath canonicalization, and `commonpath` containment.
- Added creation-parent validation for nonexistent targets based on the nearest existing parent and canonical allowed roots.
- Added allowed-root destructive operation refusal for delete, move, and mkdir root targets.
- Re-resolved mutating paths under the mutation lock before filesystem writes/deletes/moves.
- Sanitized public error responses so unsafe original paths and raw exceptions are not echoed.
- Kept the external-Beets boundary intact: the web manager still delegates authoritative media and tag operations to the engine/control-agent boundary.

## CodeQL modeling

A barrier model was required after the production code used only the canonical resolver return value at the sinks. The model is narrow:

- Function: `backend.beets_control_agent.resolve_safe_path`
- Modeled access path: `Member[resolve_safe_path].ReturnValue`
- Kind: `path-injection`

No alert was dismissed. No CodeQL language, query suite, severity threshold, broad path exclusion, source model, sink model, or blanket barrier was added. Model YAML parses locally, and repository tests verify the model only covers the resolver return value.

## Validation

Focused suite x5:

`python -m unittest tests.test_pr39_codeql_alerts tests.test_external_beets_architecture tests.test_security_hardening tests.test_transaction_engine tests.test_transaction_integration`

Result: 5 consecutive passes; each run reported `Ran 214 tests` and `OK`.

Full Python suite x3:

`python -m unittest discover -s tests -p "test_*.py"`

Result: 3 consecutive passes; each run reported `Ran 1526 tests` and `OK (skipped=3)`.

Skip-count note: the current local Windows worktree consistently reports 3 skips. The prior 60-skip count appears environment-specific or from a different discovery context; no local drift was observed across the three required runs.

Frontend:

- `npm ci`: passed, audited 348 packages locally, `0 vulnerabilities`; existing Rolldown/WASM peer warnings only.
- `npm run typecheck`: passed.
- `npm run lint`: passed.
- `npm run build`: passed, Next.js 16.2.11 static build generated 13 routes.
- `npm test`: passed, 1 test file / 15 tests.
- `npm audit --audit-level=high`: passed, `0 vulnerabilities`.

Security/static:

- `python -m py_compile app.py backend/beets_client.py backend/beets_control_agent.py backend/security.py routes_submissions.py scripts/validate_compose_security.py`: passed.
- `python scripts/security_secret_scan.py`: passed.
- `python scripts/validate_compose_security.py`: passed with existing non-Beets mutable-image warnings only.
- `python scripts/verify_security_config.py`: default local shell failed closed for missing required env; passed with disposable strong test env values.
- `git diff --check origin/refactor/external-beets-engine...HEAD`: passed.
- `.github` policy scan found only the intended `barrierModel` line.
- CodeQL model YAML syntax parse: passed.

Docker/runtime:

- `docker build --no-cache --build-arg VCS_REF=7da937e8e8b432cbb9911ad071b426739b46ea44 -t beets-web-manager-path-security .`: passed; image build `npm ci` reported `0 vulnerabilities`.
- `docker build --no-cache --build-arg VCS_REF=7da937e8e8b432cbb9911ad071b426739b46ea44 -f Dockerfile.beets -t beets-engine-path-security .`: passed; known non-fatal bpsync incompatibility remained unchanged.
- `python scripts/verify_beets_engine_image.py --image beets-engine-path-security --check-s6`: passed, including inherited `svc-beets` down, control agent supervised, restart after crash, and clean shutdown.
- Disposable runtime stack: passed with temp-only config/music/staging/web-data roots; web-to-engine health passed; valid mkdir/move/delete/tag/job flows worked; encoded traversal, allowed-root delete, symlink file/dir/destination escape, tag traversal, malicious job source, and config option injection were rejected; no outside-root mutation observed.

Ordinary GitHub CI on draft PR #47:

- `docker-build` run `30485657027`: `beets-engine-verification` passed and `compose-verification` passed.
- `lint` run `30485657165`: `frontend-lint` passed.
- `typecheck` run `30485657262`: `frontend-typecheck` passed.
- `unit-tests` run `30485657143`: `python-tests` passed.
- `node-build` run `30485662010`: `build` passed.
- `security` run `30485661849`: `security` passed.
- All of the above are `pull_request` runs for head `7da937e8e8b432cbb9911ad071b426739b46ea44`.
Local CodeQL:

`codeql version` failed because CodeQL CLI is not installed in this environment. No unpinned scanner was installed. Parent PR main-targeting CodeQL after merge remains authoritative.

## Remaining limitations

- This child PR targets `refactor/external-beets-engine`, so child PR CodeQL may not run depending on workflow trigger scope.
- Parent PR #39 CodeQL after this child PR is reviewed and merged is the authoritative verification point.
- PR #39 remains conflicting with `main` in `frontend/package.json` and `frontend/package-lock.json`; conflict resolution is explicitly outside this PR.
- No production deployment occurred.



## Independent Stage 2 review (commit 9aa6c56)

Verified independently against GitHub (not just AGY's report above): PR number, title, draft state, mergeable state, head/base SHAs, changed-file count, and commit list all matched exactly. The 13 alert-to-sink mappings in the table above were independently re-derived from the base commit and confirmed accurate: every flagged line already used the canonical `resolve_safe_path()`-derived value, so the alerts are CodeQL's inability to recognize the resolver as a sanitizer, not an unfixed vulnerability.

Two real defects were found via direct adversarial testing (not assumed from the table above) and fixed in this commit:

1. **`resolve_safe_path()` canonicalized from the decoded form, not the original path.** A legitimate literal filename containing a percent-sign byte sequence (e.g. `convention%20album.flac`) was silently rewritten to a different string (`convention album.flac`) before reaching the filesystem sink. Reproduced directly, then fixed: decoding is now used only to detect a hidden attack; the returned canonical path is always derived from the original raw input. Re-verified nested encoding is still rejected at 1/2/5/6/7 layers.
2. **`_sanitize_command_path_args()` rejected any `..` substring**, which blocked Beets' own supported range-query syntax (`year:2020..2023`) even though non-absolute args are never filesystem-joined here. Narrowed to reject `..` only as an actual path segment; real traversal (`..`, `../etc/passwd`, `foo/../bar`) is still blocked.

Both fixes were re-verified against a live disposable two-container stack (real files, real moves/deletes, real subprocess argument inspection) in addition to unit tests.

**CodeQL discovery gap confirmed definitively** (not just "may not run"): `gh api repos/Iranman/beets-web-manager/code-scanning/default-setup` shows this repository uses GitHub's *default* CodeQL setup, and `code-scanning/analyses` shows zero analyses have ever run for any ref other than `refs/pull/39/head` or `refs/heads/main`. Default setup cannot discover a repository-local CodeQL pack under `.github/codeql/extensions/`, regardless of how correctly it's authored. Added `.github/codeql/codeql-config.yml` and `.github/workflows/codeql-advanced.yml` documenting the correct advanced-setup wiring for the existing barrier model pack -- left on `workflow_dispatch`-only (not auto-triggered), since GitHub does not allow default setup and a custom analysis workflow to run simultaneously, and disabling default setup is a repository-wide setting change outside this PR's scope. This does not narrow, exclude, or disable any default security query. The CodeQL CLI was unavailable locally, so pack/config resolution in the new workflow is unverified -- it's a documented starting point for the project owner's decision, not a proven-working pipeline.

Root/creation-target/destructive-operation handling (exact root, trailing slash, symlink alias to root, symlink-parent-replacement race for both mkdir and move) was independently re-verified correct with real symlinks; no changes needed there.

Full validation re-run after the fixes: focused suite x5 (216 tests; one transient Docker-daemon flake on run 1, self-resolved, unrelated to these changes), full suite x3 (1528 tests, 0 failures, 60 skips, consistent across all runs), frontend (typecheck/lint/build/test/audit all clean, 0 vulnerabilities), static/security scripts clean, both Docker images rebuilt from clean cache with OCI revision labels confirmed matching commit `9aa6c56`, and a fresh disposable two-container adversarial run confirming both fixes live.

Skip-count note: the task description assumed "local: 3 skips vs. CI: 60 skips" -- that does not match current reality. Both local and the actual CI run for this exact PR head show 60 skips (39 because the real `beets` package isn't installed in either environment, by design, plus a few opt-in Docker-gated tests neither environment enables by default).

Still draft, still unmerged, no production paths touched.
