### PR TITLE
fix: salvage path compatibility regressions from PR #47

### DIFF
--- a/backend/beets_client.py
+++ b/backend/beets_client.py
@@ -170,7 +170,7 @@ class BeetsClient:
         """Raw SQL is intentionally unavailable; use structured query helpers."""
         raise BeetsError("Raw SQLite queries are not permitted; use structured library query helpers")
 
-    def run_command(self, command: str, args: Optional[List[str]] = None, timeout: float = 120.0, config_override: str = "", source_path: str = "", target_path: str = "") -> Dict[str, Any]:
+    def run_command(self, command: str, args: Optional[List[str]] = None, timeout: float = 120.0, config_override: str = "", source_path: str = "") -> Dict[str, Any]:
         """Execute a beet command synchronously on the Beets control agent."""
         payload = {
             "command": command,
@@ -180,8 +180,6 @@ class BeetsClient:
         }
         if source_path:
             payload["source_path"] = source_path
-        if target_path:
-            payload["target_path"] = target_path
 
         return self._request("POST", "/commands/execute", payload, timeout=timeout + 5.0)
 

--- a/backend/beets_control_agent.py
+++ b/backend/beets_control_agent.py
@@ -516,7 +516,17 @@ def resolve_safe_path(
     if ".." in parts or "." in parts:
         raise UnsafePathError("path contains a traversal segment")
 
-    abs_path = os.path.abspath(decoded)
+    # Canonicalize from the ORIGINAL raw path, not the decoded form above:
+    # decoding is used only to detect a hidden traversal/separator/null-byte
+    # attack encoded into the request. Every path endpoint here receives
+    # values in a JSON body, never URL-encoded by any real caller, so a
+    # legitimate literal filename that merely contains a percent-sign byte
+    # sequence (e.g. "50%20off.flac") must resolve to itself -- it must not
+    # be silently rewritten to a different string ("50 off.flac") before it
+    # reaches the filesystem sink. The traversal/separator/null checks above
+    # already ran against the fully-decoded form, so nothing unsafe can slip
+    # through by canonicalizing the original string here instead.
+    abs_path = os.path.abspath(path)
     real_path = os.path.realpath(abs_path)
     trusted: Optional[Path] = None
     for root in _allowed_root_paths(allowed_types):
@@ -544,6 +554,44 @@ def is_safe_path(path: object, allowed_types: list = None) -> bool:
         return True
     except UnsafePathError:
         return False
+
+
+_DOTDOT_SEGMENT_RE = re.compile(r"(^|/)\.\.(/|$)")
+
+
+def _sanitize_command_path_args(args: Any, allowed_types: list) -> list:
+    """Validate a command/job argument list, replacing any absolute-path
+    argument with its canonical resolved value (never the original
+    request string). Raises UnsafePathError for any unsafe argument.
+
+    Rejects ".." only as an actual path segment (bounded by "/" or the
+    whole string), not as a bare substring: Beets' own supported query
+    syntax uses ".." for range queries (e.g. `year:2020..2023`,
+    `added:2020-01-01..2020-02-01`), which a blanket substring check would
+    incorrectly reject even though these args are never filesystem-joined.
+    A relative arg is still only relevant to traversal for a command like
+    `import` that can accept a second positional path, so a genuine
+    "../"-shaped segment must still be blocked.
+    """
+    if not isinstance(args, list):
+        raise UnsafePathError("args must be a list")
+
+    sanitized: list = []
+    for arg in args:
+        s_arg = str(arg)
+        if s_arg in ("-c", "--config") or s_arg.startswith(("-c=", "--config=")):
+            raise UnsafePathError("unsupported config override in args")
+        if (
+            s_arg == "." or s_arg.startswith("./")
+            or _DOTDOT_SEGMENT_RE.search(s_arg)
+            or "\\" in s_arg or "\x00" in s_arg
+        ):
+            raise UnsafePathError("invalid path parameter in args")
+        if s_arg.startswith("/"):
+            sanitized.append(str(resolve_safe_path(s_arg, allowed_types)))
+        else:
+            sanitized.append(s_arg)
+    return sanitized
 
 
 def acquire_os_lock(read_only: bool = False):
@@ -717,20 +765,46 @@ def _handle_delete_album(album_id: int, delete_files: bool = True) -> tuple:
             files_deleted = 0
             file_errors = []
             if delete_files:
+                # Stored item/album paths come from the database, not the
+                # current request, but they are still untrusted: a corrupt
+                # or maliciously-written row must not be able to direct a
+                # delete outside the approved roots. Resolve each one through
+                # resolve_safe_path() and operate only on the returned Path
+                # (never the raw stored string), and refuse an approved root
+                # itself the same way /files/delete does.
                 for fpath in item_files:
-                    if fpath and is_safe_path(fpath, ["music", "staging"]) and os.path.exists(fpath):
-                        try:
-                            os.unlink(fpath)
-                            files_deleted += 1
-                        except Exception as exc:
-                            file_errors.append(f"Failed to delete {fpath}: {exc}")
-
-                if album_path and is_safe_path(album_path, ["music"]) and os.path.exists(album_path):
+                    if not fpath:
+                        continue
                     try:
-                        if os.path.isdir(album_path) and not os.listdir(album_path):
-                            os.rmdir(album_path)
-                    except Exception:
-                        pass
+                        safe_fpath = resolve_safe_path(fpath, ["music", "staging"])
+                    except UnsafePathError:
+                        file_errors.append("Skipped unsafe album item path")
+                        continue
+                    if any(str(safe_fpath) == os.path.realpath(root) for root in _allowed_root_paths(["music", "staging"])):
+                        file_errors.append("Skipped allowed root path")
+                        continue
+                    if safe_fpath.exists():
+                        try:
+                            safe_fpath.unlink()
+                            files_deleted += 1
+                        except Exception:
+                            file_errors.append("Failed to delete album item file")
+
+                if album_path:
+                    try:
+                        safe_album_path = resolve_safe_path(album_path, ["music"])
+                    except UnsafePathError:
+                        safe_album_path = None
+                    if (
+                        safe_album_path is not None
+                        and not any(str(safe_album_path) == os.path.realpath(root) for root in _allowed_root_paths(["music"]))
+                        and safe_album_path.is_dir()
+                        and not os.listdir(safe_album_path)
+                    ):
+                        try:
+                            safe_album_path.rmdir()
+                        except Exception:
+                            pass
 
             files_failed = len(file_errors)
             if files_failed > 0:
@@ -1175,30 +1249,32 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 self._send_json(409, capability_error)
                 return
 
+            safe_source_path = None
             if source_path:
                 allowed_roots = ["staging"] if command == "import" else ["music", "staging"]
-                if not is_safe_path(source_path, allowed_roots):
-                    self._send_json(403, {"error": f"Access denied for source_path: {source_path}"})
+                try:
+                    safe_source_path = resolve_safe_path(source_path, allowed_roots)
+                except UnsafePathError:
+                    self._send_json(403, {"error": "Access denied for source_path outside allowed roots"})
                     return
 
             if target_path:
-                if not is_safe_path(target_path, ["music", "staging"]):
-                    self._send_json(403, {"error": f"Access denied for target_path: {target_path}"})
+                try:
+                    resolve_safe_path(target_path, ["music", "staging"])
+                except UnsafePathError:
+                    self._send_json(403, {"error": "Access denied for target_path outside allowed roots"})
                     return
 
-            for arg in args:
-                s_arg = str(arg)
-                if s_arg.startswith(".") or ".." in s_arg or "\\" in s_arg or "\x00" in s_arg:
-                    self._send_json(403, {"error": f"Invalid path parameter in command args: {arg}"})
-                    return
-                if s_arg.startswith("/") and not is_safe_path(s_arg, ["music", "staging", "config", "tmp"]):
-                    self._send_json(403, {"error": f"Access denied for path in command args: {arg}"})
-                    return
+            try:
+                sanitized_args = _sanitize_command_path_args(args, ["music", "staging", "config", "tmp"])
+            except UnsafePathError:
+                self._send_json(403, {"error": "Invalid path parameter in command args"})
+                return
 
             cmd_list = [command]
-            if source_path:
-                cmd_list.append(source_path)
-            cmd_list.extend([str(a) for a in args])
+            if safe_source_path is not None:
+                cmd_list.append(str(safe_source_path))
+            cmd_list.extend(sanitized_args)
 
             mutating = command in {
                 "import", "update", "write", "move", "modify", "mbsync",
@@ -1233,8 +1309,8 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 })
             except subprocess.TimeoutExpired:
                 self._send_json(408, {"error": f"Command '{command}' timed out after {timeout}s", "returncode": 124})
