### PR TITLE
fix(security): update nanoid dependency chain to resolve GHSA-2v37-7h3g-55p8

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4826,9 +4826,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -6012,22 +6012,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6014,6 +6014,22 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "extraneous": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "tailwindcss": "4.3.0"
   },
   "overrides": {
+    "nanoid": "^3.3.17",
     "postcss": "8.5.24",
     "sharp": "0.35.3"
   },


### PR DESCRIPTION
## Summary of Security Fix

Fixes high-severity security advisory **GHSA-2v37-7h3g-55p8** (`nanoid < 3.3.17`).

### Dependency Chain & Fix
- **Security Advisory**: GHSA-2v37-7h3g-55p8 (`nanoid: custom generators can loop indefinitely when size is zero`).
- **Dependency Chain**: `beets-web-frontend@0.1.0` -> `postcss@8.5.24` (overridden) -> `nanoid@3.3.16`
- **Previous Version**: `3.3.16`
- **New Version**: `3.3.18`
- **Fix Mechanism**: Added `"nanoid": "^3.3.17"` override to `frontend/package.json` and updated `frontend/package-lock.json`.
- **NPM Audit Result**: 0 high/critical vulnerabilities (`npm audit --audit-level=high` passed).

### Release & Scope Invariants
- No application, backend, or UI behavior changes.
- `v0.1.6` remains an immutable release attempt.
- `v0.1.7` will be tagged once this PR is merged and post-merge `main` CI is green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
