### PR TITLE
fix: apply PR #48 path compatibility fixes to main

### DIFF
--- a/backend/beets_client.py
+++ b/backend/beets_client.py
@@ -170,7 +170,7 @@ class BeetsClient:
         """Raw SQL is intentionally unavailable; use structured query helpers."""
         raise BeetsError("Raw SQLite queries are not permitted; use structured library query helpers")
 
-    def run_command(self, command: str, args: Optional[List[str]] = None, timeout: float = 120.0, config_override: str = "", source_path: str = "", target_path: str = "") -> Dict[str, Any]:
+    def run_command(self, command: str, args: Optional[List[str]] = None, timeout: float = 120.0, config_override: str = "", source_path: str = "") -> Dict[str, Any]:
         """Execute a beet command synchronously on the Beets control agent."""
         payload = {
             "command": command,
@@ -180,8 +180,6 @@ class BeetsClient:
         }
         if source_path:
             payload["source_path"] = source_path
-        if target_path:
-            payload["target_path"] = target_path
 
         return self._request("POST", "/commands/execute", payload, timeout=timeout + 5.0)
 

--- a/backend/beets_control_agent.py
+++ b/backend/beets_control_agent.py
@@ -503,6 +503,15 @@ def resolve_safe_path(
         raise UnsafePathError("path must be a non-empty string")
     if "\x00" in path or "\\" in path:
         raise UnsafePathError("path contains a null byte or backslash")
+    # The absolute-path requirement must hold for the RAW string, not just its
+    # decoded form: canonicalization below deliberately uses `path` (the raw
+    # string), so a value whose raw form is relative but whose fully-decoded
+    # form happens to be absolute (e.g. "%2Fdata%2Fmusic%2Ffile.flac") must
+    # not be allowed to slip past on the strength of its decoded copy alone --
+    # os.path.abspath() would silently anchor a relative raw string to the
+    # process's cwd instead of raising here.
+    if not path.startswith("/"):
+        raise UnsafePathError("path must be absolute")
 
     decoded = _decode_untrusted_path(path)
     if decoded is None:
@@ -516,7 +525,17 @@ def resolve_safe_path(
     if ".." in parts or "." in parts:
         raise UnsafePathError("path contains a traversal segment")
 
-    abs_path = os.path.abspath(decoded)
+    # Canonicalize from the ORIGINAL raw path, not the decoded form above:
+    # decoding is used only to detect a hidden traversal/separator/null-byte
+    # attack encoded into the request. Every path endpoint here receives
+    # values in a JSON body, never URL-encoded by any real caller, so a
+    # legitimate literal filename that merely contains a percent-sign byte
+    # sequence (e.g. "50%20off.flac") must resolve to itself -- it must not
+    # be silently rewritten to a different string ("50 off.flac") before it
+    # reaches the filesystem sink. The traversal/separator/null checks above
+    # already ran against the fully-decoded form, so nothing unsafe can slip
+    # through by canonicalizing the original string here instead.
+    abs_path = os.path.abspath(path)
     real_path = os.path.realpath(abs_path)
     trusted: Optional[Path] = None
     for root in _allowed_root_paths(allowed_types):
@@ -544,6 +563,44 @@ def is_safe_path(path: object, allowed_types: list = None) -> bool:
         return True
     except UnsafePathError:
         return False
+
+
+_DOTDOT_SEGMENT_RE = re.compile(r"(^|/)\.\.(/|$)")
+
+
+def _sanitize_command_path_args(args: Any, allowed_types: list) -> list:
+    """Validate a command/job argument list, replacing any absolute-path
+    argument with its canonical resolved value (never the original
+    request string). Raises UnsafePathError for any unsafe argument.
+
+    Rejects ".." only as an actual path segment (bounded by "/" or the
+    whole string), not as a bare substring: Beets' own supported query
+    syntax uses ".." for range queries (e.g. `year:2020..2023`,
+    `added:2020-01-01..2020-02-01`), which a blanket substring check would
+    incorrectly reject even though these args are never filesystem-joined.
+    A relative arg is still only relevant to traversal for a command like
+    `import` that can accept a second positional path, so a genuine
+    "../"-shaped segment must still be blocked.
+    """
+    if not isinstance(args, list):
+        raise UnsafePathError("args must be a list")
+
+    sanitized: list = []
+    for arg in args:
+        s_arg = str(arg)
+        if s_arg in ("-c", "--config") or s_arg.startswith(("-c=", "--config=")):
+            raise UnsafePathError("unsupported config override in args")
+        if (
+            s_arg == "." or s_arg.startswith("./")
+            or _DOTDOT_SEGMENT_RE.search(s_arg)
+            or "\\" in s_arg or "\x00" in s_arg
+        ):
+            raise UnsafePathError("invalid path parameter in args")
+        if s_arg.startswith("/"):
+            sanitized.append(str(resolve_safe_path(s_arg, allowed_types)))
+        else:
+            sanitized.append(s_arg)
+    return sanitized
 
 
 def acquire_os_lock(read_only: bool = False):
@@ -717,20 +774,57 @@ def _handle_delete_album(album_id: int, delete_files: bool = True) -> tuple:
             files_deleted = 0
             file_errors = []
             if delete_files:
-                for fpath in item_files:
-                    if fpath and is_safe_path(fpath, ["music", "staging"]) and os.path.exists(fpath):
+                # Database rows are already committed above at this point.
+                # Everything below is best-effort filesystem cleanup, and
+                # must never be allowed to propagate an exception up to the
+                # outer handler -- doing so would incorrectly report
+                # database_deleted: False for a delete that already
+                # succeeded. Stored item/album paths come from the
+                # database, not the current request, but are still
+                # untrusted: a corrupt or maliciously-written row must not
+                # be able to direct a delete outside the approved roots.
+                # Resolve each one through resolve_safe_path() and operate
+                # only on the returned Path (never the raw stored string),
+                # and refuse an approved root itself the same way
+                # /files/delete does.
+                try:
+                    for fpath in item_files:
+                        if not fpath:
+                            continue
                         try:
-                            os.unlink(fpath)
-                            files_deleted += 1
-                        except Exception as exc:
-                            file_errors.append(f"Failed to delete {fpath}: {exc}")
+                            safe_fpath = resolve_safe_path(fpath, ["music", "staging"])
+                        except UnsafePathError:
+                            file_errors.append("Skipped unsafe album item path")
+                            continue
+                        if any(str(safe_fpath) == os.path.realpath(root) for root in _allowed_root_paths(["music", "staging"])):
+                            file_errors.append("Skipped allowed root path")
+                            continue
+                        if safe_fpath.exists():
+                            try:
+                                safe_fpath.unlink()
+                                files_deleted += 1
+                            except Exception:
+                                file_errors.append("Failed to delete album item file")
 
-                if album_path and is_safe_path(album_path, ["music"]) and os.path.exists(album_path):
-                    try:
-                        if os.path.isdir(album_path) and not os.listdir(album_path):
-                            os.rmdir(album_path)
-                    except Exception:
-                        pass
+                    if album_path:
+                        try:
+                            safe_album_path = resolve_safe_path(album_path, ["music"])
+                        except UnsafePathError:
+                            safe_album_path = None
+                        if safe_album_path is not None and not any(
+                            str(safe_album_path) == os.path.realpath(root) for root in _allowed_root_paths(["music"])
+                        ):
+                            try:
+                                album_dir_is_empty = safe_album_path.is_dir() and not os.listdir(safe_album_path)
+                            except Exception:
+                                album_dir_is_empty = False
+                            if album_dir_is_empty:
+                                try:
+                                    safe_album_path.rmdir()
+                                except Exception:
+                                    pass
+                except Exception:
+                    file_errors.append("Unexpected error during file cleanup")
 
             files_failed = len(file_errors)
             if files_failed > 0:
@@ -1164,7 +1258,6 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
             timeout = body.get("timeout", 120)
             config_override = body.get("config_override", "")
             source_path = body.get("source_path", "")
-            target_path = body.get("target_path", "")
 
             if not command or command not in ALLOWED_COMMANDS:
                 self._send_json(400, {"error": f"Command '{command}' is not in the allowlist"})
@@ -1175,30 +1268,25 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 self._send_json(409, capability_error)
                 return
 
+            safe_source_path = None
             if source_path:
                 allowed_roots = ["staging"] if command == "import" else ["music", "staging"]
-                if not is_safe_path(source_path, allowed_roots):
-                    self._send_json(403, {"error": f"Access denied for source_path: {source_path}"})
+                try:
+                    safe_source_path = resolve_safe_path(source_path, allowed_roots)
+                except UnsafePathError:
+                    self._send_json(403, {"error": "Access denied for source_path outside allowed roots"})
                     return
 
-            if target_path:
-                if not is_safe_path(target_path, ["music", "staging"]):
-                    self._send_json(403, {"error": f"Access denied for target_path: {target_path}"})
-                    return
-
-            for arg in args:
-                s_arg = str(arg)
-                if s_arg.startswith(".") or ".." in s_arg or "\\" in s_arg or "\x00" in s_arg:
-                    self._send_json(403, {"error": f"Invalid path parameter in command args: {arg}"})
-                    return
-                if s_arg.startswith("/") and not is_safe_path(s_arg, ["music", "staging", "config", "tmp"]):
-                    self._send_json(403, {"error": f"Access denied for path in command args: {arg}"})
-                    return
+            try:
+                sanitized_args = _sanitize_command_path_args(args, ["music", "staging", "config", "tmp"])
+            except UnsafePathError:
+                self._send_json(403, {"error": "Invalid path parameter in command args"})
+                return
 
             cmd_list = [command]
-            if source_path:
-                cmd_list.append(source_path)
-            cmd_list.extend([str(a) for a in args])
+            if safe_source_path is not None:
+                cmd_list.append(str(safe_source_path))
+            cmd_list.extend(sanitized_args)
 
             mutating = command in {
                 "import", "update", "write", "move", "modify", "mbsync",
@@ -1233,8 +1321,8 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 })
             except subprocess.TimeoutExpired:
                 self._send_json(408, {"error": f"Command '{command}' timed out after {timeout}s", "returncode": 124})
-            except Exception as exc:
-                self._send_json(500, {"error": f"Command execution error: {exc}"})
+            except Exception:
+                self._send_json(500, {"error": "Command execution error"})
             finally:
                 if tmp_cfg_path and os.path.exists(tmp_cfg_path):
                     try:
@@ -1260,26 +1348,26 @@ class ControlAgentHandler(BaseHTTPRequestHandler):
                 self._send_json(409, capability_error)
                 return
 
+            safe_source_path = None
             if source_path:
                 allowed_roots = ["staging"] if command == "import" else ["music", "staging"]
-                if not is_safe_path(source_path, allowed_roots):
-                    self._send_json(403, {"error": f"Access denied for source_path: {source_path}"})
+                try:
+                    safe_source_path = resolve_safe_path(source_path, allowed_roots)
+                except UnsafePathError:
+                    self._send_json(403, {"error": "Access denied for source_path outside allowed roots"})
                     return
 
-            for arg in args:
-                s_arg = str(arg)
-                if s_arg.startswith(".") or ".." in s_arg or "\\" in s_arg or "\x00" in s_arg:
-                    self._send_json(403, {"error": f"Invalid path parameter in job args: {arg}"})
-                    return
-                if s_arg.startswith("/") and not is_safe_path(s_arg, ["music", "staging", "config", "tmp"]):
-                    self._send_json(403, {"error": f"Access denied for path in job args: {arg}"})
-                    return
+            try:
+                sanitized_args = _sanitize_command_path_args(args, ["music", "staging", "config", "tmp"])
+            except UnsafePathError:
+                self._send_json(403, {"error": "Invalid path parameter in job args"})
+                return
 
             job_id = uuid.uuid4().hex
             cmd_list = [command]
-            if source_path:
-                cmd_list.append(source_path)
-            cmd_list.extend([str(a) for a in args])
+            if safe_source_path is not None:
+                cmd_list.append(str(safe_source_path))
+            cmd_list.extend(sanitized_args)
 
             job = AgentJob(job_id, cmd_list, label=label, config_override=config_override)
             with JOBS_LOCK:

--- a/tests/test_external_beets_architecture.py
+++ b/tests/test_external_beets_architecture.py
@@ -352,8 +352,8 @@ class TestBeetsClientRemoteOnly(unittest.TestCase):
             con.close()
 
             with mock.patch("backend.beets_control_agent.LIB_PATH", str(db_path)), \
-                 mock.patch("backend.beets_control_agent.is_safe_path", return_value=True), \
-                 mock.patch("os.unlink", side_effect=PermissionError("Permission denied")):
+                 mock.patch("backend.beets_control_agent.MUSIC_LIBRARY_PATH", str(music_path)), \
+                 mock.patch.object(Path, "unlink", side_effect=PermissionError("Permission denied")):
                 code, res = _handle_delete_album(1, delete_files=True)
                 self.assertEqual(code, 200)
                 self.assertFalse(res["success"])

--- a/tests/test_pr39_codeql_alerts.py
+++ b/tests/test_pr39_codeql_alerts.py
@@ -206,6 +206,303 @@ class ControlAgentPathBoundaryTests(unittest.TestCase):
         self.assertTrue(Path(dest).exists())
         self.assertFalse(Path(source).exists())
 
+    def test_resolve_safe_path_preserves_literal_percent_filenames(self):
+        """Regression test: resolve_safe_path() must canonicalize from the
+        original raw path, not its decoded form. Decoding is used only to
+        detect a hidden traversal/separator/null-byte attack; a legitimate
+        literal filename that happens to contain a percent-sign byte
+        sequence must resolve to itself, not be silently rewritten to a
+        different string before it reaches the filesystem sink. Every path
+        endpoint here receives values in a JSON body, never URL-encoded by
+        any real caller, so decoding must never change what gets operated
+        on."""
+        literal_names = [
+            "convention%20album.flac",
+            "100%25 legit.flac",
+            "literal%2520name.flac",
+        ]
+        for name in literal_names:
+            with self.subTest(name=name):
+                literal_path = f"{self.music}/{name}"
+                Path(literal_path).write_text("audio", encoding="utf-8")
+                resolved = resolve_safe_path(literal_path, ["music"])
+                self.assertEqual(resolved, Path(literal_path).resolve())
+
+        # Encoded traversal, separators, nulls, and nested encoding must
+        # still be rejected -- the fix must not weaken detection.
+        attack_paths = [
+            f"{self.music}/../outside/secret.flac",
+            f"{self.music}/%2e%2e/outside/secret.flac",
+            f"{self.music}/%252e%252e/outside/secret.flac",
+            f"{self.music}/foo%00.flac",
+            f"{self.music}/..%2f..%2fetc/passwd",
+        ]
+        for candidate in attack_paths:
+            with self.subTest(candidate=candidate):
+                with self.assertRaises(UnsafePathError):
+                    resolve_safe_path(candidate, ["music"])
+
+        # Nested encoding of a genuine "../" must be rejected at every
+        # depth, including beyond the resolver's decode budget.
+        import urllib.parse as _up
+        s = "../"
+        for depth in range(1, 7):
+            s = _up.quote(s, safe="")
+            raw = f"{self.music}/{s}etc/passwd"
+            with self.subTest(depth=depth):
+                with self.assertRaises(UnsafePathError):
+                    resolve_safe_path(raw, ["music"])
+
+    def test_resolve_safe_path_requires_raw_absolute_not_just_decoded(self):
+        """Regression test: resolve_safe_path() canonicalizes from the raw
+        input string, so the absolute-path requirement must be enforced on
+        that same raw string -- not only on its decoded copy. A value whose
+        raw form is relative but whose fully-decoded form happens to be
+        absolute (e.g. a fully percent-encoded leading separator) must be
+        rejected outright rather than falling through to os.path.abspath(),
+        which would silently anchor it to the process's cwd instead."""
+        candidates = [
+            "%2Fdata%2Fmedia%2Fmusic%2Ffile.flac",
+            "%252Fdata%252Fmedia%252Fmusic%252Ffile.flac",
+            "relative%2Fencoded",
+        ]
+        for candidate in candidates:
+            with self.subTest(candidate=candidate):
+                with self.assertRaises(UnsafePathError):
+                    resolve_safe_path(candidate, ["music"])
+
+    def test_literal_percent_filename_survives_delete_endpoint(self):
+        literal_path = f"{self.music}/convention%20album.flac"
+        Path(literal_path).write_text("audio", encoding="utf-8")
+        decoded_sibling = f"{self.music}/convention album.flac"
+        self.assertFalse(Path(decoded_sibling).exists())
+
+        code, data = _post_agent("/files/delete", {"path": literal_path})
+        self.assertEqual(code, 200, data)
+        self.assertEqual(data["path"], str(Path(literal_path).resolve()))
+        self.assertFalse(Path(literal_path).exists())
+        self.assertFalse(Path(decoded_sibling).exists())
+
+    def test_command_args_allow_beets_range_query_syntax(self):
+        """Regression test: a blanket '".." in arg' substring check rejected
+        legitimate Beets range-query syntax (e.g. `year:2020..2023`), which
+        is never filesystem-joined -- only an actual relative path segment
+        is a real traversal-relevant shape and must still be rejected."""
+        legitimate_args = ["year:2020..2023", "added:2020-01-01..2020-02-01", "title:Mr...Wonderful"]
+        fake_result = mock.MagicMock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(bca.subprocess, "run", return_value=fake_result) as run_mock:
+            code, data = _post_agent("/commands/execute", {"command": "ls", "args": legitimate_args})
+        self.assertEqual(code, 200, data)
+        full_cmd = run_mock.call_args.args[0]
+        self.assertEqual(full_cmd[-len(legitimate_args):], legitimate_args)
+
+        for traversal_arg in ["..", "../etc/passwd", "foo/../bar", "./relative"]:
+            with self.subTest(arg=traversal_arg):
+                with mock.patch.object(bca.subprocess, "run") as run_mock:
+                    code, data = _post_agent("/commands/execute", {"command": "ls", "args": [traversal_arg]})
+                self.assertEqual(code, 403, data)
+                run_mock.assert_not_called()
+
+    def test_commands_execute_and_jobs_create_use_canonical_source_path(self):
+        """source_path and absolute args must be replaced by their canonical
+        resolved values in the actual subprocess/job command array -- never
+        the original request string."""
+        source = f"{self.staging}/import-source"
+        Path(source).mkdir()
+        arg_file = f"{self.music}/Artist/Track.flac"
+        Path(arg_file).parent.mkdir(parents=True, exist_ok=True)
+        Path(arg_file).write_text("audio", encoding="utf-8")
+
+        fake_result = mock.MagicMock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(bca.subprocess, "run", return_value=fake_result) as run_mock:
+            code, data = _post_agent("/commands/execute", {
+                "command": "import",
+                "source_path": source,
+                "args": ["--quiet", arg_file],
+            })
+        self.assertEqual(code, 200, data)
+        full_cmd = run_mock.call_args.args[0]
+        self.assertEqual(
+            full_cmd[-4:],
+            ["import", str(Path(source).resolve()), "--quiet", str(Path(arg_file).resolve())],
+        )
+
+        created = {}
+
+        class FakeJob:
+            def __init__(self, job_id, command, label="", config_override=""):
+                created["job_id"] = job_id
+                created["command"] = command
+
+        with mock.patch.object(bca, "AgentJob", FakeJob):
+            code, data = _post_agent("/jobs/create", {
+                "command": "import",
+                "source_path": source,
+                "args": ["--quiet", arg_file],
+            })
+        try:
+            self.assertEqual(code, 200, data)
+            self.assertEqual(
+                created["command"],
+                ["import", str(Path(source).resolve()), "--quiet", str(Path(arg_file).resolve())],
+            )
+        finally:
+            bca.JOBS.pop(created.get("job_id"), None)
+
+    def test_command_and_job_reject_traversal_and_option_injection(self):
+        with mock.patch.object(bca.subprocess, "run") as run_mock:
+            code, data = _post_agent("/commands/execute", {
+                "command": "import",
+                "source_path": self.staging,
+                "args": ["--config=/etc/passwd"],
+            })
+        self.assertEqual(code, 403, data)
+        run_mock.assert_not_called()
+        self.assertNotIn("/etc/passwd", json.dumps(data))
+
+        before_jobs = set(bca.JOBS)
+        code, data = _post_agent("/jobs/create", {
+            "command": "import",
+            "source_path": f"{self.staging}/%252e%252e/outside",
+            "args": [],
+        })
+        self.assertEqual(code, 403, data)
+        self.assertEqual(set(bca.JOBS), before_jobs)
+        self.assertNotIn("%252e%252e", json.dumps(data))
+
+    def test_commands_execute_ignores_unused_target_path(self):
+        """target_path is not part of /commands/execute's actual command
+        contract -- it is never appended to the constructed command array by
+        any allowed subcommand, and no current caller sends it. It must be
+        accepted (as inert, unvalidated JSON) rather than silently
+        influencing command construction or being treated as a path sink."""
+        fake_result = mock.MagicMock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(bca.subprocess, "run", return_value=fake_result) as run_mock:
+            code, data = _post_agent("/commands/execute", {
+                "command": "ls",
+                "args": ["title:x"],
+                "target_path": f"{self.outside}/anywhere-outside-every-root",
+            })
+        self.assertEqual(code, 200, data)
+        full_cmd = run_mock.call_args.args[0]
+        self.assertNotIn(f"{self.outside}/anywhere-outside-every-root", full_cmd)
+        self.assertEqual(full_cmd[-1:], ["title:x"])
+
+
+class AlbumDeleteCanonicalPathTests(unittest.TestCase):
+    """Regression tests for _handle_delete_album() treating database-stored
+    paths as untrusted, matching the same canonical-path/root-refusal
+    contract as the /files/delete endpoint."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(dir="/tmp")
+        base_name = Path(self.tmp.name).name
+        self.base = f"/tmp/{base_name}"
+        self.music = f"{self.base}/music"
+        self.staging = f"{self.base}/staging"
+        self.outside = f"{self.base}/outside"
+        Path(self.music).mkdir(parents=True, exist_ok=True)
+        Path(self.staging).mkdir(parents=True, exist_ok=True)
+        Path(self.outside).mkdir(parents=True, exist_ok=True)
+        self.db_path = Path(self.base) / "musiclibrary.blb"
+        self.patches = [
+            mock.patch.object(bca, "MUSIC_LIBRARY_PATH", self.music),
+            mock.patch.object(bca, "DOWNLOAD_PATH", self.staging),
+            mock.patch.object(bca, "LOCK_PATH", f"{self.base}/agent.lock"),
+            mock.patch.object(bca, "LIB_PATH", str(self.db_path)),
+        ]
+        for patch in self.patches:
+            patch.start()
+
+    def tearDown(self):
+        for patch in reversed(self.patches):
+            patch.stop()
+        self.tmp.cleanup()
+
+    def _seed_album(self, album_path: str, item_paths: list[str]):
+        con = sqlite3.connect(self.db_path)
+        con.execute("CREATE TABLE albums (id INTEGER PRIMARY KEY, album TEXT, path TEXT)")
+        con.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, album_id INTEGER, path TEXT)")
+        con.execute("INSERT INTO albums (id, album, path) VALUES (1, 'Album', ?)", (album_path,))
+        for idx, p in enumerate(item_paths, start=10):
+            con.execute("INSERT INTO items (id, album_id, path) VALUES (?, 1, ?)", (idx, p))
+        con.commit()
+        con.close()
+
+    def test_hostile_stored_paths_do_not_escape_approved_roots(self):
+        real_item = f"{self.music}/Artist/Album/Track.flac"
+        Path(real_item).parent.mkdir(parents=True, exist_ok=True)
+        Path(real_item).write_text("audio", encoding="utf-8")
+
+        outside_item = f"{self.outside}/secret.flac"
+        Path(outside_item).write_text("secret", encoding="utf-8")
+
+        percent_item = f"{self.music}/Artist/Album/convention%20album.flac"
+        Path(percent_item).write_text("audio", encoding="utf-8")
+        decoded_sibling = f"{self.music}/Artist/Album/convention album.flac"
+
+        traversal_item = f"{self.music}/Artist/Album/%2e%2e/%2e%2e/outside/escape.flac"
+
+        self._seed_album(
+            self.music,  # hostile: album path itself is the approved root
+            [real_item, outside_item, percent_item, traversal_item],
+        )
+
+        code, data = bca._handle_delete_album(1, delete_files=True)
+        self.assertEqual(code, 200, data)
+
+        # The real, legitimate item is gone.
+        self.assertFalse(Path(real_item).exists())
+        # The literal-percent file was deleted exactly, not a decoded sibling.
+        self.assertFalse(Path(percent_item).exists())
+        self.assertFalse(Path(decoded_sibling).exists())
+        # The outside-root item was never touched.
+        self.assertTrue(Path(outside_item).exists())
+        # The approved root itself (used as the "album path") was not removed.
+        self.assertTrue(Path(self.music).is_dir())
+
+        self.assertEqual(data["files_deleted"], 2)
+        self.assertGreaterEqual(data["files_failed"], 1)
+        self.assertNotIn(self.outside, json.dumps(data))
+        self.assertNotIn("secret.flac", json.dumps(data))
+
+    def test_database_row_deletion_is_unconditional_even_with_hostile_paths(self):
+        """A malicious stored path must not prevent safe database cleanup:
+        the album/item rows are removed regardless of whether any stored
+        file path is safe to delete."""
+        self._seed_album(f"{self.outside}/evil-album", [f"{self.outside}/evil.flac"])
+        code, data = bca._handle_delete_album(1, delete_files=True)
+        self.assertEqual(code, 200, data)
+        self.assertTrue(data["database_deleted"])
+        self.assertEqual(data["items_deleted"], 1)
+        self.assertEqual(data["albums_deleted"], 1)
+
+    def test_filesystem_exception_after_commit_does_not_misreport_database_deleted(self):
+        """Regression test: the album/item DB rows are committed before any
+        filesystem cleanup runs. An unexpected filesystem exception during
+        that best-effort cleanup (e.g. os.listdir() raising on the album
+        directory) must not be allowed to propagate to the outer handler and
+        misreport an already-successful database deletion as a total
+        failure."""
+        real_item = f"{self.music}/Artist/Album/Track.flac"
+        Path(real_item).parent.mkdir(parents=True, exist_ok=True)
+        Path(real_item).write_text("audio", encoding="utf-8")
+        album_dir = f"{self.music}/Artist/Album"
+
+        self._seed_album(album_dir, [real_item])
+
+        with mock.patch.object(bca.os, "listdir", side_effect=PermissionError("denied")):
+            code, data = bca._handle_delete_album(1, delete_files=True)
+
+        self.assertEqual(code, 200, data)
+        self.assertTrue(data["database_deleted"])
+        self.assertEqual(data["items_deleted"], 1)
+        self.assertEqual(data["albums_deleted"], 1)
+        self.assertNotEqual(data["status"], "failed")
+        # The item file itself must still have been deleted -- only the
+        # album-directory listdir() call was made to fail.
+        self.assertFalse(Path(real_item).exists())
+
 
 class ControlAgentSqlBoundaryTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Recovery reason

PR #39 merged into main at `d4dea8808966fe884fa9460272db46676c294ad0` before PR #48 completed.

PR #48 later squash-merged as `125752d84eda4e1e0adda29170c49e72dd3baca1` into `refactor/external-beets-engine`.

This follow-up cherry-picks only that reviewed squash commit onto current `main`.

## Provenance

- Original implementation: PR #48
- Original squash: `125752d84eda4e1e0adda29170c49e72dd3baca1`
- Application method: `git cherry-pick -x 125752d84eda4e1e0adda29170c49e72dd3baca1` onto current `main`
- No rebase
- No force-push
- No integration-branch merge
- No conflict resolution was required

## Changed files

- `backend/beets_client.py`
- `backend/beets_control_agent.py`
- `tests/test_external_beets_architecture.py`
- `tests/test_pr39_codeql_alerts.py`

## Fixes

- Preserves literal-percent filenames by validating decoded attack shape while canonicalizing from the raw path.
- Enforces that the raw submitted path is absolute, not only the decoded copy.
- Builds command/job arrays from canonical `source_path` and canonical absolute arguments.
- Preserves valid Beets range-query syntax such as `year:2020..2023` and `title:Mr...Wonderful`.
- Rejects real path-segment traversal in command args.
- Uses canonical database-stored album/item cleanup paths and refuses approved-root cleanup targets.
- Keeps post-commit album cleanup exception-safe so filesystem cleanup errors do not mask committed DB deletion.
- Removes the unused `target_path` parameter from `run_command()`.
- Avoids raw rejected path or raw exception leakage in the corrected flows.

## Validation

Focused tests x3:

`python -m unittest tests.test_pr39_codeql_alerts tests.test_external_beets_architecture tests.test_security_hardening tests.test_transaction_engine tests.test_transaction_integration`

- Initial local focused run reproduced a stale local `beets-web-manager:0.1.0` image timeout in `test_docker_web_manager_image_has_no_beets_binary`.
- Rebuilt the web-manager image from this exact branch head and reran the required loop.
- Pass 1: `Ran 226 tests`, `OK`.
- Pass 2: `Ran 226 tests`, `OK`.
- Pass 3: `Ran 226 tests`, `OK`.

Full Python tests x2:

`python -m unittest discover -s tests -p "test_*.py"`

- Pass 1: `Ran 1538 tests`, `OK (skipped=3)`.
- Pass 2: `Ran 1538 tests`, `OK (skipped=3)`.

Frontend validation:

- `npm ci`: passed; audited 353 packages; `0 vulnerabilities`; existing peer warnings only.
- `npm run typecheck`: passed.
- `npm run lint`: passed.
- `npm run build`: passed; Next.js 16.2.11 static build generated 13 routes.
- `npm test`: passed; 1 test file / 15 tests.
- `npm audit --audit-level=high`: passed; `0 vulnerabilities`.
- `git status --short -- frontend`: no output.

Static and security:

- `python -m py_compile backend/beets_client.py backend/beets_control_agent.py backend/security.py`: passed.
- `python scripts/security_secret_scan.py`: passed.
- `python scripts/validate_compose_security.py`: passed with existing non-Beets mutable-image warnings only.
- `python scripts/verify_security_config.py`: passed using disposable synthetic strong env values.
- `git diff --check origin/main...HEAD`: passed.

Docker builds and labels:

- `docker build --no-cache --build-arg VCS_REF=78fa4b0731dd193c558b73e89b11e0db3f7cf9ab -t beets-web-manager-main-path-followup -t beets-web-manager:0.1.0 .`: passed; build-time `npm ci` reported `0 vulnerabilities`.
- `docker build --no-cache --build-arg VCS_REF=78fa4b0731dd193c558b73e89b11e0db3f7cf9ab -f Dockerfile.beets -t beets-engine-main-path-followup .`: passed; known non-fatal bpsync incompatibility remained unchanged.
- `beets-web-manager-main-path-followup` OCI revision label: `78fa4b0731dd193c558b73e89b11e0db3f7cf9ab`.
- `beets-engine-main-path-followup` OCI revision label: `78fa4b0731dd193c558b73e89b11e0db3f7cf9ab`.
- `python scripts/verify_beets_engine_image.py --image beets-engine-main-path-followup --check-s6`: passed, including inherited `svc-beets` down, control agent supervised, restart after crash, and clean shutdown.

Disposable runtime:

A temporary two-service stack was started with temporary config/database/music/staging/web-manager-data roots and synthetic strong tokens. No production mounts were used.

Runtime checks passed:

- literal-percent mkdir/move/delete
- raw-relative but decoded-absolute rejection
- single/double/nested encoded traversal rejection
- valid range-query command
- valid range-query background job
- real traversal command rejection
- canonical absolute command argument
- hostile SQLite album cleanup
- post-commit filesystem exception behavior
- root and outside-root cleanup refusal

Containers, network, volumes, and temporary root were removed after the successful probe.

GitHub CI on `78fa4b0731dd193c558b73e89b11e0db3f7cf9ab`:

- `frontend-lint`: passed.
- `frontend-typecheck`: passed.
- `build` / `node-build`: passed.
- `python-tests`: passed.
- `security`: passed.
- `compose-verification`: passed.
- `beets-engine-verification`: passed.

Authoritative CodeQL on `refs/pull/49/head` at `78fa4b0731dd193c558b73e89b11e0db3f7cf9ab`:

- `Analyze (actions)`: passed; results count `0`.
- `Analyze (javascript-typescript)`: passed; results count `0`.
- `Analyze (python)`: passed; results count `0`.
- Aggregate `CodeQL`: passed.
- Open code-scanning alerts for PR #49: `0`.
## Deployment distinction

Current production deployment was built from `f6485a25`-era code.

This follow-up commit is not deployed.

No production action occurred in this task.

## Risk record

SEC-001 remains the owner-accepted retained Plex credential risk.

This PR neither changes nor reevaluates that decision.