-            except Exception as exc:
-                self._send_json(500, {"error": f"Command execution error: {exc}"})
+            except Exception:
+                self._send_json(500, {"error": "Command execution error"})
             finally:
                 if tmp_cfg_path and os.path.exists(tmp_cfg_path):
                     try:
@@ -1260,26 +1336,26 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 self._send_json(409, capability_error)
                 return
 
+            safe_source_path = None
             if source_path:
                 allowed_roots = ["staging"] if command == "import" else ["music", "staging"]
-                if not is_safe_path(source_path, allowed_roots):
-                    self._send_json(403, {"error": f"Access denied for source_path: {source_path}"})
+                try:
+                    safe_source_path = resolve_safe_path(source_path, allowed_roots)
+                except UnsafePathError:
+                    self._send_json(403, {"error": "Access denied for source_path outside allowed roots"})
                     return
 
-            for arg in args:
-                s_arg = str(arg)
-                if s_arg.startswith(".") or ".." in s_arg or "\\" in s_arg or "\x00" in s_arg:
-                    self._send_json(403, {"error": f"Invalid path parameter in job args: {arg}"})
-                    return
-                if s_arg.startswith("/") and not is_safe_path(s_arg, ["music", "staging", "config", "tmp"]):
-                    self._send_json(403, {"error": f"Access denied for path in job args: {arg}"})
-                    return
+            try:
+                sanitized_args = _sanitize_command_path_args(args, ["music", "staging", "config", "tmp"])
+            except UnsafePathError:
+                self._send_json(403, {"error": "Invalid path parameter in job args"})
+                return
 
             job_id = uuid.uuid4().hex
             cmd_list = [command]
-            if source_path:
-                cmd_list.append(source_path)
-            cmd_list.extend([str(a) for a in args])
+            if safe_source_path is not None:
+                cmd_list.append(str(safe_source_path))
+            cmd_list.extend(sanitized_args)
 
             job = AgentJob(job_id, cmd_list, label=label, config_override=config_override)
             with JOBS_LOCK:

--- a/backend/beets_control_agent.py
+++ b/backend/beets_control_agent.py
@@ -503,6 +503,15 @@ def resolve_safe_path(
         raise UnsafePathError("path must be a non-empty string")
     if "\x00" in path or "\\" in path:
         raise UnsafePathError("path contains a null byte or backslash")
+    # The absolute-path requirement must hold for the RAW string, not just its
+    # decoded form: canonicalization below deliberately uses `path` (the raw
+    # string), so a value whose raw form is relative but whose fully-decoded
+    # form happens to be absolute (e.g. "%2Fdata%2Fmusic%2Ffile.flac") must
+    # not be allowed to slip past on the strength of its decoded copy alone --
+    # os.path.abspath() would silently anchor a relative raw string to the
+    # process's cwd instead of raising here.
+    if not path.startswith("/"):
+        raise UnsafePathError("path must be absolute")
 
     decoded = _decode_untrusted_path(path)
     if decoded is None:
@@ -765,46 +774,57 @@ def _handle_delete_album(album_id: int, delete_files: bool = True) -> tuple:
             files_deleted = 0
             file_errors = []
             if delete_files:
-                # Stored item/album paths come from the database, not the
-                # current request, but they are still untrusted: a corrupt
-                # or maliciously-written row must not be able to direct a
-                # delete outside the approved roots. Resolve each one through
-                # resolve_safe_path() and operate only on the returned Path
-                # (never the raw stored string), and refuse an approved root
-                # itself the same way /files/delete does.
-                for fpath in item_files:
-                    if not fpath:
-                        continue
-                    try:
-                        safe_fpath = resolve_safe_path(fpath, ["music", "staging"])
-                    except UnsafePathError:
-                        file_errors.append("Skipped unsafe album item path")
-                        continue
-                    if any(str(safe_fpath) == os.path.realpath(root) for root in _allowed_root_paths(["music", "staging"])):
-                        file_errors.append("Skipped allowed root path")
-                        continue
-                    if safe_fpath.exists():
+                # Database rows are already committed above at this point.
+                # Everything below is best-effort filesystem cleanup, and
+                # must never be allowed to propagate an exception up to the
+                # outer handler -- doing so would incorrectly report
+                # database_deleted: False for a delete that already
+                # succeeded. Stored item/album paths come from the
+                # database, not the current request, but are still
+                # untrusted: a corrupt or maliciously-written row must not
+                # be able to direct a delete outside the approved roots.
+                # Resolve each one through resolve_safe_path() and operate
+                # only on the returned Path (never the raw stored string),
+                # and refuse an approved root itself the same way
+                # /files/delete does.
+                try:
+                    for fpath in item_files:
+                        if not fpath:
+                            continue
                         try:
-                            safe_fpath.unlink()
-                            files_deleted += 1
-                        except Exception:
-                            file_errors.append("Failed to delete album item file")
+                            safe_fpath = resolve_safe_path(fpath, ["music", "staging"])
+                        except UnsafePathError:
+                            file_errors.append("Skipped unsafe album item path")
+                            continue
+                        if any(str(safe_fpath) == os.path.realpath(root) for root in _allowed_root_paths(["music", "staging"])):
+                            file_errors.append("Skipped allowed root path")
+                            continue
+                        if safe_fpath.exists():
+                            try:
+                                safe_fpath.unlink()
+                                files_deleted += 1
+                            except Exception:
+                                file_errors.append("Failed to delete album item file")
 
-                if album_path:
-                    try:
-                        safe_album_path = resolve_safe_path(album_path, ["music"])
-                    except UnsafePathError:
-                        safe_album_path = None
-                    if (
-                        safe_album_path is not None
-                        and not any(str(safe_album_path) == os.path.realpath(root) for root in _allowed_root_paths(["music"]))
-                        and safe_album_path.is_dir()
-                        and not os.listdir(safe_album_path)
-                    ):
+                    if album_path:
                         try:
-                            safe_album_path.rmdir()
-                        except Exception:
-                            pass
+                            safe_album_path = resolve_safe_path(album_path, ["music"])
+                        except UnsafePathError:
+                            safe_album_path = None
+                        if safe_album_path is not None and not any(
+                            str(safe_album_path) == os.path.realpath(root) for root in _allowed_root_paths(["music"])
+                        ):
+                            try:
+                                album_dir_is_empty = safe_album_path.is_dir() and not os.listdir(safe_album_path)
+                            except Exception:
+                                album_dir_is_empty = False
+                            if album_dir_is_empty:
+                                try:
+                                    safe_album_path.rmdir()
+                                except Exception:
+                                    pass
+                except Exception:
+                    file_errors.append("Unexpected error during file cleanup")
 
             files_failed = len(file_errors)
             if files_failed > 0:
@@ -1238,7 +1258,6 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
             timeout = body.get("timeout", 120)
             config_override = body.get("config_override", "")
             source_path = body.get("source_path", "")
-            target_path = body.get("target_path", "")
 
             if not command or command not in ALLOWED_COMMANDS:
                 self._send_json(400, {"error": f"Command '{command}' is not in the allowlist"})
@@ -1256,13 +1275,6 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                     safe_source_path = resolve_safe_path(source_path, allowed_roots)
                 except UnsafePathError:
                     self._send_json(403, {"error": "Access denied for source_path outside allowed roots"})
-                    return
-
-            if target_path:
-                try:
-                    resolve_safe_path(target_path, ["music", "staging"])
-                except UnsafePathError:
-                    self._send_json(403, {"error": "Access denied for target_path outside allowed roots"})
                     return
 
             try:

--- a/tests/test_external_beets_architecture.py
+++ b/tests/test_external_beets_architecture.py
@@ -352,8 +352,8 @@ class TestBeetsClientRemoteOnly(unittest.TestCase):
             con.close()
 
             with mock.patch("backend.beets_control_agent.LIB_PATH", str(db_path)), \
-                 mock.patch("backend.beets_control_agent.is_safe_path", return_value=True), \
-                 mock.patch("os.unlink", side_effect=PermissionError("Permission denied")):
+                 mock.patch("backend.beets_control_agent.MUSIC_LIBRARY_PATH", str(music_path)), \
+                 mock.patch.object(Path, "unlink", side_effect=PermissionError("Permission denied")):
                 code, res = _handle_delete_album(1, delete_files=True)
                 self.assertEqual(code, 200)
                 self.assertFalse(res["success"])

--- a/tests/test_pr39_codeql_alerts.py
+++ b/tests/test_pr39_codeql_alerts.py
@@ -253,6 +253,24 @@ class ControlAgentPathBoundaryTests(unittest.TestCase):
                 with self.assertRaises(UnsafePathError):
                     resolve_safe_path(raw, ["music"])
 
+    def test_resolve_safe_path_requires_raw_absolute_not_just_decoded(self):
+        """Regression test: resolve_safe_path() canonicalizes from the raw
+        input string, so the absolute-path requirement must be enforced on
+        that same raw string -- not only on its decoded copy. A value whose
+        raw form is relative but whose fully-decoded form happens to be
+        absolute (e.g. a fully percent-encoded leading separator) must be
+        rejected outright rather than falling through to os.path.abspath(),
+        which would silently anchor it to the process's cwd instead."""
+        candidates = [
+            "%2Fdata%2Fmedia%2Fmusic%2Ffile.flac",
+            "%252Fdata%252Fmedia%252Fmusic%252Ffile.flac",
+            "relative%2Fencoded",
+        ]
+        for candidate in candidates:
+            with self.subTest(candidate=candidate):
+                with self.assertRaises(UnsafePathError):
+                    resolve_safe_path(candidate, ["music"])
+
     def test_literal_percent_filename_survives_delete_endpoint(self):
         literal_path = f"{self.music}/convention%20album.flac"
         Path(literal_path).write_text("audio", encoding="utf-8")
@@ -352,6 +370,24 @@ class ControlAgentPathBoundaryTests(unittest.TestCase):
         self.assertEqual(set(bca.JOBS), before_jobs)
         self.assertNotIn("%252e%252e", json.dumps(data))
 
+    def test_commands_execute_ignores_unused_target_path(self):
+        """target_path is not part of /commands/execute's actual command
+        contract -- it is never appended to the constructed command array by
+        any allowed subcommand, and no current caller sends it. It must be
+        accepted (as inert, unvalidated JSON) rather than silently
+        influencing command construction or being treated as a path sink."""
+        fake_result = mock.MagicMock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(bca.subprocess, "run", return_value=fake_result) as run_mock:
+            code, data = _post_agent("/commands/execute", {
+                "command": "ls",
+                "args": ["title:x"],
+                "target_path": f"{self.outside}/anywhere-outside-every-root",
+            })
+        self.assertEqual(code, 200, data)
+        full_cmd = run_mock.call_args.args[0]
+        self.assertNotIn(f"{self.outside}/anywhere-outside-every-root", full_cmd)
+        self.assertEqual(full_cmd[-1:], ["title:x"])
+
 
 class AlbumDeleteCanonicalPathTests(unittest.TestCase):
     """Regression tests for _handle_delete_album() treating database-stored
@@ -440,6 +476,32 @@ class AlbumDeleteCanonicalPathTests(unittest.TestCase):
         self.assertTrue(data["database_deleted"])
         self.assertEqual(data["items_deleted"], 1)
         self.assertEqual(data["albums_deleted"], 1)
+
+    def test_filesystem_exception_after_commit_does_not_misreport_database_deleted(self):
+        """Regression test: the album/item DB rows are committed before any
+        filesystem cleanup runs. An unexpected filesystem exception during
+        that best-effort cleanup (e.g. os.listdir() raising on the album
+        directory) must not be allowed to propagate to the outer handler and
+        misreport an already-successful database deletion as a total
+        failure."""
+        real_item = f"{self.music}/Artist/Album/Track.flac"
+        Path(real_item).parent.mkdir(parents=True, exist_ok=True)
+        Path(real_item).write_text("audio", encoding="utf-8")
+        album_dir = f"{self.music}/Artist/Album"
+
+        self._seed_album(album_dir, [real_item])
+
+        with mock.patch.object(bca.os, "listdir", side_effect=PermissionError("denied")):
+            code, data = bca._handle_delete_album(1, delete_files=True)
+
+        self.assertEqual(code, 200, data)
+        self.assertTrue(data["database_deleted"])
+        self.assertEqual(data["items_deleted"], 1)
+        self.assertEqual(data["albums_deleted"], 1)
+        self.assertNotEqual(data["status"], "failed")
+        # The item file itself must still have been deleted -- only the
+        # album-directory listdir() call was made to fail.
+        self.assertFalse(Path(real_item).exists())
 
 
 class ControlAgentSqlBoundaryTests(unittest.TestCase):

--- a/tests/test_pr39_codeql_alerts.py
+++ b/tests/test_pr39_codeql_alerts.py
@@ -206,6 +206,241 @@ class ControlAgentPathBoundaryTests(unittest.TestCase):
         self.assertTrue(Path(dest).exists())
         self.assertFalse(Path(source).exists())
 
+    def test_resolve_safe_path_preserves_literal_percent_filenames(self):
+        """Regression test: resolve_safe_path() must canonicalize from the
+        original raw path, not its decoded form. Decoding is used only to
+        detect a hidden traversal/separator/null-byte attack; a legitimate
+        literal filename that happens to contain a percent-sign byte
+        sequence must resolve to itself, not be silently rewritten to a
+        different string before it reaches the filesystem sink. Every path
+        endpoint here receives values in a JSON body, never URL-encoded by
+        any real caller, so decoding must never change what gets operated
+        on."""
+        literal_names = [
+            "convention%20album.flac",
+            "100%25 legit.flac",
+            "literal%2520name.flac",
+        ]
+        for name in literal_names:
+            with self.subTest(name=name):
+                literal_path = f"{self.music}/{name}"
+                Path(literal_path).write_text("audio", encoding="utf-8")
+                resolved = resolve_safe_path(literal_path, ["music"])
+                self.assertEqual(resolved, Path(literal_path).resolve())
+
+        # Encoded traversal, separators, nulls, and nested encoding must
+        # still be rejected -- the fix must not weaken detection.
+        attack_paths = [
+            f"{self.music}/../outside/secret.flac",
+            f"{self.music}/%2e%2e/outside/secret.flac",
+            f"{self.music}/%252e%252e/outside/secret.flac",
+            f"{self.music}/foo%00.flac",
+            f"{self.music}/..%2f..%2fetc/passwd",
+        ]
+        for candidate in attack_paths:
+            with self.subTest(candidate=candidate):
+                with self.assertRaises(UnsafePathError):
+                    resolve_safe_path(candidate, ["music"])
+
+        # Nested encoding of a genuine "../" must be rejected at every
+        # depth, including beyond the resolver's decode budget.
+        import urllib.parse as _up
+        s = "../"
+        for depth in range(1, 7):
+            s = _up.quote(s, safe="")
+            raw = f"{self.music}/{s}etc/passwd"
+            with self.subTest(depth=depth):
+                with self.assertRaises(UnsafePathError):
+                    resolve_safe_path(raw, ["music"])
+
+    def test_literal_percent_filename_survives_delete_endpoint(self):
+        literal_path = f"{self.music}/convention%20album.flac"
+        Path(literal_path).write_text("audio", encoding="utf-8")
+        decoded_sibling = f"{self.music}/convention album.flac"
+        self.assertFalse(Path(decoded_sibling).exists())
+
+        code, data = _post_agent("/files/delete", {"path": literal_path})
+        self.assertEqual(code, 200, data)
+        self.assertEqual(data["path"], str(Path(literal_path).resolve()))
+        self.assertFalse(Path(literal_path).exists())
+        self.assertFalse(Path(decoded_sibling).exists())
+
+    def test_command_args_allow_beets_range_query_syntax(self):
+        """Regression test: a blanket '".." in arg' substring check rejected
+        legitimate Beets range-query syntax (e.g. `year:2020..2023`), which
+        is never filesystem-joined -- only an actual relative path segment
+        is a real traversal-relevant shape and must still be rejected."""
+        legitimate_args = ["year:2020..2023", "added:2020-01-01..2020-02-01", "title:Mr...Wonderful"]
+        fake_result = mock.MagicMock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(bca.subprocess, "run", return_value=fake_result) as run_mock:
+            code, data = _post_agent("/commands/execute", {"command": "ls", "args": legitimate_args})
+        self.assertEqual(code, 200, data)
+        full_cmd = run_mock.call_args.args[0]
+        self.assertEqual(full_cmd[-len(legitimate_args):], legitimate_args)
+
+        for traversal_arg in ["..", "../etc/passwd", "foo/../bar", "./relative"]:
+            with self.subTest(arg=traversal_arg):
+                with mock.patch.object(bca.subprocess, "run") as run_mock:
+                    code, data = _post_agent("/commands/execute", {"command": "ls", "args": [traversal_arg]})
+                self.assertEqual(code, 403, data)
+                run_mock.assert_not_called()
+
+    def test_commands_execute_and_jobs_create_use_canonical_source_path(self):
+        """source_path and absolute args must be replaced by their canonical
+        resolved values in the actual subprocess/job command array -- never
+        the original request string."""
+        source = f"{self.staging}/import-source"
+        Path(source).mkdir()
+        arg_file = f"{self.music}/Artist/Track.flac"
+        Path(arg_file).parent.mkdir(parents=True, exist_ok=True)
+        Path(arg_file).write_text("audio", encoding="utf-8")
+
+        fake_result = mock.MagicMock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(bca.subprocess, "run", return_value=fake_result) as run_mock:
+            code, data = _post_agent("/commands/execute", {
+                "command": "import",
+                "source_path": source,
+                "args": ["--quiet", arg_file],
+            })
+        self.assertEqual(code, 200, data)
+        full_cmd = run_mock.call_args.args[0]
+        self.assertEqual(
+            full_cmd[-4:],
+            ["import", str(Path(source).resolve()), "--quiet", str(Path(arg_file).resolve())],
+        )
+
+        created = {}
+
+        class FakeJob:
+            def __init__(self, job_id, command, label="", config_override=""):
+                created["job_id"] = job_id
+                created["command"] = command
+
+        with mock.patch.object(bca, "AgentJob", FakeJob):
+            code, data = _post_agent("/jobs/create", {
+                "command": "import",
+                "source_path": source,
+                "args": ["--quiet", arg_file],
+            })
+        try:
+            self.assertEqual(code, 200, data)
+            self.assertEqual(
+                created["command"],
+                ["import", str(Path(source).resolve()), "--quiet", str(Path(arg_file).resolve())],
+            )
+        finally:
+            bca.JOBS.pop(created.get("job_id"), None)
+
+    def test_command_and_job_reject_traversal_and_option_injection(self):
+        with mock.patch.object(bca.subprocess, "run") as run_mock:
+            code, data = _post_agent("/commands/execute", {
+                "command": "import",
+                "source_path": self.staging,
+                "args": ["--config=/etc/passwd"],
+            })
+        self.assertEqual(code, 403, data)
+        run_mock.assert_not_called()
+        self.assertNotIn("/etc/passwd", json.dumps(data))
+
+        before_jobs = set(bca.JOBS)
+        code, data = _post_agent("/jobs/create", {
+            "command": "import",
+            "source_path": f"{self.staging}/%252e%252e/outside",
+            "args": [],
+        })
+        self.assertEqual(code, 403, data)
+        self.assertEqual(set(bca.JOBS), before_jobs)
+        self.assertNotIn("%252e%252e", json.dumps(data))
+
+
+class AlbumDeleteCanonicalPathTests(unittest.TestCase):
+    """Regression tests for _handle_delete_album() treating database-stored
+    paths as untrusted, matching the same canonical-path/root-refusal
+    contract as the /files/delete endpoint."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(dir="/tmp")
+        base_name = Path(self.tmp.name).name
+        self.base = f"/tmp/{base_name}"
+        self.music = f"{self.base}/music"
+        self.staging = f"{self.base}/staging"
+        self.outside = f"{self.base}/outside"
+        Path(self.music).mkdir(parents=True, exist_ok=True)
+        Path(self.staging).mkdir(parents=True, exist_ok=True)
+        Path(self.outside).mkdir(parents=True, exist_ok=True)
+        self.db_path = Path(self.base) / "musiclibrary.blb"
+        self.patches = [
+            mock.patch.object(bca, "MUSIC_LIBRARY_PATH", self.music),
+            mock.patch.object(bca, "DOWNLOAD_PATH", self.staging),
+            mock.patch.object(bca, "LOCK_PATH", f"{self.base}/agent.lock"),
+            mock.patch.object(bca, "LIB_PATH", str(self.db_path)),
+        ]
+        for patch in self.patches:
+            patch.start()
+
+    def tearDown(self):
+        for patch in reversed(self.patches):
+            patch.stop()
+        self.tmp.cleanup()
+
+    def _seed_album(self, album_path: str, item_paths: list[str]):
+        con = sqlite3.connect(self.db_path)
+        con.execute("CREATE TABLE albums (id INTEGER PRIMARY KEY, album TEXT, path TEXT)")
+        con.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, album_id INTEGER, path TEXT)")
+        con.execute("INSERT INTO albums (id, album, path) VALUES (1, 'Album', ?)", (album_path,))
+        for idx, p in enumerate(item_paths, start=10):
+            con.execute("INSERT INTO items (id, album_id, path) VALUES (?, 1, ?)", (idx, p))
+        con.commit()
+        con.close()
+
+    def test_hostile_stored_paths_do_not_escape_approved_roots(self):
+        real_item = f"{self.music}/Artist/Album/Track.flac"
+        Path(real_item).parent.mkdir(parents=True, exist_ok=True)
+        Path(real_item).write_text("audio", encoding="utf-8")
+
+        outside_item = f"{self.outside}/secret.flac"
+        Path(outside_item).write_text("secret", encoding="utf-8")
+
+        percent_item = f"{self.music}/Artist/Album/convention%20album.flac"
+        Path(percent_item).write_text("audio", encoding="utf-8")
+        decoded_sibling = f"{self.music}/Artist/Album/convention album.flac"
+
+        traversal_item = f"{self.music}/Artist/Album/%2e%2e/%2e%2e/outside/escape.flac"
+
+        self._seed_album(
+            self.music,  # hostile: album path itself is the approved root
+            [real_item, outside_item, percent_item, traversal_item],
+        )
+
+        code, data = bca._handle_delete_album(1, delete_files=True)
+        self.assertEqual(code, 200, data)
+
+        # The real, legitimate item is gone.
+        self.assertFalse(Path(real_item).exists())
+        # The literal-percent file was deleted exactly, not a decoded sibling.
+        self.assertFalse(Path(percent_item).exists())
+        self.assertFalse(Path(decoded_sibling).exists())
+        # The outside-root item was never touched.
+        self.assertTrue(Path(outside_item).exists())
+        # The approved root itself (used as the "album path") was not removed.
+        self.assertTrue(Path(self.music).is_dir())
+
+        self.assertEqual(data["files_deleted"], 2)
+        self.assertGreaterEqual(data["files_failed"], 1)
+        self.assertNotIn(self.outside, json.dumps(data))
+        self.assertNotIn("secret.flac", json.dumps(data))
+
+    def test_database_row_deletion_is_unconditional_even_with_hostile_paths(self):
+        """A malicious stored path must not prevent safe database cleanup:
+        the album/item rows are removed regardless of whether any stored
+        file path is safe to delete."""
+        self._seed_album(f"{self.outside}/evil-album", [f"{self.outside}/evil.flac"])
+        code, data = bca._handle_delete_album(1, delete_files=True)
+        self.assertEqual(code, 200, data)
+        self.assertTrue(data["database_deleted"])
+        self.assertEqual(data["items_deleted"], 1)
+        self.assertEqual(data["albums_deleted"], 1)
+
 
 class ControlAgentSqlBoundaryTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Why PR #47 could not be merged wholesale

PR #47 (`fix/pr39-remaining-path-alerts`) was reviewed independently and found two real, reproduced defects, both fixed and adversarially verified live. But the parent branch (`refactor/external-beets-engine`) advanced with its own, independently-developed path-security implementation (commit `94e05fa`, "fix: canonicalize control-agent filesystem paths") before PR #47 could be merged. That implementation uses a stricter contract than PR #47's:

- `resolve_safe_path()` returns `pathlib.Path` and raises `UnsafePathError`, instead of PR #47's `Optional[str]`/`None`.
- It already has its own (independently correct) root-refusal check for `/files/delete`.

`git merge-tree` confirmed real conflicts in `backend/beets_control_agent.py` and `tests/test_pr39_codeql_alerts.py`. Rather than rebase PR #47 wholesale or cherry-pick either commit (both would either lose the parent's stricter contract or drag in an unrelated, already-superseded implementation), this PR ports only the independently-reproduced defects onto the current parent head, preserving its `Path`/`UnsafePathError` contract throughout.

## Which two independently reproduced defects were ported

1. **Literal-percent-filename preservation.** `resolve_safe_path()` canonicalized from the URL-decoded form of the input, not the original raw path -- the same bug independently present in both the parent and PR #47's original code. A legitimate literal filename containing a percent-sign byte sequence (e.g. `convention%20album.flac`) was silently rewritten to a different string (`convention album.flac`) before reaching the filesystem sink. Decoding is still used to detect a hidden traversal/separator/null-byte attack; the canonical return value is now always derived from the original path. Verified directly against the parent's actual (otherwise unmodified) resolver: plain and single/double-encoded traversal, encoded slash/null/backslash, and nested-encoded `../` up to 6 layers (beyond the resolver's own decode budget) all remain correctly rejected.
2. **Beets range-query argument compatibility.** `/commands/execute` and `/jobs/create` rejected any argument containing `..` as a bare substring, incorrectly blocking Beets' own supported range-query syntax (`year:2020..2023`, `added:2020-01-01..2020-02-01`) even though non-absolute args are never filesystem-joined here. Narrowed to reject `..` only as an actual path segment.

## Which boolean/original-value paths were corrected

Audited every `is_safe_path`/`resolve_safe_path`/filesystem-sink/`subprocess.run`/`AgentJob` call site in `backend/beets_control_agent.py`. Four genuine `is_safe_path(original) -> sink(original)` patterns remained; `/files/move`, `/files/delete`, `/files/mkdir`, `/tags/read`, `/tags/write`, and the artpath endpoint already used canonical `Path` values correctly:

- `/commands/execute` and `/jobs/create` validated `source_path`/absolute args with a boolean check, then appended the *original* request string to the command array. Both now use a shared `_sanitize_command_path_args()` helper that returns the canonical resolved value for every absolute-path argument, raising `UnsafePathError` (matching the parent's contract) for anything unsafe.
- `_handle_delete_album()` treated database-stored item/album paths as trusted after only a boolean check, then deleted the *original* stored string. Stored paths are database content, not request input, but are exactly as untrusted -- a corrupted or maliciously-written row must not be able to direct a delete outside the approved roots. Now resolves each stored path through `resolve_safe_path()`, operates only on the returned `Path`, refuses an approved root itself (matching `/files/delete`'s existing protection), and no longer echoes raw paths or exception text into `file_errors`. Database row deletion remains unconditional regardless of any individual file's safety.
- Also removed a raw-exception leak in `/commands/execute`'s generic error handler while already in that code path, for consistency with the same principle applied to album cleanup.

## Why the CodeQL workflow/model files were intentionally not ported

This repository currently uses GitHub's *default* CodeQL setup (confirmed via `gh api code-scanning/default-setup`), under which PR #39 (base: `main`) already records a green, real, authoritative CodeQL analysis (`Analyze (python)`, `Analyze (javascript-typescript)`, `Analyze (actions)`, and the diff-scoped `CodeQL` check all currently pass on `refactor/external-beets-engine`'s head). Default and advanced setup cannot be enabled simultaneously; switching to advanced setup solely to load a repository-local model pack is a repository-wide governance decision, not part of this bug-compatibility salvage. Recorded as a technical-debt recommendation rather than active configuration in this PR. PR #47's `.github/codeql/extensions/pr39-path-sanitizers/`, `.github/codeql/codeql-config.yml`, and `.github/workflows/codeql-advanced.yml` were **not** ported.

## Tests and runtime validation

- Regression tests added to `tests/test_pr39_codeql_alerts.py`: literal-percent-filename preservation (multiple encodings, including survival through the real `/files/delete` endpoint), nested-encoding rejection at depths 1-6, legitimate Beets range-query arguments passing through both `/commands/execute` and `/jobs/create`'s real subprocess/job command arrays unchanged, real traversal/option-injection still rejected, and a hostile-SQLite-database album-cleanup test (mixed valid/outside-root/literal-percent/encoded-traversal stored paths) proving no outside-root deletion occurs and database rows are removed unconditionally regardless.
- One existing test (`test_album_delete_partial_failure_status_contract`) updated: it mocked `is_safe_path` and `os.unlink`, both no longer used by the corrected `_handle_delete_album()`; now mocks `MUSIC_LIBRARY_PATH` and `pathlib.Path.unlink`.
- Focused suite x5: 223 tests, `OK (skipped=17)`, consistent across all five runs.
- Full suite x3: 1535 tests, `OK (skipped=60)`, 0 failures, consistent across all three runs.
- Frontend: `npm ci`, `typecheck`, `lint`, `build` (13/13 static pages), `test` (15/15 vitest), `npm audit --audit-level=high` -- all clean, 0 vulnerabilities. No frontend files touched.
- Static/security: `py_compile`, `security_secret_scan.py`, `validate_compose_security.py` (`ok: true`), `git diff --check` -- all clean. `verify_security_config.py`'s bare-checkout failures are the documented expected behavior (no real credentials configured).
- Docker: both images rebuilt `--no-cache` with `VCS_REF` set to the final commit; OCI `org.opencontainers.image.revision` labels on both confirmed matching. Engine verifier confirmed `beet`/`ffmpeg`/`ffprobe`/`fpcalc` present, `svc-beets` disabled, control agent supervised.
- Disposable two-container runtime test (synthetic token, temp-only roots, no production mounts): literal-percent-filename delete (exact fix confirmation), traversal rejection, root refusal, a real move with destination verification, and a legitimate range-query command argument passing while a real traversal argument was rejected -- all correct against the live running engine.

## Remaining gates

- PR #39 is currently marked ready but remains unmerged.
- The owner accepted the retained Plex-token risk and recorded SEC-001 in `docs/TECHNICAL_DEBT.md`.
- Production currently runs the earlier `f6485a2` code images.
- PR #48's newer code changes (this branch) are not yet deployed.
- This task performs no production deployment.
- PR #47 (`fix/pr39-remaining-path-alerts`) is closed as superseded and remains preserved for reference.

## Independent final review (post-salvage hardening)

An independent final review pass inspected the complete diff, the surrounding
`resolve_safe_path()`/command-sanitizer/album-cleanup implementation, and every
filesystem/subprocess sink (not only the changed lines). Three narrow, real
defects were found and fixed directly on this branch, each with an added
regression test:

1. **Raw absolute-path enforcement gap.** `resolve_safe_path()` canonicalizes
   from the *raw* input string (by design, so literal percent-sign filenames
   survive), but only checked that the *decoded* copy started with `/`. A
   value whose raw form was relative but whose fully-decoded form happened to
   be absolute (a fully percent-encoded leading separator, e.g.
   `%2Fdata%2Fmedia%2Fmusic%2Ffile.flac`) could fall through to
   `os.path.abspath()`, which silently anchors a relative string to the
   process's cwd instead of being rejected outright. Added an explicit
   raw-string absolute-path check.
2. **Album-cleanup post-commit exception mislabeling.** `_handle_delete_album()`
   commits the database deletion before attempting best-effort filesystem
   cleanup. The album-directory emptiness check (`is_dir()` + `os.listdir()`)
   was unguarded; a filesystem exception there (e.g. `PermissionError`) would
   propagate to the outer handler and report `database_deleted: False` for a
   delete that had already succeeded. Wrapped the emptiness check and the
   whole `delete_files` block so a post-commit filesystem error can never
   misreport an already-committed database result.
3. **Dead `target_path` validation in `/commands/execute`.** The endpoint
   validated `target_path` with `resolve_safe_path()` but never used the
   result -- it was never appended to the constructed command array, and no
   current caller (`beets_client.run_command()`'s only caller,
   `job_engine.py`, never passes it) ever sends it. Removed the dead,
   misleading validation and the corresponding unused client-side parameter.

All fixes were verified with real temporary files/directories, real
`subprocess.run` call arrays, and a live two-container adversarial run
(literal-percent mkdir/move, encoded-separator creation target, the new
raw-relative/decoded-absolute rejection, range-query vs. real-traversal
commands, root/outside-root delete refusal, and confirmation that
`target_path` is now inert) before being torn down. Full validation (focused
x5: 226 tests; full discover x3: 1538 tests; frontend typecheck/lint/build/
test/audit; static/security scans) passed cleanly and consistently on the
final head.

No CodeQL workflow, model, or config files were added or changed by this
review; the repository's default CodeQL setup is untouched.

**Remaining limitation (accepted, not fixed):** `_sanitize_command_path_args()`
rejects a literal `".."` path *segment* in a relative argument, but does not
decode-and-recheck relative (non-absolute) arguments the way `resolve_safe_path()`
does for absolute ones -- so a percent-encoded relative traversal shape (e.g.
`%2e%2e/escape`) is not caught by that specific defense-in-depth check. This is
not a live vulnerability in the current architecture: relative `args` entries
are never filesystem-joined anywhere in this codebase (the only real
filesystem path for `import` is `source_path`, which is always resolved
through `resolve_safe_path()` separately) -- they are passed through as opaque
CLI argument strings interpreted by Beets' own query parser. Recorded here for
visibility rather than adding decode-based checking that risks the same
over-rejection failure mode already fixed once for legitimate range-query
syntax.

## PR #48 Synchronization

```text
Current parent synchronized:
5a7e871ce3c53694452364cc85db493722bce19c

Synchronization method:
normal merge, no rebase, no force-push

SEC-001:
preserved from parent and not part of this PR's resulting diff

Synchronized head:
a6c86a50c102f9a845da899d59bceddadce0ab3f
```

Post-sync revalidation on `a6c86a5...`:

- Focused suite: 226 tests, `OK`. One transient error occurred on the single run immediately following the merge commit; it did not reproduce across 4 subsequent attempts (2 full re-runs + 2 targeted verbose re-runs), and the last 3 consecutive runs are clean.
- Full suite x2: 1538 tests, `OK (skipped=3)` both runs (skips are the pre-existing opt-in Docker gates, unrelated to this change).
- Frontend: `npm ci`/`typecheck`/`lint`/`build`/`test`/`audit --audit-level=high` -- all clean, 0 vulnerabilities. No frontend files changed by the sync.
- Static/security: `py_compile`, secret scan, compose-security validator, `git diff --check` -- all clean.
- Docker: both images rebuilt `--no-cache` at `a6c86a5...`; OCI `org.opencontainers.image.revision` labels confirmed matching on both. Disposable two-container smoke test: literal-percent path (mkdir), raw-relative/decoded-absolute rejection, range-query command, real-traversal rejection, canonical absolute argument, and root/outside-root cleanup refusal all correct against the live engine.
- Live ordinary CI: all 14 emitted checks (7 workflows x 2 runs) pass on `a6c86a5...`.

The PR diff against the updated parent remains limited to `backend/beets_client.py`, `backend/beets_control_agent.py`, `tests/test_external_beets_architecture.py`, and `tests/test_pr39_codeql_alerts.py`. `docs/TECHNICAL_DEBT.md` (SEC-001) is no longer part of this PR's diff since it now comes from the updated base.

PR #48 remains **draft** and **unmerged** as of this update; PR #39 is untouched by this branch.
